### PR TITLE
[-] commit string on stats page should be trimmed, closes #217

### DIFF
--- a/src/webui/src/layout/StatsSummary/StatsSummaryGrid/index.tsx
+++ b/src/webui/src/layout/StatsSummary/StatsSummaryGrid/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, Typography } from "@mui/material";
+import { Box, Grid, Tooltip, Typography } from "@mui/material";
 import { ErrorComponent } from "layout/common/ErrorComponent";
 import { LoadingComponent } from "layout/common/LoadingComponent";
 import { useStatsSummary } from "queries/StatsSummary";
@@ -66,14 +66,17 @@ export const StatsSummaryGrid = () => {
               >
                 {prettifyString(key)}
               </Typography>
-              <Typography
-                sx={{
-                  fontWeight: "bold"
-                }}
-                variant="h6"
-              >
-                {value}
-              </Typography>
+              <Tooltip title={value} placement="bottom-start">
+                <Typography
+                  sx={{
+                    fontWeight: "bold"
+                  }}
+                  variant="h6"
+                  noWrap
+                >
+                  {value}
+                </Typography>
+              </Tooltip>
             </Box>
           ))
         }
@@ -93,7 +96,7 @@ export const StatsSummaryGrid = () => {
                 gap: 1
               }}
             >
-              <Typography variant="h5" fontWeight="bold" sx={{width: "100%"}}>{prettifyString(key)}</Typography>
+              <Typography variant="h5" fontWeight="bold" sx={{ width: "100%" }}>{prettifyString(key)}</Typography>
               <Grid
                 container
                 sx={{
@@ -121,7 +124,13 @@ export const StatsSummaryGrid = () => {
                         borderColor: "lightgray"
                       }}
                     >
-                      <Box sx={{ display: "flex", height: "100%", width: "75%", alignItems: "center" }}>{prettifyString(dataSetKey)}</Box>
+                      <Box sx={{ display: "flex", height: "100%", width: "75%", alignItems: "center" }}>
+                        <Tooltip title={prettifyString(dataSetKey)} placement="bottom-start">
+                          <Typography noWrap>
+                            {prettifyString(dataSetKey)}
+                          </Typography>
+                        </Tooltip>
+                      </Box>
                       <Box sx={{ display: "flex", height: "100%", width: "25%", alignItems: "center", justifyContent: "right" }}>{dataSetValue}</Box>
                     </Grid>
                   ))


### PR DESCRIPTION
Now values strings look like this _(example values)_.
![image](https://github.com/cybertec-postgresql/pgwatch3/assets/54646255/9bc2b045-b159-4864-825c-00c195630548)

I added a `Tooltip` component with the help of which, when the user hovers the string, the full value is shown.
![image](https://github.com/cybertec-postgresql/pgwatch3/assets/54646255/06379927-1489-4209-82c0-6f9b665de9e3)

Also, I added the `no-wrap` option and a `Tooltip` component for metric option names.
![image](https://github.com/cybertec-postgresql/pgwatch3/assets/54646255/59b7c6dc-58af-4457-bddb-7138a0a47954)
