### PR TITLE
[-] fix deprecated usage of `yaml.load()`

### DIFF
--- a/src/metrics/sql/00_helpers/rollout_helper.py
+++ b/src/metrics/sql/00_helpers/rollout_helper.py
@@ -200,7 +200,7 @@ def get_monitored_dbs_from_yaml_config():   # active entries ("is_enabled": true
                 with open(os.path.join(root, f), 'r') as fp:
                     config = fp.read()
                 try:
-                    monitored_dbs = yaml.load(config)
+                    monitored_dbs = yaml.full_load(config)
                 except:
                     logging.error("skipping config file %s as could not parse YAML")
                     continue


### PR DESCRIPTION
Current usage of yaml.load is deprecated in rollout_helper.py. Non fatal warning in older versions but fatal error in newer versions that is somewhat difficult to debug because of the error handling. 

Same issue as found in pgwatch2 covered in the below PR. Just wanted to make sure it gets fixed in this repo as well.

https://github.com/cybertec-postgresql/pgwatch2/pull/739