### PR TITLE
refactor: Updated Receiver to Handler for Sync Metric functionality. …

### DIFF
--- a/internal/sinks/rpc.go
+++ b/internal/sinks/rpc.go
@@ -64,7 +64,7 @@ type SyncReq struct {
 
 func (rw *RPCWriter) SyncMetric(dbUnique string, metricName string, op string) error {
 	var logMsg string
-	if err := rw.client.Call("Receiver.SyncMetric", &SyncReq{
+	if err := rw.client.Call("Handler.SyncMetric", &SyncReq{
 		Operation:  op,
 		DbName:     dbUnique,
 		MetricName: metricName,

--- a/internal/sinks/rpc_test.go
+++ b/internal/sinks/rpc_test.go
@@ -17,6 +17,9 @@ import (
 type Receiver struct {
 }
 
+type Handler struct {
+}
+
 var ctxt = context.Background()
 
 func (receiver *Receiver) UpdateMeasurements(msg *metrics.MeasurementEnvelope, logMsg *string) error {
@@ -30,7 +33,7 @@ func (receiver *Receiver) UpdateMeasurements(msg *metrics.MeasurementEnvelope, l
 	return nil
 }
 
-func (receiver *Receiver) SyncMetric(syncReq *sinks.SyncReq, logMsg *string) error {
+func (handler *Handler) SyncMetric(syncReq *sinks.SyncReq, logMsg *string) error {
 	if syncReq == nil {
 		return errors.New("msgs is nil")
 	}
@@ -43,7 +46,11 @@ func (receiver *Receiver) SyncMetric(syncReq *sinks.SyncReq, logMsg *string) err
 
 func init() {
 	recv := new(Receiver)
+	handler := new(Handler)
 	if err := rpc.Register(recv); err != nil {
+		panic(err)
+	}
+	if err := rpc.Register(handler); err != nil {
 		panic(err)
 	}
 	rpc.HandleHTTP()


### PR DESCRIPTION
References the current upstream version of pgwatch3_rpc_receivers where we have separated both the receiver and the sync metric handler.

A new type called Handler now handles the Sync Metric calls in the receivers: https://github.com/destrex271/pgwatch3_rpc_server/blob/1cb1f44d237ce5817831194c9285c20397277fc2/cmd/csv_receiver/main.go#L32