### PR TITLE
[+] persist visible column settings, fixes #581

### DIFF
--- a/internal/webui/src/hooks/useGridColumnVisibility.ts
+++ b/internal/webui/src/hooks/useGridColumnVisibility.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+import { GridColDef, GridColumnVisibilityModel } from '@mui/x-data-grid';
+
+export const useGridColumnVisibility = (
+  storageKey: string,
+  columns: GridColDef[]
+) => {
+  const [columnVisibility, setColumnVisibility] = useState<GridColumnVisibilityModel>(() => {
+    const defaultVisibility = columns?.reduce((acc, col) => ({
+      ...acc,
+      [col.field]: col.hide !== true
+    }), {});
+
+    const saved = localStorage.getItem(storageKey);
+    const savedVisibility = saved ? JSON.parse(saved) : {};
+
+    return {
+      ...defaultVisibility,
+      ...savedVisibility
+    };
+  });
+
+  const handleColumnVisibilityChange = useCallback((newModel: GridColumnVisibilityModel) => {
+    setColumnVisibility(newModel);
+    localStorage.setItem(storageKey, JSON.stringify(newModel));
+  }, [storageKey]);
+
+  return {
+    columnVisibility,
+    onColumnVisibilityChange: handleColumnVisibilityChange
+  };
+};

--- a/internal/webui/src/pages/MetricsPage/components/MetricsGrid/MetricsGrid.tsx
+++ b/internal/webui/src/pages/MetricsPage/components/MetricsGrid/MetricsGrid.tsx
@@ -4,6 +4,7 @@ import { Error } from "components/Error/Error";
 import { Loading } from "components/Loading/Loading";
 import { MetricFormDialog } from "containers/MetricFormDialog/MetricFormDialog";
 import { MetricFormProvider } from "contexts/MetricForm/MetricForm.provider";
+import { useGridColumnVisibility } from 'hooks/useGridColumnVisibility';
 import { usePageStyles } from "styles/page";
 import { useMetrics } from "queries/Metric";
 import { useMetricsGridColumns } from "./MetricsGrid.consts";
@@ -14,6 +15,9 @@ export const MetricsGrid = () => {
   const { data, isLoading, isError, error } = useMetrics();
 
   const { classes } = usePageStyles();
+
+  const columns = useMetricsGridColumns();
+  const { columnVisibility, onColumnVisibilityChange } = useGridColumnVisibility('METRICS_GRID', columns);
 
   const rows: MetricGridRow[] | [] = useMemo(() => {
     if (data) {
@@ -27,8 +31,6 @@ export const MetricsGrid = () => {
     }
     return [];
   }, [data]);
-
-  const columns = useMetricsGridColumns();
 
   if (isLoading) {
     return (
@@ -53,6 +55,8 @@ export const MetricsGrid = () => {
           rowsPerPageOptions={[]}
           components={{ Toolbar: () => <MetricsGridToolbar /> }}
           disableColumnMenu
+          columnVisibilityModel={columnVisibility}
+          onColumnVisibilityModelChange={onColumnVisibilityChange}
         />
         <MetricFormDialog />
       </MetricFormProvider>

--- a/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
+++ b/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
@@ -4,6 +4,7 @@ import { Error } from "components/Error/Error";
 import { Loading } from "components/Loading/Loading";
 import { PresetFormDialog } from "containers/PresetFormDialog/PresetFormDialog";
 import { PresetFormProvider } from "contexts/PresetForm/PresetForm.provider";
+import { useGridColumnVisibility } from 'hooks/useGridColumnVisibility';
 import { usePageStyles } from "styles/page";
 import { usePresets } from "queries/Preset";
 import { usePresetsGridColumns } from "./PresetsGrid.consts";
@@ -14,6 +15,9 @@ export const PresetsGrid = () => {
   const { classes } = usePageStyles();
 
   const { data, isLoading, isError, error } = usePresets();
+
+  const columns = usePresetsGridColumns();
+  const { columnVisibility, onColumnVisibilityChange } = useGridColumnVisibility('PRESETS_GRID', columns);
 
   const rows: PresetGridRow[] | [] = useMemo(() => {
     if (data) {
@@ -27,8 +31,6 @@ export const PresetsGrid = () => {
     }
     return [];
   }, [data]);
-
-  const columns = usePresetsGridColumns();
 
   if (isLoading) {
     return (
@@ -53,6 +55,8 @@ export const PresetsGrid = () => {
           rowsPerPageOptions={[]}
           components={{ Toolbar: () => <PresetsGridToolbar /> }}
           disableColumnMenu
+          columnVisibilityModel={columnVisibility}
+          onColumnVisibilityModelChange={onColumnVisibilityChange}
         />
         <PresetFormDialog />
       </PresetFormProvider>

--- a/internal/webui/src/pages/SourcesPage/components/SourcesGrid/SourcesGrid.tsx
+++ b/internal/webui/src/pages/SourcesPage/components/SourcesGrid/SourcesGrid.tsx
@@ -3,6 +3,7 @@ import { Error } from "components/Error/Error";
 import { Loading } from "components/Loading/Loading";
 import { SourceFormDialog } from "containers/SourceFormDialog/SourceFormDialog";
 import { SourceFormProvider } from "contexts/SourceForm/SourceForm.provider";
+import { useGridColumnVisibility } from 'hooks/useGridColumnVisibility';
 import { usePageStyles } from "styles/page";
 import { useSources } from "queries/Source";
 import { useSourcesGridColumns } from "./SourcesGrid.consts";
@@ -14,6 +15,7 @@ export const SourcesGrid = () => {
   const { data, isLoading, isError, error } = useSources();
 
   const columns = useSourcesGridColumns();
+  const { columnVisibility, onColumnVisibilityChange } = useGridColumnVisibility('SOURCES_GRID', columns);
 
   if (isLoading) {
     return (
@@ -38,6 +40,8 @@ export const SourcesGrid = () => {
           rowsPerPageOptions={[]}
           components={{ Toolbar: () => <SourcesGridToolbar /> }}
           disableColumnMenu
+          columnVisibilityModel={columnVisibility}
+          onColumnVisibilityModelChange={onColumnVisibilityChange}
         />
         <SourceFormDialog />
       </SourceFormProvider>


### PR DESCRIPTION
### **Fixes**  
- Ensures column visibility persists across refreshes.  
- Defaults to provided column settings if no saved state exists.  

### Changes  
- Implemented `useGridColumnVisibility` hook to manage column visibility state.  
- Saves visibility settings to `localStorage` to persist user preferences.  
- Restores saved settings on component mount.  

Closes #581 