### PR TITLE
[+] improve `pgwatch-demo` Docker image

### DIFF
--- a/docker/bootstrap/init_dbs.sh
+++ b/docker/bootstrap/init_dbs.sh
@@ -1,22 +1,3 @@
 #!/bin/bash
 
-psql -v ON_ERROR_STOP=1 --username "postgres" --dbname "pgwatch" <<-EOSQL
-    CREATE EXTENSION pg_qualstats;
-    CREATE EXTENSION plpython3u;
-    CREATE EXTENSION pg_stat_statements;
-    GRANT EXECUTE ON FUNCTION pg_stat_file(text) TO pgwatch;
-    GRANT EXECUTE ON FUNCTION pg_stat_file(text, boolean) TO pgwatch;
-EOSQL
-
-psql -v ON_ERROR_STOP=1 --username "postgres" --dbname "pgwatch" <<-EOSQL
-BEGIN;
-CREATE OR REPLACE FUNCTION get_load_average(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
-'
-    from os import getloadavg
-    la = getloadavg()
-    return [la[0], la[1], la[2]]
-' LANGUAGE plpython3u VOLATILE;
-GRANT EXECUTE ON FUNCTION get_load_average() TO pgwatch;
-COMMENT ON FUNCTION get_load_average() is 'created for pgwatch';
-COMMIT;
-EOSQL
+/pgwatch/pgwatch metric print-init full | psql -v ON_ERROR_STOP=1 --username "postgres" --dbname "pgwatch"

--- a/docker/bootstrap/init_test_monitored_db.sh
+++ b/docker/bootstrap/init_test_monitored_db.sh
@@ -4,7 +4,7 @@ if [ -n "$PW_TESTDB" ] ; then
   echo "adding test monitored database..."
   psql -v ON_ERROR_STOP=1 --username "postgres" --dbname "pgwatch" <<-EOSQL
       INSERT INTO pgwatch.source (name, preset_config, config, connstr)
-      SELECT 'test', 'exhaustive', null, 'postgresql://pgwatch:pgwatchadmin@localhost:5432/pgwatch'
+      SELECT 'test', 'full', null, 'postgresql://pgwatch:pgwatchadmin@localhost:5432/pgwatch'
       WHERE NOT EXISTS (SELECT * FROM pgwatch.source WHERE name = 'test');
 EOSQL
 fi

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update \
 # Install Grafana
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
     && curl "https://dl.grafana.com/oss/release/grafana_10.4.7_${arch}.deb" --output grafana.deb \
-    && dpkg -i grafana.deb && rm grafana.deb
+    && dpkg -i grafana.deb && rm grafana.deb \
+    && grafana-cli plugins install marcusolsson-treemap-panel
 COPY docker/demo/grafana.ini /etc/grafana/grafana.ini
 COPY grafana/postgres_datasource.yml /etc/grafana/provisioning/datasources/pg_ds.yml
 COPY grafana/dashboards.yml /etc/grafana/provisioning/dashboards/pg_db.yml

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
 
 # Install Grafana
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-    && curl "https://dl.grafana.com/oss/release/grafana_10.3.3_${arch}.deb" --output grafana.deb \
+    && curl "https://dl.grafana.com/oss/release/grafana_10.4.7_${arch}.deb" --output grafana.deb \
     && dpkg -i grafana.deb && rm grafana.deb
 COPY docker/demo/grafana.ini /etc/grafana/grafana.ini
 COPY grafana/postgres_datasource.yml /etc/grafana/provisioning/datasources/pg_ds.yml

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /pgwatch && CGO_ENABLED=0 go build -ldflags "-X 'main.commit=${GIT_HASH}'
 # ----------------------------------------------------------------
 # 3. Build the final image
 # ----------------------------------------------------------------
-FROM postgres:16-bullseye AS releaser
+FROM postgres:17-bullseye AS releaser
 
 # Copy over the compiled gatherer
 COPY --from=builder /pgwatch/pgwatch /pgwatch/
@@ -37,7 +37,7 @@ RUN apt-get update \
     && curl -L "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | apt-key add - \
     && apt-get update \
     && apt-get -qy install \
-        timescaledb-2-postgresql-16 postgresql-plpython3-16 postgresql-16-pg-qualstats \
+        timescaledb-2-postgresql-17 postgresql-plpython3-17 postgresql-17-pg-qualstats \
         supervisor python3-psutil libfontconfig1 \
     && apt-get purge -y --auto-remove \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -48,8 +48,8 @@ RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
     && dpkg -i grafana.deb && rm grafana.deb
 COPY docker/demo/grafana.ini /etc/grafana/grafana.ini
 COPY grafana/postgres_datasource.yml /etc/grafana/provisioning/datasources/pg_ds.yml
-COPY grafana/postgres_dashboard.yml /etc/grafana/provisioning/dashboards/pg_db.yml
-ADD grafana/postgres/v10/ /var/lib/grafana/dashboards/
+COPY grafana/dashboards.yml /etc/grafana/provisioning/dashboards/pg_db.yml
+COPY grafana/postgres/v10/ /var/lib/grafana/dashboards/
 
 
 # Set up supervisord [https://docs.docker.com/engine/admin/using_supervisord/]

--- a/docker/demo/grafana.ini
+++ b/docker/demo/grafana.ini
@@ -3,13 +3,6 @@ protocol = http
 cert_file = /pgwatch/persistent-config/self-signed-ssl.pem
 cert_key = /pgwatch/persistent-config/self-signed-ssl.key
 
-[database]
-type = postgres
-host = 127.0.0.1:5432
-name = pgwatch_grafana
-user = pgwatch
-password = pgwatchadmin
-
 [security]
 admin_user = admin
 admin_password = pgwatchadmin

--- a/docker/demo/grafana.ini
+++ b/docker/demo/grafana.ini
@@ -19,3 +19,6 @@ default_home_dashboard_path = /var/lib/grafana/dashboards/1-global-db-overview.j
 
 [metrics]
 enabled = false
+
+[plugins]
+preinstall = marcusolsson-treemap-panel

--- a/docker/demo/supervisord.conf
+++ b/docker/demo/supervisord.conf
@@ -35,7 +35,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:pgwatch]
-command=/pgwatch/pgwatch --log-file=/var/log/pgwatch/pgwatch.log --log-level=debug
+command=/pgwatch/pgwatch --log-file=/var/log/pgwatch/pgwatch.log
 startsecs=5
 priority=300
 autostart=false


### PR DESCRIPTION
`[+]` bump PostgreSQL to v17
`[*]` make Grafana use standard storage instead of Postgres
`[*]` use `full` preset for demo source instead of `exhaustive`
`[+]` use `pgwatch metric print-init` to prepare test monitoring source