### PR TITLE
[!] refactor `reaper` package and `sinks.MultiWriter`

### DIFF
--- a/internal/reaper/cache.go
+++ b/internal/reaper/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/log"
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/metrics"
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
+	"github.com/sirupsen/logrus"
 )
 
 var monitoredDbCache map[string]*sources.MonitoredDatabase
@@ -78,29 +79,55 @@ func GetMetricVersionProperties(metric string, _ MonitoredDatabaseSettings, metr
 }
 
 // LoadMetricDefs loads metric definitions from the reader
-func LoadMetricDefs(r metrics.Reader) (err error) {
+func (r *Reaper) LoadMetricDefs() (err error) {
 	var metricDefs *metrics.Metrics
-	if metricDefs, err = r.GetMetrics(); err != nil {
+	if metricDefs, err = r.MetricsReaderWriter.GetMetrics(); err != nil {
 		return
 	}
 	metricDefMapLock.Lock()
 	metricDefinitionMap.MetricDefs = maps.Clone(metricDefs.MetricDefs)
 	metricDefinitionMap.PresetDefs = maps.Clone(metricDefs.PresetDefs)
 	metricDefMapLock.Unlock()
+	r.logger.
+		WithField("metrics", len(metricDefinitionMap.MetricDefs)).
+		WithField("presets", len(metricDefinitionMap.PresetDefs)).
+		Log(func() logrus.Level {
+			if len(metricDefinitionMap.PresetDefs)*len(metricDefinitionMap.MetricDefs) == 0 {
+				return logrus.WarnLevel
+			}
+			return logrus.InfoLevel
+		}(), "metrics and presets refreshed")
 	return
 }
 
 const metricDefinitionRefreshInterval time.Duration = time.Minute * 2 // min time before checking for new/changed metric definitions
 
-// SyncMetricDefs refreshes metric definitions at regular intervals
-func SyncMetricDefs(ctx context.Context, r metrics.Reader) {
+// ReadMetrics refreshes metric definitions at regular intervals
+func (r *Reaper) ReadMetrics(ctx context.Context) {
 	for {
+		if err := r.LoadMetricDefs(); err != nil {
+			log.GetLogger(ctx).Errorf("Could not refresh metric definitions: %w", err)
+			continue
+		}
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(metricDefinitionRefreshInterval):
-			if err := LoadMetricDefs(r); err != nil {
-				log.GetLogger(ctx).Errorf("Could not refresh metric definitions: %w", err)
+			// pass through
+		}
+	}
+}
+
+// WriteMeasurements() writes the metrics to the sinks
+func (r *Reaper) WriteMeasurements(ctx context.Context) {
+	var err error
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-r.measurementCh:
+			if err = r.SinksWriter.Write(msg); err != nil {
+				r.logger.Error(err)
 			}
 		}
 	}

--- a/internal/reaper/database.go
+++ b/internal/reaper/database.go
@@ -938,7 +938,7 @@ func GetGoPsutilDiskPG(ctx context.Context, dbUnique string) (metrics.Measuremen
 	return psutil.GetGoPsutilDiskPG(data, dataTblsp)
 }
 
-func CloseResourcesForRemovedMonitoredDBs(metricsWriter *sinks.MultiWriter, currentDBs, prevLoopDBs sources.MonitoredDatabases, shutDownDueToRoleChange map[string]bool) {
+func CloseResourcesForRemovedMonitoredDBs(metricsWriter sinks.Writer, currentDBs, prevLoopDBs sources.MonitoredDatabases, shutDownDueToRoleChange map[string]bool) {
 	var curDBsMap = make(map[string]bool)
 
 	for _, curDB := range currentDBs {
@@ -948,7 +948,7 @@ func CloseResourcesForRemovedMonitoredDBs(metricsWriter *sinks.MultiWriter, curr
 	for _, prevDB := range prevLoopDBs {
 		if _, ok := curDBsMap[prevDB.Name]; !ok { // removed from config
 			prevDB.Conn.Close()
-			_ = metricsWriter.SyncMetrics(prevDB.Name, "", "remove")
+			_ = metricsWriter.SyncMetric(prevDB.Name, "", "remove")
 		}
 	}
 
@@ -957,7 +957,7 @@ func CloseResourcesForRemovedMonitoredDBs(metricsWriter *sinks.MultiWriter, curr
 		if db := currentDBs.GetMonitoredDatabase(roleChangedDB); db != nil {
 			db.Conn.Close()
 		}
-		_ = metricsWriter.SyncMetrics(roleChangedDB, "", "remove")
+		_ = metricsWriter.SyncMetric(roleChangedDB, "", "remove")
 	}
 }
 

--- a/internal/sinks/multiwriter_test.go
+++ b/internal/sinks/multiwriter_test.go
@@ -34,7 +34,7 @@ func TestNewMultiWriter(t *testing.T) {
 	}
 
 	for _, i := range input {
-		mw, err := NewMultiWriter(context.Background(), i.opts, metrics.GetDefaultMetrics())
+		mw, err := NewSinkWriter(context.Background(), i.opts, metrics.GetDefaultMetrics())
 		if i.err {
 			assert.Error(t, err)
 		} else {
@@ -59,7 +59,7 @@ func TestSyncMetrics(t *testing.T) {
 	mw := &MultiWriter{}
 	mockWriter := &MockWriter{}
 	mw.AddWriter(mockWriter)
-	err := mw.SyncMetrics("db", "metric", "op")
+	err := mw.SyncMetric("db", "metric", "op")
 	assert.NoError(t, err)
 }
 
@@ -67,11 +67,6 @@ func TestWriteMeasurements(t *testing.T) {
 	mw := &MultiWriter{}
 	mockWriter := &MockWriter{}
 	mw.AddWriter(mockWriter)
-	ctx, c := context.WithCancel(context.Background())
-	assert.NotNil(t, c)
-	storageCh := make(chan []metrics.MeasurementEnvelope)
-	go mw.WriteMeasurements(ctx, storageCh)
-	storageCh <- []metrics.MeasurementEnvelope{{}}
-	c()
-	close(storageCh)
+	err := mw.Write([]metrics.MeasurementEnvelope{{}})
+	assert.NoError(t, err)
 }

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -35,7 +35,7 @@ var Kinds = []Kind{
 }
 
 func (k Kind) IsValid() bool {
-	return slices.Contains[[]Kind, Kind](Kinds, k)
+	return slices.Contains(Kinds, k)
 }
 
 type (


### PR DESCRIPTION
- make MultiWriter implement Writer interface
- if there is only one target sink, return it instead of MultiWriter
- move WriteMeasurements() to Reaper struct
- make NewReaper() constructor responsible for read/write inits
- rename SyncMetricDefs() to Reaper.ReadMetrics()
- improve Reaper.Reap()
- add Options.InitSinkWriter()
- move sinks init to main()