### PR TITLE
[*] rename `sources.MonitoredDatabase` to `SourceConn`

### DIFF
--- a/internal/cmdopts/cmdsource.go
+++ b/internal/cmdopts/cmdsource.go
@@ -54,7 +54,7 @@ func (cmd *SourcePingCommand) Execute(args []string) error {
 		case sources.SourcePostgresContinuous:
 			_, e = sources.ResolveDatabasesFromPostgres(s)
 		default:
-			mdb := &sources.MonitoredDatabase{Source: s}
+			mdb := &sources.SourceConn{Source: s}
 			e = mdb.Ping(context.Background())
 		}
 		if e != nil {

--- a/internal/metrics/logparse.go
+++ b/internal/metrics/logparse.go
@@ -84,7 +84,7 @@ func getFileWithNextModTimestamp(logsGlobPath, currentFile string) (string, erro
 }
 
 // 1. add zero counts for severity levels that didn't have any occurrences in the log
-func eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal map[string]int64, mdb *sources.MonitoredDatabase) []MeasurementEnvelope {
+func eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal map[string]int64, mdb *sources.SourceConn) []MeasurementEnvelope {
 	allSeverityCounts := make(Measurement)
 	for _, s := range PgSeverities {
 		parsedCount, ok := eventCounts[s]
@@ -110,7 +110,7 @@ func eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal map[string]i
 	}}
 }
 
-func ParseLogs(ctx context.Context, mdb *sources.MonitoredDatabase, realDbname, metricName string, configMap map[string]float64, storeCh chan<- []MeasurementEnvelope) {
+func ParseLogs(ctx context.Context, mdb *sources.SourceConn, realDbname, metricName string, configMap map[string]float64, storeCh chan<- []MeasurementEnvelope) {
 
 	var latest, previous, serverMessagesLang string
 	var latestHandle *os.File

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -1,0 +1,168 @@
+package sources
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/cybertec-postgresql/pgwatch/v3/internal/db"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SourceConn represents a single connection to monitor. Unlike source, it contains a database connection.
+// Continuous discovery sources (postgres-continuous-discovery, patroni-continuous-discovery, patroni-namespace-discovery)
+// will produce multiple monitored databases structs based on the discovered databases.
+type (
+	SourceConn struct {
+		Source
+		Conn       db.PgxPoolIface
+		ConnConfig *pgxpool.Config
+	}
+
+	SourceConns []*SourceConn
+)
+
+// ping will try to ping the server to ensure the connection is still alive
+func (md *SourceConn) ping(ctx context.Context) (err error) {
+	if md.Kind == SourcePgBouncer {
+		// pgbouncer is very picky about the queries it accepts
+		_, err = md.Conn.Exec(ctx, "SHOW VERSION")
+		return
+	}
+	return md.Conn.Ping(ctx)
+}
+
+// Ping will try to establish a brand new connection to the server and return any error
+func (md *SourceConn) Ping(ctx context.Context) error {
+	c, err := pgx.Connect(ctx, md.ConnStr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close(ctx) }()
+	return md.ping(ctx)
+}
+
+// Connect will establish a connection to the database if it's not already connected.
+// If the connection is already established, it pings the server to ensure it's still alive.
+func (md *SourceConn) Connect(ctx context.Context, opts CmdOpts) (err error) {
+	if md.Conn == nil {
+		if err = md.ParseConfig(); err != nil {
+			return err
+		}
+		if md.Kind == SourcePgBouncer {
+			md.ConnConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+		}
+		if opts.MaxParallelConnectionsPerDb > 0 {
+			md.ConnConfig.MaxConns = int32(opts.MaxParallelConnectionsPerDb)
+		}
+		md.Conn, err = db.NewWithConfig(ctx, md.ConnConfig)
+		if err != nil {
+			return err
+		}
+	}
+	return md.ping(ctx)
+}
+
+// ParseConfig will parse the connection string and store the result in the connection config
+func (md *SourceConn) ParseConfig() (err error) {
+	if md.ConnConfig == nil {
+		md.ConnConfig, err = pgxpool.ParseConfig(md.ConnStr)
+		return
+	}
+	return
+}
+
+// GetDatabaseName returns the database name from the connection string
+func (md *SourceConn) GetDatabaseName() string {
+	if err := md.ParseConfig(); err != nil {
+		return ""
+	}
+	return md.ConnConfig.ConnConfig.Database
+}
+
+// SetDatabaseName sets the database name in the connection config for resolved databases
+func (md *SourceConn) SetDatabaseName(name string) {
+	if err := md.ParseConfig(); err != nil {
+		return
+	}
+	md.ConnStr = "" // unset the connection string to force conn config usage
+	md.ConnConfig.ConnConfig.Database = name
+}
+
+func (md *SourceConn) IsPostgresSource() bool {
+	return md.Kind != SourcePgBouncer && md.Kind != SourcePgPool
+}
+
+// TryDiscoverPlatform tries to discover the platform based on the database version string and some special settings
+// that are only available on certain platforms. Returns the platform name or "UNKNOWN" if not sure.
+func (md *SourceConn) DiscoverPlatform(ctx context.Context) (platform string) {
+	sql := `select /* pgwatch_generated */
+	case
+	  when exists (select * from pg_settings where name = 'pg_qs.host_database' and setting = 'azure_sys') and version() ~* 'compiled by Visual C' then 'AZURE_SINGLE'
+	  when exists (select * from pg_settings where name = 'pg_qs.host_database' and setting = 'azure_sys') and version() ~* 'compiled by gcc' then 'AZURE_FLEXIBLE'
+	  when exists (select * from pg_settings where name = 'cloudsql.supported_extensions') then 'GOOGLE'
+	else
+	  'UNKNOWN'
+	end as exec_env`
+	_ = md.Conn.QueryRow(ctx, sql).Scan(&platform)
+	return
+}
+
+// GetApproxSize returns the approximate size of the database in bytes
+func (md *SourceConn) GetApproxSize(ctx context.Context) (size int64, err error) {
+	sqlApproxDBSize := `select /* pgwatch_generated */ 
+	current_setting('block_size')::int8 * sum(relpages)
+from 
+	pg_class c
+where
+	c.relpersistence != 't'`
+	err = md.Conn.QueryRow(ctx, sqlApproxDBSize).Scan(&size)
+	return
+}
+
+// FunctionExists checks if a function exists in the database
+func (md *SourceConn) FunctionExists(ctx context.Context, functionName string) (exists bool) {
+	sql := `select /* pgwatch_generated */ true 
+from 
+	pg_proc join pg_namespace n on pronamespace = n.oid 
+where 
+	proname = $1 and n.nspname = 'public'`
+	_ = md.Conn.QueryRow(ctx, sql, functionName).Scan(&exists)
+	return
+}
+
+func (mds SourceConns) GetMonitoredDatabase(DBUniqueName string) *SourceConn {
+	for _, md := range mds {
+		if md.Name == DBUniqueName {
+			return md
+		}
+	}
+	return nil
+}
+
+// SyncFromReader will update the monitored databases with the latest configuration from the reader.
+// Any resolution errors will be returned, e.g. etcd unavailability.
+// It's up to the caller to proceed with the databases available or stop the execution due to errors.
+func (mds SourceConns) SyncFromReader(r Reader) (newmds SourceConns, err error) {
+	srcs, err := r.GetSources()
+	if err != nil {
+		return nil, err
+	}
+	newmds, err = srcs.ResolveDatabases()
+	for _, newMD := range newmds {
+		md := mds.GetMonitoredDatabase(newMD.Name)
+		if md == nil {
+			continue
+		}
+		if reflect.DeepEqual(md.Source, newMD.Source) {
+			// keep the existing connection if the source is the same
+			newMD.Conn = md.Conn
+			newMD.ConnConfig = md.ConnConfig
+			continue
+		}
+		if md.Conn != nil {
+			md.Conn.Close()
+		}
+	}
+	return newmds, err
+}

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -1,0 +1,147 @@
+package sources_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
+	testcontainers "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestMonitoredDatabase_Connect(t *testing.T) {
+	pgContainer, err := postgres.Run(ctx,
+		"docker.io/postgres:16-alpine",
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Second)),
+	)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, pgContainer.Terminate(ctx)) }()
+
+	// Create a new MonitoredDatabase instance
+	md := &sources.SourceConn{}
+	md.ConnStr, err = pgContainer.ConnectionString(ctx)
+	assert.NoError(t, err)
+
+	// Call the Connect method
+	err = md.Connect(ctx, sources.CmdOpts{})
+	assert.NoError(t, err)
+
+	// Check cached connection
+	err = md.Connect(ctx, sources.CmdOpts{})
+	assert.NoError(t, err)
+}
+func TestMonitoredDatabase_GetDatabaseName(t *testing.T) {
+	md := &sources.SourceConn{}
+	md.ConnStr = "postgres://user:password@localhost:5432/mydatabase"
+	expected := "mydatabase"
+	// check pgx.ConnConfig related code
+	got := md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+	// check ConnStr parsing
+	got = md.Source.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+
+	md = &sources.SourceConn{}
+	md.ConnStr = "foo boo"
+	expected = ""
+	got = md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+}
+
+func TestMonitoredDatabase_SetDatabaseName(t *testing.T) {
+	md := &sources.SourceConn{}
+	md.ConnStr = "postgres://user:password@localhost:5432/mydatabase"
+	expected := "mydatabase"
+	// check ConnStr parsing
+	md.SetDatabaseName(expected)
+	got := md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+	// check pgx.ConnConfig related code
+	expected = "newdatabase"
+	md.SetDatabaseName(expected)
+	got = md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+
+	md = &sources.SourceConn{}
+	md.ConnStr = "foo boo"
+	expected = ""
+	md.SetDatabaseName("ingored due to invalid ConnStr")
+	got = md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+}
+
+func TestMonitoredDatabase_IsPostgresSource(t *testing.T) {
+	md := &sources.SourceConn{}
+	md.Kind = sources.SourcePostgres
+	assert.True(t, md.IsPostgresSource(), "IsPostgresSource() = false, want true")
+
+	md.Kind = sources.SourcePgBouncer
+	assert.False(t, md.IsPostgresSource(), "IsPostgresSource() = true, want false")
+
+	md.Kind = sources.SourcePgPool
+	assert.False(t, md.IsPostgresSource(), "IsPostgresSource() = true, want false")
+
+	md.Kind = sources.SourcePatroni
+	assert.True(t, md.IsPostgresSource(), "IsPostgresSource() = false, want true")
+}
+
+type testSourceReader struct {
+	sources.Sources
+	error
+}
+
+func (r testSourceReader) GetSources() (sources.Sources, error) {
+	return r.Sources, r.error
+}
+
+func TestMonitoredDatabases_SyncFromReader_error(t *testing.T) {
+	reader := testSourceReader{error: assert.AnError}
+	mds := sources.SourceConns{}
+	_, err := mds.SyncFromReader(reader)
+	assert.Error(t, err)
+}
+
+func TestMonitoredDatabases_SyncFromReader(t *testing.T) {
+	db, _ := pgxmock.NewPool()
+	src := sources.Source{
+		Name:      "test",
+		Kind:      sources.SourcePostgres,
+		IsEnabled: true,
+		ConnStr:   "postgres://user:password@localhost:5432/mydatabase",
+	}
+	reader := testSourceReader{Sources: sources.Sources{src}}
+	// first read the sources
+	mds, _ := reader.GetSources()
+	assert.NotNil(t, mds, "GetSources() = nil, want not nil")
+	// then resolve the databases
+	mdbs, _ := mds.ResolveDatabases()
+	assert.NotNil(t, mdbs, "ResolveDatabases() = nil, want not nil")
+	// pretend that we have a connection
+	mdbs[0].Conn = db
+	db.ExpectClose()
+	// sync the databases and make sure they are the same
+	newmdbs, _ := mdbs.SyncFromReader(reader)
+	assert.NotNil(t, newmdbs)
+	assert.Equal(t, mdbs[0].ConnStr, newmdbs[0].ConnStr)
+	assert.Equal(t, db, newmdbs[0].Conn)
+	// change the connection string and check if databases are updated
+	reader.Sources[0].ConnStr = "postgres://user:password@localhost:5432/anotherdatabase"
+	newmdbs, _ = mdbs.SyncFromReader(reader)
+	assert.NotNil(t, newmdbs)
+	assert.NotEqual(t, mdbs[0].ConnStr, newmdbs[0].ConnStr)
+	assert.Nil(t, newmdbs[0].Conn)
+	assert.NoError(t, db.ExpectationsWereMet())
+	// change the unique name of the source and check if it's updated
+	reader.Sources[0].Name = "another"
+	newmdbs, _ = mdbs.SyncFromReader(reader)
+	assert.NotNil(t, newmdbs)
+	assert.NotEqual(t, mdbs[0].Name, newmdbs[0].Name)
+	assert.Nil(t, newmdbs[0].Conn)
+}

--- a/internal/sources/postgres_test.go
+++ b/internal/sources/postgres_test.go
@@ -83,9 +83,9 @@ func TestSyncFromReader(t *testing.T) {
 	pgrw, err := sources.NewPostgresSourcesReaderWriterConn(ctx, conn)
 	a.NoError(err)
 
-	md := &sources.MonitoredDatabase{}
+	md := &sources.SourceConn{}
 	md.Name = "db1"
-	dbs := sources.MonitoredDatabases{md}
+	dbs := sources.SourceConns{md}
 	dbs, err = dbs.SyncFromReader(pgrw)
 	a.NoError(err)
 	a.Len(dbs, 1)

--- a/internal/sources/types_test.go
+++ b/internal/sources/types_test.go
@@ -3,15 +3,10 @@ package sources_test
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
-	testcontainers "github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 var ctx = context.Background()
@@ -35,137 +30,4 @@ func TestKind_IsValid(t *testing.T) {
 		got := tt.kind.IsValid()
 		assert.True(t, got == tt.expected, "IsValid(%v) = %v, want %v", tt.kind, got, tt.expected)
 	}
-}
-
-func TestMonitoredDatabase_Connect(t *testing.T) {
-	pgContainer, err := postgres.Run(ctx,
-		"docker.io/postgres:16-alpine",
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second)),
-	)
-	assert.NoError(t, err)
-	defer func() { assert.NoError(t, pgContainer.Terminate(ctx)) }()
-
-	// Create a new MonitoredDatabase instance
-	md := &sources.MonitoredDatabase{}
-	md.ConnStr, err = pgContainer.ConnectionString(ctx)
-	assert.NoError(t, err)
-
-	// Call the Connect method
-	err = md.Connect(ctx, sources.CmdOpts{})
-	assert.NoError(t, err)
-
-	// Check cached connection
-	err = md.Connect(ctx, sources.CmdOpts{})
-	assert.NoError(t, err)
-}
-func TestMonitoredDatabase_GetDatabaseName(t *testing.T) {
-	md := &sources.MonitoredDatabase{}
-	md.ConnStr = "postgres://user:password@localhost:5432/mydatabase"
-	expected := "mydatabase"
-	// check pgx.ConnConfig related code
-	got := md.GetDatabaseName()
-	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
-	// check ConnStr parsing
-	got = md.Source.GetDatabaseName()
-	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
-
-	md = &sources.MonitoredDatabase{}
-	md.ConnStr = "foo boo"
-	expected = ""
-	got = md.GetDatabaseName()
-	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
-}
-
-func TestMonitoredDatabase_SetDatabaseName(t *testing.T) {
-	md := &sources.MonitoredDatabase{}
-	md.ConnStr = "postgres://user:password@localhost:5432/mydatabase"
-	expected := "mydatabase"
-	// check ConnStr parsing
-	md.SetDatabaseName(expected)
-	got := md.GetDatabaseName()
-	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
-	// check pgx.ConnConfig related code
-	expected = "newdatabase"
-	md.SetDatabaseName(expected)
-	got = md.GetDatabaseName()
-	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
-
-	md = &sources.MonitoredDatabase{}
-	md.ConnStr = "foo boo"
-	expected = ""
-	md.SetDatabaseName("ingored due to invalid ConnStr")
-	got = md.GetDatabaseName()
-	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
-}
-
-func TestMonitoredDatabase_IsPostgresSource(t *testing.T) {
-	md := &sources.MonitoredDatabase{}
-	md.Kind = sources.SourcePostgres
-	assert.True(t, md.IsPostgresSource(), "IsPostgresSource() = false, want true")
-
-	md.Kind = sources.SourcePgBouncer
-	assert.False(t, md.IsPostgresSource(), "IsPostgresSource() = true, want false")
-
-	md.Kind = sources.SourcePgPool
-	assert.False(t, md.IsPostgresSource(), "IsPostgresSource() = true, want false")
-
-	md.Kind = sources.SourcePatroni
-	assert.True(t, md.IsPostgresSource(), "IsPostgresSource() = false, want true")
-}
-
-type testSourceReader struct {
-	sources.Sources
-	error
-}
-
-func (r testSourceReader) GetSources() (sources.Sources, error) {
-	return r.Sources, r.error
-}
-
-func TestMonitoredDatabases_SyncFromReader_error(t *testing.T) {
-	reader := testSourceReader{error: assert.AnError}
-	mds := sources.MonitoredDatabases{}
-	_, err := mds.SyncFromReader(reader)
-	assert.Error(t, err)
-}
-
-func TestMonitoredDatabases_SyncFromReader(t *testing.T) {
-	db, _ := pgxmock.NewPool()
-	src := sources.Source{
-		Name:      "test",
-		Kind:      sources.SourcePostgres,
-		IsEnabled: true,
-		ConnStr:   "postgres://user:password@localhost:5432/mydatabase",
-	}
-	reader := testSourceReader{Sources: sources.Sources{src}}
-	// first read the sources
-	mds, _ := reader.GetSources()
-	assert.NotNil(t, mds, "GetSources() = nil, want not nil")
-	// then resolve the databases
-	mdbs, _ := mds.ResolveDatabases()
-	assert.NotNil(t, mdbs, "ResolveDatabases() = nil, want not nil")
-	// pretend that we have a connection
-	mdbs[0].Conn = db
-	db.ExpectClose()
-	// sync the databases and make sure they are the same
-	newmdbs, _ := mdbs.SyncFromReader(reader)
-	assert.NotNil(t, newmdbs)
-	assert.Equal(t, mdbs[0].ConnStr, newmdbs[0].ConnStr)
-	assert.Equal(t, db, newmdbs[0].Conn)
-	// change the connection string and check if databases are updated
-	reader.Sources[0].ConnStr = "postgres://user:password@localhost:5432/anotherdatabase"
-	newmdbs, _ = mdbs.SyncFromReader(reader)
-	assert.NotNil(t, newmdbs)
-	assert.NotEqual(t, mdbs[0].ConnStr, newmdbs[0].ConnStr)
-	assert.Nil(t, newmdbs[0].Conn)
-	assert.NoError(t, db.ExpectationsWereMet())
-	// change the unique name of the source and check if it's updated
-	reader.Sources[0].Name = "another"
-	newmdbs, _ = mdbs.SyncFromReader(reader)
-	assert.NotNil(t, newmdbs)
-	assert.NotEqual(t, mdbs[0].Name, newmdbs[0].Name)
-	assert.Nil(t, newmdbs[0].Conn)
 }


### PR DESCRIPTION
Also move some connection specific functions from reaper to SourceConn methods, e.g. TryDiscoverExecutionEnv(), DoesFunctionExists()