### PR TITLE
Update sproc-details.json for Grafana v11 Compatibility

### DIFF
--- a/grafana/postgres/v10/sproc-details.json
+++ b/grafana/postgres/v10/sproc-details.json
@@ -19,41 +19,16 @@
   "links": [],
   "panels": [
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fill": 1,
+      "id": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 1,
-      "interval": "2m",
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "type": "timeseries",
+      "title": "Calls ($agg_interval aggregate)",
+      "datasource": null,
       "targets": [
         {
           "alias": "calls",
@@ -125,87 +100,50 @@
           ]
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Calls ($agg_interval aggregate)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
         },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "mean"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "display": "line",
+        "lineWidth": 1,
+        "nullValue": "null",
+        "fillOpacity": 1,
+        "showPoints": false,
+        "pointSize": 5,
+        "steppedLine": false
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "decimals": 3,
-      "fill": 1,
+      "id": 2,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
         "y": 7
       },
-      "id": 2,
-      "interval": "2m",
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "type": "timeseries",
+      "title": "Avg. runtime ($agg_interval avg.)",
+      "datasource": null,
       "targets": [
         {
           "alias": "total_time",
@@ -277,51 +215,42 @@
           ]
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Avg. runtime ($agg_interval avg.)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
           "decimals": 3,
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
         },
-        {
-          "decimals": null,
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "mean"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "display": "line",
+        "lineWidth": 1,
+        "nullValue": "null as zero",
+        "fillOpacity": 1,
+        "showPoints": false,
+        "pointSize": 5,
+        "steppedLine": false
       }
     }
   ],
-  "schemaVersion": 19,
+  "schemaVersion": 39,
   "style": "dark",
   "tags": [
     "pgwatch"


### PR DESCRIPTION
This pull request updates the dashboard JSON file sproc-details.json to support Grafana v11. The changes include:

Schema Version:
- The "schemaVersion" has been updated from 19 (Grafana v10) to 39 (Grafana v11), aligning with the new JSON model requirements.

Panel Type Conversion:
- Legacy panel types have been converted from "graph" to "timeseries". The configuration now utilizes the new fieldConfig and options structure for visual settings such as legend, tooltip, and line display.

Legacy Options Removal:
-  Outdated properties (e.g., "renderer": "flot") have been removed to ensure compatibility and avoid errors in Grafana v11.

Templating and Time Picker:
-  The templating, time picker, and other dashboard-level settings remain unchanged to preserve functionality

Testing:

- The updated sproc-details.json has been loaded in Grafana v11, and all panels render without errors.
- All automated tests pass.