### PR TITLE
[-] fix duplicate object key in `postgres/v11/system-stats.json`

### DIFF
--- a/grafana/postgres/v11/system-stats.json
+++ b/grafana/postgres/v11/system-stats.json
@@ -1219,7 +1219,6 @@
       {
         "allValue": null,
         "current": {
-          "text": null,
           "text": null
         },
         "datasource": null,


### PR DESCRIPTION
## Changes Made  
- Removed a duplicate `"text": null` key in the `grafana/postgres/v11/system-stats.json` file under the `"current"` object.
<img width="379" alt="Screenshot 2025-03-21 at 01 14 16" src="https://github.com/user-attachments/assets/83a20191-6d75-494a-8df5-16300acddae6" />
->
<img width="313" alt="Screenshot 2025-03-21 at 01 14 28" src="https://github.com/user-attachments/assets/2495a63c-d592-4ff2-bae8-64671d612fea" />
  

## Reason for Changes  
- The duplicate key caused invalid JSON syntax, which could lead to parsing errors or unexpected behavior in Grafana dashboards.  
- JSON objects require unique keys; removing the duplicate ensures compliance with JSON standards.  

## Impact  
- Fixes syntax validity without altering functionality.  
- Improves reliability of the dashboard configuration.  

## Note  
This is a straightforward syntax correction. No tests or additional documentation updates are required as the change does not affect logic or features.  