### PR TITLE
[*] fix typo in documentation

### DIFF
--- a/docs/tutorial/custom_installation.md
+++ b/docs/tutorial/custom_installation.md
@@ -4,7 +4,7 @@ title: Custom installation
 
 As described in the [Components](../concept/components.md)
 chapter, there is a couple of ways how to set up pgwatch.
-Two most common ways though are using the central **configurartion database**
+Two most common ways though are using the central **configuration database**
 approach and the **YAML file** based approach, plus Grafana to
 visualize the gathered metrics.
 
@@ -29,11 +29,11 @@ visualize the gathered metrics.
 1. Make sure that there are auto-start services for all
     components in place and optionally set up also backups.
 
-### Detailed steps for the configurartion database approach with Postgres sink
+### Detailed steps for the configuration database approach with Postgres sink
 
 Below are the sample steps for a custom installation from scratch using
-Postgres for the pgwatch configurartion database, measurements database and Grafana
-configurartion database.
+Postgres for the pgwatch configuration database, measurements database and Grafana
+configuration database.
 
 All examples here assume Ubuntu as OS but it's basically the same for
 RedHat family of operations systems also, minus package installation

--- a/docs/tutorial/upgrading.md
+++ b/docs/tutorial/upgrading.md
@@ -78,7 +78,7 @@ YAML schema has default values for everything and there are no other
 
 The update process for Grafana looks pretty much like the installation
 so take a look at the according
-[chapter](custom_installation.md#detailed-steps-for-the-configurartion-database-approach-with-postgres-sink).
+[chapter](custom_installation.md#detailed-steps-for-the-configuration-database-approach-with-postgres-sink).
 If using Grafana package repository it should happen automatically along
 with other system packages. Grafana has a built-in database schema
 migrator, so updating the binaries and restarting is enough.


### PR DESCRIPTION
Some docs have `configurartion` instead of `configuration`.