### PR TITLE
Add a SystemD service template to DEB / RPM / Tar

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,8 @@ archives:
       dst: sample.sources.yaml
     - src: ./internal/metrics/metrics.yaml
       dst: metrics.yaml
+    - src: "./internal/sources/sample.systemd.service"
+      dst: "/etc/pgwatch/sample.systemd.service"
 
 
 checksum:
@@ -69,3 +71,5 @@ nfpms:
         dst: "/etc/pgwatch/metrics.yaml"
       - src: "./README.md"
         dst: "/etc/pgwatch/README.md"
+      - src: "./internal/sources/sample.systemd.service"
+        dst: "/etc/pgwatch/sample.systemd.service"

--- a/internal/sources/sample.sources.yaml
+++ b/internal/sources/sample.sources.yaml
@@ -1,5 +1,5 @@
 - name: test1       # An arbitrary unique name for the monitored source
-  conn_str: postgresql://pgwatch:pgwatchadmin@somehost/mydb
+  conn_str: postgresql://postgres@localhost/postgres
   kind: postgres              # One of the:
                               # - postgres
                               # - postgres-continuous-discovery

--- a/internal/sources/sample.systemd.service
+++ b/internal/sources/sample.systemd.service
@@ -1,0 +1,20 @@
+# This is an example of a systemD config file for pgwatch.
+# You can copy it to "/etc/systemd/system/pgwatch.service", adjust as necessary and then call
+# systemctl daemon-reload && systemctl start pgwatch && systemctl enable pgwatch
+# to start and also enable auto-start after reboot.
+
+[Unit]
+Description=Pgwatch Gathering Daemon
+After=network-online.target
+# When on the monitored node then it's a good idea to only launch after Postgres
+# After=postgresql
+
+[Service]
+User=postgres
+Type=simple
+ExecStart=/usr/bin/pgwatch --sources /etc/pgwatch/sample.sources.yaml --sink=prometheus://0.0.0.0:9187
+Restart=on-failure
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
To get started more quickly after installing from packages. Currently a bit annoying to hunt for a SystemD definition from old pgwatch2 and make source and sink adjustments