### PR TITLE
[-] fix Pgpool-II support, closes #730

### DIFF
--- a/docs/reference/advanced_features.md
+++ b/docs/reference/advanced_features.md
@@ -17,8 +17,8 @@ standard way a bit tricky. But luckily Patroni cluster members
 information is stored in a DCS (Distributed Consensus Store), like
 *etcd*, so it can be fetched from there periodically.
 
-When 'patroni' is selected as a **source type** then the usual Postgres 
-host/port fields should be left empty ("dbname" can still be filled if only a 
+When 'patroni' is selected as a **source type** then the usual Postgres
+host/port fields should be left empty ("dbname" can still be filled if only a
 specific single database is
 to be monitored) and instead "Host config" JSON field should be filled
 with DCS address, type and scope (cluster name) information. A sample
@@ -71,7 +71,7 @@ to be specified manually under "Host config" as seen for example
 
 On Postgres side (on the monitored DB)
 
-```
+```ini
     # Debian / Ubuntu default log_line_prefix actually
     log_line_prefix = '%m [%p] %q%u@%d '
 ```
@@ -79,7 +79,7 @@ On Postgres side (on the monitored DB)
 YAML config (recommended when "pushing" metrics from DB nodes to a
 central metrics DB)
 
-```
+```yaml
     ## logs_glob_path is only needed if the monitoring user is cannot auto-detect it (i.e. not a superuser / pg_monitor role)
     # logs_glob_path:
     logs_match_regex: '^(?P<log_time>.*) \[(?P<process_id>\d+)\] (?P<user_name>.*)@(?P<database_name>.*?) (?P<error_severity>.*?): '
@@ -113,7 +113,8 @@ Quite similar to PgBouncer, also Pgpool offers some statistics on pool
 performance and status, which might be of interest especially if using
 the load balancing features. To enable it choose the according *DB
 Type*, provide connection info to the pooler port and make sure the
-**pgpool_stats** metric / preset config is selected for the host.
+**pgpool_stats** and **pgpool_processes** metrics or **pgpool** preset config
+is selected for the host.
 
 The built-in Grafana dashboard for Pgpool data looks something like
 that:

--- a/grafana/postgres/v10/pgpool-stats.json
+++ b/grafana/postgres/v10/pgpool-stats.json
@@ -81,7 +81,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "select\n  dbname,\n  tag_data->>'node_id' as node_id,\n  data->>'role' as role,\n  data->>'status' as status,\n  case when data->>'status' = 'up' then 1 else 0 end as status_num,\n  data->>'hostname' as hostname,\n  data->>'port' as port,\n  data->>'lb_weight' as lb_weight,\n  data->>'load_balance_node' as load_balance_node,\n  data->>'replication_delay' as replication_delay,\n  data->>'select_cnt' as select_cnt,\n  data->>'processes_total' as processes_total,\n  data->>'processes_active' as processes_active,  \n  data->>'last_status_change' as last_status_change,  \n  date_trunc('second', time::timestamp)::time as time\nfrom\n  pgpool_stats\nwhere\n  time = (select max(time) from pgpool_stats where dbname in ($dbname) and $__timeFilter(time) group by dbname)\n  and dbname in ($dbname)\norder by\n  dbname,\n  node_id,\n  time desc\n",
+          "rawSql": "select\n  dbname,\n  tag_data->>'node_id' as node_id,\n  data->>'role' as role,\n  data->>'status' as status,\n  case when data->>'status' = 'up' then 1 else 0 end as status_num,\n  data->>'hostname' as hostname,\n  data->>'port' as port,\n  data->>'lb_weight' as lb_weight,\n  data->>'load_balance_node' as load_balance_node,\n  data->>'replication_delay' as replication_delay,\n  data->>'select_cnt' as select_cnt,  \n  data->>'last_status_change' as last_status_change,  \n  time::text as \"updated\"\nfrom\n  pgpool_stats\nwhere\n  time = (select max(time) from pgpool_stats where dbname in ($dbname) and $__timeFilter(time) group by dbname)\n  and dbname in ($dbname)\norder by\n  dbname,\n  node_id,\n  time desc\n",
           "refId": "A",
           "select": [
             [
@@ -154,7 +154,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroup(time, $agg_interval),\n  (max((data->'select_cnt')::int8) - min((data->'select_cnt')::int8))::int8 as select_cnt,\n  dbname || ' (node: ' || (tag_data->>'node_id')::text || ')' as node_id\nFROM\n  pgpool_stats\nWHERE\n  $__timeFilter(time)\n  AND dbname in ($dbname)\nGROUP BY\n  1, 3\nORDER BY\n  1\n",
+          "rawSql": "SELECT\n  $__timeGroup(time, $agg_interval),\n  (max((data->>'select_cnt')::int8) - min((data->>'select_cnt')::int8))::int8 as select_cnt,\n  dbname || ' (node: ' || (tag_data->>'node_id')::text || ')' as node_id\nFROM\n  pgpool_stats\nWHERE\n  $__timeFilter(time)\n  AND dbname in ($dbname)\nGROUP BY\n  1, 3\nORDER BY\n  1\n",
           "refId": "A",
           "select": [
             [

--- a/grafana/postgres/v11/pgpool-stats.json
+++ b/grafana/postgres/v11/pgpool-stats.json
@@ -142,7 +142,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "select\n  dbname,\n  tag_data->>'node_id' as node_id,\n  data->>'role' as role,\n  data->>'status' as status,\n  case when data->>'status' = 'up' then 1 else 0 end as status_num,\n  data->>'hostname' as hostname,\n  data->>'port' as port,\n  data->>'lb_weight' as lb_weight,\n  data->>'load_balance_node' as load_balance_node,\n  data->>'replication_delay' as replication_delay,\n  data->>'select_cnt' as select_cnt,\n  data->>'processes_total' as processes_total,\n  data->>'processes_active' as processes_active,  \n  data->>'last_status_change' as last_status_change,  \n  date_trunc('second', time::timestamp)::time as time\nfrom\n  pgpool_stats\nwhere\n  time = (select max(time) from pgpool_stats where dbname in ($dbname) and $__timeFilter(time) group by dbname)\n  and dbname in ($dbname)\norder by\n  dbname,\n  node_id,\n  time desc\n",
+          "rawSql": "select\n  dbname,\n  tag_data->>'node_id' as node_id,\n  data->>'role' as role,\n  data->>'status' as status,\n  case when data->>'status' = 'up' then 1 else 0 end as status_num,\n  data->>'hostname' as hostname,\n  data->>'port' as port,\n  data->>'lb_weight' as lb_weight,\n  data->>'load_balance_node' as load_balance_node,\n  data->>'replication_delay' as replication_delay,\n  data->>'select_cnt' as select_cnt,  \n  data->>'last_status_change' as last_status_change,  \n  time::text as \"updated\"\nfrom\n  pgpool_stats\nwhere\n  time = (select max(time) from pgpool_stats where dbname in ($dbname) and $__timeFilter(time) group by dbname)\n  and dbname in ($dbname)\norder by\n  dbname,\n  node_id,\n  time desc\n",
           "refId": "A",
           "select": [
             [
@@ -268,7 +268,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroup(time, $agg_interval),\n  (max((data->'select_cnt')::int8) - min((data->'select_cnt')::int8))::int8 as select_cnt,\n  dbname || ' (node: ' || (tag_data->>'node_id')::text || ')' as node_id\nFROM\n  pgpool_stats\nWHERE\n  $__timeFilter(time)\n  AND dbname in ($dbname)\nGROUP BY\n  1, 3\nORDER BY\n  1\n",
+          "rawSql": "SELECT\n  $__timeGroup(time, $agg_interval),\n  (max((data->>'select_cnt')::int8) - min((data->>'select_cnt')::int8))::int8 as select_cnt,\n  dbname || ' (node: ' || (tag_data->>'node_id')::text || ')' as node_id\nFROM\n  pgpool_stats\nWHERE\n  $__timeFilter(time)\n  AND dbname in ($dbname)\nGROUP BY\n  1, 3\nORDER BY\n  1\n",
           "refId": "A",
           "select": [
             [

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -992,14 +992,12 @@ metrics:
     pgbouncer_clients:
         sqls:
             0: show clients
+    pgpool_processes:
+        sqls:
+            3: show pool_processes
     pgpool_stats:
         sqls:
-            3: |-
-                /* SHOW POOL_NODES expected to be 1st "command" */
-                SHOW POOL_NODES;
-                /* special handling in code - when below SHOW POOL_PROCESSES line is defined pgpool_stats will have additional summary columns:
-                 processes_total, processes_active */
-                SHOW POOL_PROCESSES
+            3: show pool_nodes
     privilege_changes:
         sqls:
             11: |-
@@ -4161,9 +4159,10 @@ presets:
             pgbouncer_stats: 60
             pgbouncer_clients: 60
     pgpool:
-        description: pool global stats, 1 row per node ID
+        description: pool global stats
         metrics:
             pgpool_stats: 60
+            pgpool_processes: 60
     prometheus:
         description: similar to "exhaustive" but without some possibly longer-running metrics and those keeping state
         metrics:

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"maps"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 type (
@@ -76,6 +78,25 @@ const (
 )
 
 type Measurement map[string]any
+
+// RowToMap returns a map scanned from row.
+func RowToMeasurement(row pgx.CollectableRow) (map[string]any, error) {
+	value := NewMeasurement(time.Now().UnixNano())
+	err := row.Scan((*Measurement)(&value))
+	return value, err
+}
+
+func (rs *Measurement) ScanRow(rows pgx.Rows) error {
+	values, err := rows.Values()
+	if err != nil {
+		return err
+	}
+	// *rs = make(Measurement, len(values))
+	for i := range values {
+		(*rs)[string(rows.FieldDescriptions()[i].Name)] = values[i]
+	}
+	return nil
+}
 
 func NewMeasurement(epoch int64) Measurement {
 	m := make(Measurement)

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -86,14 +86,14 @@ func RowToMeasurement(row pgx.CollectableRow) (map[string]any, error) {
 	return value, err
 }
 
-func (rs *Measurement) ScanRow(rows pgx.Rows) error {
+func (m *Measurement) ScanRow(rows pgx.Rows) error {
 	values, err := rows.Values()
 	if err != nil {
 		return err
 	}
 	// *rs = make(Measurement, len(values))
 	for i := range values {
-		(*rs)[string(rows.FieldDescriptions()[i].Name)] = values[i]
+		(*m)[string(rows.FieldDescriptions()[i].Name)] = values[i]
 	}
 	return nil
 }

--- a/internal/reaper/recommendations.go
+++ b/internal/reaper/recommendations.go
@@ -16,7 +16,6 @@ const (
 	recoMetricName                    = "recommendations"
 	specialMetricChangeEvents         = "change_events"
 	specialMetricServerLogEventCounts = "server_log_event_counts"
-	specialMetricPgpoolStats          = "pgpool_stats"
 	specialMetricInstanceUp           = "instance_up"
 )
 

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -206,7 +206,7 @@ FROM
 }
 
 func (md *SourceConn) FetchVersion(ctx context.Context, sql string) (version string, ver int, err error) {
-	if err = md.Conn.QueryRow(ctx, sql).Scan(&version); err != nil {
+	if err = md.Conn.QueryRow(ctx, sql, pgx.QueryExecModeSimpleProtocol).Scan(&version); err != nil {
 		return
 	}
 	ver = VersionToInt(version)

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pashagolub/pgxmock/v4"
@@ -300,7 +301,9 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 			Conn:   mock,
 			Source: sources.Source{Kind: sources.SourcePgBouncer},
 		}
-		mock.ExpectQuery("SHOW VERSION").WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("PgBouncer 1.12.0"))
+		mock.ExpectQuery("SHOW VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("PgBouncer 1.12.0"))
 		err = md.FetchRuntimeInfo(ctx, true)
 		assert.NoError(t, err)
 		assert.Contains(t, md.VersionStr, "PgBouncer")
@@ -315,7 +318,9 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 			Conn:   mock,
 			Source: sources.Source{Kind: sources.SourcePgPool},
 		}
-		mock.ExpectQuery("SHOW POOL_VERSION").WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("4.1.2"))
+		mock.ExpectQuery("SHOW POOL_VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("4.1.2"))
 		err = md.FetchRuntimeInfo(ctx, true)
 		assert.NoError(t, err)
 		assert.Contains(t, md.VersionStr, "4.1.2")
@@ -359,7 +364,9 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 			Conn:   mock,
 			Source: sources.Source{Kind: sources.SourcePgBouncer},
 		}
-		mock.ExpectQuery("SHOW VERSION").WillReturnError(fmt.Errorf("db error"))
+		mock.ExpectQuery("SHOW VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnError(fmt.Errorf("db error"))
 		err = md.FetchRuntimeInfo(ctx, true)
 		assert.Error(t, err)
 		assert.NoError(t, mock.ExpectationsWereMet())
@@ -373,7 +380,9 @@ func TestSourceConn_FetchVersion(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
 		md := &sources.SourceConn{Conn: mock}
-		mock.ExpectQuery("SHOW VERSION").WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("FooBar 1.12.0"))
+		mock.ExpectQuery("SHOW VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("FooBar 1.12.0"))
 		verStr, verInt, err := md.FetchVersion(ctx, "SHOW VERSION")
 		assert.NoError(t, err)
 		assert.Equal(t, "FooBar 1.12.0", verStr)
@@ -385,7 +394,9 @@ func TestSourceConn_FetchVersion(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
 		md := &sources.SourceConn{Conn: mock}
-		mock.ExpectQuery("SHOW VERSION").WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("invalid version"))
+		mock.ExpectQuery("SHOW VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("invalid version"))
 		_, verInt, err := md.FetchVersion(ctx, "SHOW VERSION")
 		assert.Equal(t, 0, verInt)
 		assert.NoError(t, err)
@@ -396,7 +407,9 @@ func TestSourceConn_FetchVersion(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
 		md := &sources.SourceConn{Conn: mock}
-		mock.ExpectQuery("SHOW VERSION").WillReturnError(assert.AnError)
+		mock.ExpectQuery("SHOW VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnError(assert.AnError)
 		_, _, err = md.FetchVersion(ctx, "SHOW VERSION")
 		assert.Error(t, err)
 		assert.NoError(t, mock.ExpectationsWereMet())


### PR DESCRIPTION
- split `pgpool_stats` into two separate metrics
- update documentation
- update Grafana dashboards
- add `metrics.RowToMeasurement()`
- use `pgx.QueryExecModeSimpleProtocol` for non-Postgres connections
- remove `FetchMetricsPgpool()` and use standard fetching