### PR TITLE
[-] fix `QueryMeasurements` nil pointer dereference, fixes #766

### DIFF
--- a/internal/reaper/cache.go
+++ b/internal/reaper/cache.go
@@ -32,7 +32,7 @@ func GetMonitoredDatabaseByUniqueName(ctx context.Context, name string) (*source
 	monitoredDbCacheLock.RLock()
 	defer monitoredDbCacheLock.RUnlock()
 	md, exists := monitoredDbCache[name]
-	if !exists || md == nil {
+	if !exists || md == nil || md.Conn == nil {
 		return nil, fmt.Errorf("database %s not found in cache", name)
 	}
 	return md, nil

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -264,7 +264,6 @@ func (r *Reaper) ShutdownOldWorkers(ctx context.Context, hostsToShutDownDueToRol
 	r.CloseResourcesForRemovedMonitoredDBs(hostsToShutDownDueToRoleChange)
 }
 
-// metrics.ControlMessage notifies of shutdown + interval change
 func (r *Reaper) reapMetricMeasurements(ctx context.Context, md *sources.SourceConn, metricName string) {
 	hostState := make(map[string]map[string]string)
 	var lastUptimeS int64 = -1 // used for "server restarted" event detection

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -276,19 +276,15 @@ func (mds SourceConns) SyncFromReader(r Reader) (newmds SourceConns, err error) 
 		return nil, err
 	}
 	newmds, err = srcs.ResolveDatabases()
-	for _, newMD := range newmds {
+	for i, newMD := range newmds {
 		md := mds.GetMonitoredDatabase(newMD.Name)
 		if md == nil {
 			continue
 		}
 		if reflect.DeepEqual(md.Source, newMD.Source) {
-			// keep the existing connection if the source is the same
-			newMD.Conn = md.Conn
-			newMD.ConnConfig = md.ConnConfig
+			// replace with the existing connection if the source is the same
+			newmds[i] = md
 			continue
-		}
-		if md.Conn != nil {
-			md.Conn.Close()
 		}
 	}
 	return newmds, err

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -240,7 +240,6 @@ func TestMonitoredDatabases_SyncFromReader(t *testing.T) {
 	assert.NotNil(t, mdbs, "ResolveDatabases() = nil, want not nil")
 	// pretend that we have a connection
 	mdbs[0].Conn = db
-	db.ExpectClose()
 	// sync the databases and make sure they are the same
 	newmdbs, _ := mdbs.SyncFromReader(reader)
 	assert.NotNil(t, newmdbs)


### PR DESCRIPTION
* keep existing connection in `SourceConns.SyncFromReader()`

Since `SourceConn` passed to `reapMetricMeasurements()` it's crucial to keep the existing source with connection alive, so the reaper keeps it's work. And there is no need to close the connection because it might be used right now in some metric fetcher. Let Reaper to cancel all disabled monitored sources in the main loop of `Reap()` function.