### PR TITLE
[+] decrease memory allocations for `metrics.MeasurementEnvelope`

### DIFF
--- a/internal/reaper/database.go
+++ b/internal/reaper/database.go
@@ -50,7 +50,7 @@ func QueryMeasurements(ctx context.Context, dbUnique string, sql string, args ..
 	return nil, err
 }
 
-func DetectSprocChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- []metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
+func DetectSprocChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
 	detectedChanges := make(metrics.Measurements, 0)
 	var firstRun bool
 	var changeCounts ChangeDetectionResults
@@ -122,13 +122,18 @@ func DetectSprocChanges(ctx context.Context, md *sources.SourceConn, storageCh c
 	}
 	log.GetLogger(ctx).Debugf("[%s][%s] detected %d sproc changes", md.Name, specialMetricChangeEvents, len(detectedChanges))
 	if len(detectedChanges) > 0 {
-		storageCh <- []metrics.MeasurementEnvelope{{DBName: md.Name, MetricName: "sproc_changes", Data: detectedChanges, CustomTags: md.CustomTags}}
+		storageCh <- metrics.MeasurementEnvelope{
+			DBName:     md.Name,
+			MetricName: "sproc_changes",
+			Data:       detectedChanges,
+			CustomTags: md.CustomTags,
+		}
 	}
 
 	return changeCounts
 }
 
-func DetectTableChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- []metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
+func DetectTableChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
 	detectedChanges := make(metrics.Measurements, 0)
 	var firstRun bool
 	var changeCounts ChangeDetectionResults
@@ -200,13 +205,18 @@ func DetectTableChanges(ctx context.Context, md *sources.SourceConn, storageCh c
 
 	log.GetLogger(ctx).Debugf("[%s][%s] detected %d table changes", md.Name, specialMetricChangeEvents, len(detectedChanges))
 	if len(detectedChanges) > 0 {
-		storageCh <- []metrics.MeasurementEnvelope{{DBName: md.Name, MetricName: "table_changes", Data: detectedChanges, CustomTags: md.CustomTags}}
+		storageCh <- metrics.MeasurementEnvelope{
+			DBName:     md.Name,
+			MetricName: "table_changes",
+			Data:       detectedChanges,
+			CustomTags: md.CustomTags,
+		}
 	}
 
 	return changeCounts
 }
 
-func DetectIndexChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- []metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
+func DetectIndexChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
 	detectedChanges := make(metrics.Measurements, 0)
 	var firstRun bool
 	var changeCounts ChangeDetectionResults
@@ -276,13 +286,18 @@ func DetectIndexChanges(ctx context.Context, md *sources.SourceConn, storageCh c
 	}
 	log.GetLogger(ctx).Debugf("[%s][%s] detected %d index changes", md.Name, specialMetricChangeEvents, len(detectedChanges))
 	if len(detectedChanges) > 0 {
-		storageCh <- []metrics.MeasurementEnvelope{{DBName: md.Name, MetricName: "index_changes", Data: detectedChanges, CustomTags: md.CustomTags}}
+		storageCh <- metrics.MeasurementEnvelope{
+			DBName:     md.Name,
+			MetricName: "index_changes",
+			Data:       detectedChanges,
+			CustomTags: md.CustomTags,
+		}
 	}
 
 	return changeCounts
 }
 
-func DetectPrivilegeChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- []metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
+func DetectPrivilegeChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
 	detectedChanges := make(metrics.Measurements, 0)
 	var firstRun bool
 	var changeCounts ChangeDetectionResults
@@ -346,19 +361,18 @@ func DetectPrivilegeChanges(ctx context.Context, md *sources.SourceConn, storage
 
 	log.GetLogger(ctx).Debugf("[%s][%s] detected %d object privilege changes...", md.Name, specialMetricChangeEvents, len(detectedChanges))
 	if len(detectedChanges) > 0 {
-		storageCh <- []metrics.MeasurementEnvelope{
-			{
-				DBName:     md.Name,
-				MetricName: "privilege_changes",
-				Data:       detectedChanges,
-				CustomTags: md.CustomTags,
-			}}
+		storageCh <- metrics.MeasurementEnvelope{
+			DBName:     md.Name,
+			MetricName: "privilege_changes",
+			Data:       detectedChanges,
+			CustomTags: md.CustomTags,
+		}
 	}
 
 	return changeCounts
 }
 
-func DetectConfigurationChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- []metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
+func DetectConfigurationChanges(ctx context.Context, md *sources.SourceConn, storageCh chan<- metrics.MeasurementEnvelope, hostState map[string]map[string]string) ChangeDetectionResults {
 	detectedChanges := make(metrics.Measurements, 0)
 	var firstRun bool
 	var changeCounts ChangeDetectionResults
@@ -410,12 +424,12 @@ func DetectConfigurationChanges(ctx context.Context, md *sources.SourceConn, sto
 
 	log.GetLogger(ctx).Debugf("[%s][%s] detected %d configuration changes", md.Name, specialMetricChangeEvents, len(detectedChanges))
 	if len(detectedChanges) > 0 {
-		storageCh <- []metrics.MeasurementEnvelope{{
+		storageCh <- metrics.MeasurementEnvelope{
 			DBName:     md.Name,
 			MetricName: "configuration_changes",
 			Data:       detectedChanges,
 			CustomTags: md.CustomTags,
-		}}
+		}
 	}
 
 	return changeCounts
@@ -455,12 +469,13 @@ func (r *Reaper) CheckForPGObjectChangesAndStore(ctx context.Context, dbUnique s
 		influxEntry["details"] = message
 		detectedChangesSummary = append(detectedChangesSummary, influxEntry)
 		md, _ := GetMonitoredDatabaseByUniqueName(ctx, dbUnique)
-		storageCh <- []metrics.MeasurementEnvelope{{DBName: dbUnique,
+		storageCh <- metrics.MeasurementEnvelope{
+			DBName:     dbUnique,
 			SourceType: string(md.Kind),
 			MetricName: "object_changes",
 			Data:       detectedChangesSummary,
 			CustomTags: md.CustomTags,
-		}}
+		}
 
 	}
 }

--- a/internal/sinks/json.go
+++ b/internal/sinks/json.go
@@ -30,28 +30,28 @@ func NewJSONWriter(ctx context.Context, fname string) (*JSONWriter, error) {
 	return jw, nil
 }
 
-func (jw *JSONWriter) Write(msgs []metrics.MeasurementEnvelope) error {
+func (jw *JSONWriter) Write(msg metrics.MeasurementEnvelope) error {
 	if jw.ctx.Err() != nil {
 		return jw.ctx.Err()
 	}
-	if len(msgs) == 0 {
+	if len(msg.Data) == 0 {
 		return nil
 	}
 	enc := json.NewEncoder(jw.lw)
 	t1 := time.Now()
 	written := 0
-	for _, msg := range msgs {
-		dataRow := map[string]any{
-			"metric":      msg.MetricName,
-			"data":        msg.Data,
-			"dbname":      msg.DBName,
-			"custom_tags": msg.CustomTags,
-		}
-		if err := enc.Encode(dataRow); err != nil {
-			return err
-		}
-		written += len(msg.Data)
+
+	dataRow := map[string]any{
+		"metric":      msg.MetricName,
+		"data":        msg.Data,
+		"dbname":      msg.DBName,
+		"custom_tags": msg.CustomTags,
 	}
+	if err := enc.Encode(dataRow); err != nil {
+		return err
+	}
+	written += len(msg.Data)
+
 	diff := time.Since(t1)
 	log.GetLogger(jw.ctx).WithField("rows", written).WithField("elapsed", diff).Info("measurements written")
 	return nil

--- a/internal/sinks/multiwriter.go
+++ b/internal/sinks/multiwriter.go
@@ -13,7 +13,7 @@ import (
 // Writer is an interface that writes metrics values
 type Writer interface {
 	SyncMetric(dbUnique, metricName, op string) error
-	Write(msgs []metrics.MeasurementEnvelope) error
+	Write(msgs metrics.MeasurementEnvelope) error
 }
 
 // MultiWriter ensures the simultaneous storage of data in several storages.
@@ -69,9 +69,9 @@ func (mw *MultiWriter) SyncMetric(dbUnique, metricName, op string) (err error) {
 	return
 }
 
-func (mw *MultiWriter) Write(msgs []metrics.MeasurementEnvelope) (err error) {
+func (mw *MultiWriter) Write(msg metrics.MeasurementEnvelope) (err error) {
 	for _, w := range mw.writers {
-		err = errors.Join(err, w.Write(msgs))
+		err = errors.Join(err, w.Write(msg))
 	}
 	return
 }

--- a/internal/sinks/multiwriter_test.go
+++ b/internal/sinks/multiwriter_test.go
@@ -14,7 +14,7 @@ func (mw *MockWriter) SyncMetric(_, _, _ string) error {
 	return nil
 }
 
-func (mw *MockWriter) Write(_ []metrics.MeasurementEnvelope) error {
+func (mw *MockWriter) Write(_ metrics.MeasurementEnvelope) error {
 	return nil
 }
 
@@ -82,6 +82,6 @@ func TestWriteMeasurements(t *testing.T) {
 	mw := &MultiWriter{}
 	mockWriter := &MockWriter{}
 	mw.AddWriter(mockWriter)
-	err := mw.Write([]metrics.MeasurementEnvelope{{}})
+	err := mw.Write(metrics.MeasurementEnvelope{})
 	assert.NoError(t, err)
 }

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -80,28 +80,26 @@ func TestWrite(t *testing.T) {
 		ctx:    ctx,
 		sinkDb: conn,
 	}
-	messages := []metrics.MeasurementEnvelope{
-		{
-			MetricName: "test_metric",
-			Data: metrics.Measurements{
-				{"number": 1, "string": "test_data"},
-			},
-			DBName:     "test_db",
-			CustomTags: map[string]string{"foo": "boo"},
+	message := metrics.MeasurementEnvelope{
+		MetricName: "test_metric",
+		Data: metrics.Measurements{
+			{"number": 1, "string": "test_data"},
 		},
+		DBName:     "test_db",
+		CustomTags: map[string]string{"foo": "boo"},
 	}
 
 	highLoadTimeout = 0
-	err = pgw.Write(messages)
+	err = pgw.Write(message)
 	assert.NoError(t, err, "messages skipped due to high load")
 
 	highLoadTimeout = time.Second * 5
-	pgw.input = make(chan []metrics.MeasurementEnvelope, cacheLimit)
-	err = pgw.Write(messages)
+	pgw.input = make(chan metrics.MeasurementEnvelope, cacheLimit)
+	err = pgw.Write(message)
 	assert.NoError(t, err, "write successful")
 
 	cancel()
-	err = pgw.Write(messages)
+	err = pgw.Write(message)
 	assert.Error(t, err, "context canceled")
 }
 

--- a/internal/sinks/rpc.go
+++ b/internal/sinks/rpc.go
@@ -35,21 +35,16 @@ func NewRPCWriter(ctx context.Context, address string) (*RPCWriter, error) {
 }
 
 // Sends Measurement Message to RPC Sink
-func (rw *RPCWriter) Write(msgs []metrics.MeasurementEnvelope) error {
+func (rw *RPCWriter) Write(msg metrics.MeasurementEnvelope) error {
 	if rw.ctx.Err() != nil {
 		return rw.ctx.Err()
 	}
-	if len(msgs) == 0 {
-		return nil
+	var logMsg string
+	if err := rw.client.Call("Receiver.UpdateMeasurements", &msg, &logMsg); err != nil {
+		return err
 	}
-	for _, msg := range msgs {
-		var logMsg string
-		if err := rw.client.Call("Receiver.UpdateMeasurements", &msg, &logMsg); err != nil {
-			return err
-		}
-		if len(logMsg) > 0 {
-			log.GetLogger(rw.ctx).Info(logMsg)
-		}
+	if len(logMsg) > 0 {
+		log.GetLogger(rw.ctx).Info(logMsg)
 	}
 	return nil
 }

--- a/internal/sinks/rpc_test.go
+++ b/internal/sinks/rpc_test.go
@@ -20,7 +20,7 @@ type Receiver struct {
 var ctxt = context.Background()
 
 func (receiver *Receiver) UpdateMeasurements(msg *metrics.MeasurementEnvelope, logMsg *string) error {
-	if msg == nil {
+	if msg == nil || len(msg.Data) == 0 {
 		return errors.New("msgs is nil")
 	}
 	if msg.DBName != "Db" {
@@ -69,26 +69,23 @@ func TestRPCWrite(t *testing.T) {
 	a.NoError(err)
 
 	// no error for valid messages
-	msgs := []metrics.MeasurementEnvelope{
-		{
-			DBName: "Db",
-		},
+	msgs := metrics.MeasurementEnvelope{
+		DBName: "Db",
+		Data:   metrics.Measurements{{"test": 1}},
 	}
 	err = rw.Write(msgs)
 	a.NoError(err)
 
 	// error for invalid messages
-	msgs = []metrics.MeasurementEnvelope{
-		{
-			DBName: "invalid",
-		},
+	msgs = metrics.MeasurementEnvelope{
+		DBName: "invalid",
 	}
 	err = rw.Write(msgs)
 	a.Error(err)
 
-	// no error for empty messages
-	err = rw.Write([]metrics.MeasurementEnvelope{})
-	a.NoError(err)
+	// error for empty messages
+	err = rw.Write(metrics.MeasurementEnvelope{})
+	a.Error(err)
 
 	// error for cancelled context
 	ctx, cancel := context.WithCancel(ctxt)


### PR DESCRIPTION
get rid of `[]metrics.MeasurementEnvelope` everywhere

Allocating additional slices increases a memory usage. Instead we can send `metrics.MeasurementEnvelope` one by one immediately after receiving. There is no need to collect them beforehand.
For 12 postgres instances monitored with full preset this change saves us ~4-9% of allocations.