### PR TITLE
[+] move sources sync to the reaper

### DIFF
--- a/cmd/pgwatch/main.go
+++ b/cmd/pgwatch/main.go
@@ -43,6 +43,12 @@ var (
 var Exit = os.Exit
 
 func main() {
+
+	// Uncomment the following lines to enable the pprof HTTP server for debugging
+	// go func() {
+	// 	panic(http.ListenAndServe(":6060", nil))
+	// }()
+
 	exitCode.Store(cmdopts.ExitCodeOK)
 	defer func() {
 		if err := recover(); err != nil {

--- a/internal/reaper/cache.go
+++ b/internal/reaper/cache.go
@@ -1,42 +1,13 @@
 package reaper
 
 import (
-	"context"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/metrics"
-	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
 )
 
-var monitoredDbCache map[string]*sources.SourceConn
-var monitoredDbCacheLock sync.RWMutex
-
 var lastSQLFetchError sync.Map
-
-func UpdateMonitoredDBCache(data sources.SourceConns) {
-	monitoredDbCacheNew := make(map[string]*sources.SourceConn)
-	for _, row := range data {
-		monitoredDbCacheNew[row.Name] = row
-	}
-	monitoredDbCacheLock.Lock()
-	monitoredDbCache = monitoredDbCacheNew
-	monitoredDbCacheLock.Unlock()
-}
-
-func GetMonitoredDatabaseByUniqueName(ctx context.Context, name string) (*sources.SourceConn, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-	monitoredDbCacheLock.RLock()
-	defer monitoredDbCacheLock.RUnlock()
-	md, exists := monitoredDbCache[name]
-	if !exists || md == nil || md.Conn == nil {
-		return nil, fmt.Errorf("database %s not found in cache", name)
-	}
-	return md, nil
-}
 
 type InstanceMetricCache struct {
 	cache map[string](metrics.Measurements) // [dbUnique+metric]lastly_fetched_data

--- a/internal/reaper/file.go
+++ b/internal/reaper/file.go
@@ -51,10 +51,10 @@ func (r *Reaper) FetchStatsDirectlyFromOS(ctx context.Context, md *sources.Sourc
 	case metricPsutilCPU:
 		data, err = GetGoPsutilCPU(md.GetMetricInterval(metricName))
 	case metricPsutilDisk:
-		if dataDirs, err = QueryMeasurements(ctx, md.Name, sqlPgDirs); err != nil {
+		if dataDirs, err = QueryMeasurements(ctx, md, sqlPgDirs); err != nil {
 			return nil, err
 		}
-		if dataTblspDirs, err = QueryMeasurements(ctx, md.Name, sqlTsDirs); err != nil {
+		if dataTblspDirs, err = QueryMeasurements(ctx, md, sqlTsDirs); err != nil {
 			return nil, err
 		}
 		data, err = GetGoPsutilDiskPG(dataDirs, dataTblspDirs)

--- a/internal/reaper/metric_test.go
+++ b/internal/reaper/metric_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/metrics"
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
+	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +29,8 @@ var (
 func TestReaper_FetchStatsDirectlyFromOS(t *testing.T) {
 	a := assert.New(t)
 	r := &Reaper{}
-	md := &sources.SourceConn{}
+	conn, _ := pgxmock.NewPool()
+	md := &sources.SourceConn{Conn: conn}
 	for _, m := range directlyFetchableOSMetrics {
 		a.True(IsDirectlyFetchableMetric(m), "Expected %s to be directly fetchable", m)
 		a.NotPanics(func() {

--- a/internal/reaper/recommendations.go
+++ b/internal/reaper/recommendations.go
@@ -33,7 +33,7 @@ func GetAllRecoMetricsForVersion() (metrics.MetricDefs, error) {
 	return mvpMap, nil
 }
 
-func GetRecommendations(ctx context.Context, dbUnique string, md *sources.SourceConn) (metrics.Measurements, error) {
+func GetRecommendations(ctx context.Context, md *sources.SourceConn) (metrics.Measurements, error) {
 	retData := make(metrics.Measurements, 0)
 	startTimeEpochNs := time.Now().UnixNano()
 
@@ -42,7 +42,7 @@ func GetRecommendations(ctx context.Context, dbUnique string, md *sources.Source
 		return nil, err
 	}
 	for _, mvp := range recoMetrics {
-		data, e := QueryMeasurements(ctx, dbUnique, mvp.GetSQL(md.Version))
+		data, e := QueryMeasurements(ctx, md, mvp.GetSQL(md.Version))
 		if err != nil {
 			err = errors.Join(err, e)
 			continue

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"reflect"
 	"regexp"
 	"strconv"
 	"time"
@@ -275,17 +274,5 @@ func (mds SourceConns) SyncFromReader(r Reader) (newmds SourceConns, err error) 
 	if err != nil {
 		return nil, err
 	}
-	newmds, err = srcs.ResolveDatabases()
-	for i, newMD := range newmds {
-		md := mds.GetMonitoredDatabase(newMD.Name)
-		if md == nil {
-			continue
-		}
-		if reflect.DeepEqual(md.Source, newMD.Source) {
-			// replace with the existing connection if the source is the same
-			newmds[i] = md
-			continue
-		}
-	}
-	return newmds, err
+	return srcs.ResolveDatabases()
 }

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -238,13 +238,10 @@ func TestMonitoredDatabases_SyncFromReader(t *testing.T) {
 	// then resolve the databases
 	mdbs, _ := mds.ResolveDatabases()
 	assert.NotNil(t, mdbs, "ResolveDatabases() = nil, want not nil")
-	// pretend that we have a connection
-	mdbs[0].Conn = db
 	// sync the databases and make sure they are the same
 	newmdbs, _ := mdbs.SyncFromReader(reader)
 	assert.NotNil(t, newmdbs)
 	assert.Equal(t, mdbs[0].ConnStr, newmdbs[0].ConnStr)
-	assert.Equal(t, db, newmdbs[0].Conn)
 	// change the connection string and check if databases are updated
 	reader.Sources[0].ConnStr = "postgres://user:password@localhost:5432/anotherdatabase"
 	newmdbs, _ = mdbs.SyncFromReader(reader)

--- a/internal/sources/resolver.go
+++ b/internal/sources/resolver.go
@@ -46,7 +46,7 @@ func (s Source) ResolveDatabases() (SourceConns, error) {
 	case SourcePostgresContinuous:
 		return ResolveDatabasesFromPostgres(s)
 	}
-	return SourceConns{&SourceConn{Source: *(&s).Clone()}}, nil
+	return SourceConns{&SourceConn{Source: s}}, nil
 }
 
 type PatroniClusterMember struct {

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 
 	"github.com/jackc/pgx/v5"
@@ -80,6 +81,21 @@ func (s *Source) GetDatabaseName() string {
 		return с.Database
 	}
 	return ""
+}
+
+func (s Source) Equal(s2 Source) bool {
+	return s.Name == s2.Name &&
+		s.Group == s2.Group &&
+		s.ConnStr == s2.ConnStr &&
+		s.Kind == s2.Kind &&
+		s.IsEnabled == s2.IsEnabled &&
+		s.IncludePattern == s2.IncludePattern &&
+		s.ExcludePattern == s2.ExcludePattern &&
+		(s.PresetMetrics == s2.PresetMetrics || reflect.DeepEqual(s.Metrics, s2.Metrics)) &&
+		(s.PresetMetricsStandby == s2.PresetMetricsStandby || reflect.DeepEqual(s.MetricsStandby, s2.MetricsStandby)) &&
+		s.OnlyIfMaster == s2.OnlyIfMaster &&
+		reflect.DeepEqual(s.CustomTags, s2.CustomTags) &&
+		reflect.DeepEqual(s.HostConfig, s2.HostConfig)
 }
 
 func (s *Source) Clone() *Source {


### PR DESCRIPTION
Since reapers is responsible for connections and metric syncing it's better to move source synchronization to the reaper itself. Also get rid of `monitoredDbCache` and use `reaper.monitoredSources` directly. Now we can use `QueryMeasurements` directly with connection as an argument instead of the name to look in a cache.