### PR TITLE
[!] optimize `PostgresWriter.flush()` with custom `CopyFrom` iterator

### DIFF
--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -334,6 +334,8 @@ metrics:
                   coalesce(reset_val, '') as value
                 from
                   pg_settings
+                where
+                  name <> 'connection_ID'
     cpu_load:
         sqls:
             11: |-

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -3,12 +3,13 @@ package sinks
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
+	"slices"
 	"strings"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/db"
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/log"
@@ -21,6 +22,7 @@ var (
 	cacheLimit      = 256
 	highLoadTimeout = time.Second * 5
 	deleterDelay    = time.Hour
+	targetColumns   = [...]string{"time", "dbname", "data", "tag_data"}
 )
 
 func NewPostgresWriter(ctx context.Context, connstr string, opts *CmdOpts) (pgw *PostgresWriter, err error) {
@@ -221,62 +223,105 @@ func (pgw *PostgresWriter) poll() {
 	}
 }
 
+func newCopyFromMeasurements(rows []metrics.MeasurementEnvelope) *copyFromMeasurements {
+	return &copyFromMeasurements{envelopes: rows, envelopeIdx: -1, measurementIdx: -1}
+}
+
+type copyFromMeasurements struct {
+	envelopes      []metrics.MeasurementEnvelope
+	envelopeIdx    int
+	measurementIdx int // index of the current measurement in the envelope
+	metricName     string
+}
+
+func (c *copyFromMeasurements) Next() bool {
+	for {
+		// Check if we need to advance to the next envelope
+		if c.envelopeIdx < 0 || c.measurementIdx+1 >= len(c.envelopes[c.envelopeIdx].Data) {
+			// Advance to next envelope
+			c.envelopeIdx++
+			if c.envelopeIdx >= len(c.envelopes) {
+				return false // No more envelopes
+			}
+			c.measurementIdx = -1 // Reset measurement index for new envelope
+
+			// Set metric name from first envelope, or detect metric boundary
+			if c.metricName == "" {
+				c.metricName = c.envelopes[c.envelopeIdx].MetricName
+			} else if c.metricName != c.envelopes[c.envelopeIdx].MetricName {
+				// We've hit a different metric - we're done with current metric
+				// Reset position to process this envelope on next call
+				c.envelopeIdx--
+				c.measurementIdx = len(c.envelopes[c.envelopeIdx].Data) // Set to length so we've "finished" this envelope
+				c.metricName = ""                                       // Reset for next metric
+				return false
+			}
+		}
+
+		// Advance to next measurement in current envelope
+		c.measurementIdx++
+		if c.measurementIdx < len(c.envelopes[c.envelopeIdx].Data) {
+			return true // Found valid measurement
+		}
+		// If we reach here, we've exhausted current envelope, loop will advance to next envelope
+	}
+}
+
+func (c *copyFromMeasurements) EOF() bool {
+	return c.envelopeIdx >= len(c.envelopes)
+}
+
+func (c *copyFromMeasurements) Values() ([]any, error) {
+	row := c.envelopes[c.envelopeIdx].Data[c.measurementIdx]
+	tagRow := c.envelopes[c.envelopeIdx].CustomTags
+	if tagRow == nil {
+		tagRow = make(map[string]string)
+	}
+	for k, v := range row {
+		if strings.HasPrefix(k, metrics.TagPrefix) {
+			tagRow[strings.TrimPrefix(k, metrics.TagPrefix)] = v.(string)
+			delete(row, k)
+		}
+	}
+	jsonTags, terr := jsoniter.ConfigFastest.MarshalToString(tagRow)
+	json, err := jsoniter.ConfigFastest.MarshalToString(row)
+	if err != nil || terr != nil {
+		return nil, errors.Join(err, terr)
+	}
+	return []any{time.Unix(0, c.envelopes[c.envelopeIdx].Data.GetEpoch()), c.envelopes[c.envelopeIdx].DBName, json, jsonTags}, nil
+}
+
+func (c *copyFromMeasurements) Err() error {
+	return nil
+}
+
+func (c *copyFromMeasurements) MetricName() pgx.Identifier {
+	return pgx.Identifier{c.envelopes[c.envelopeIdx+1].MetricName} // Metric name is taken from the next envelope
+}
+
 // flush sends the cached measurements to the database
 func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 	if len(msgs) == 0 {
 		return
 	}
 	logger := log.GetLogger(pgw.ctx)
-	metricsToStorePerMetric := make(map[string][]MeasurementMessagePostgres)
-	rowsBatched := 0
-	totalRows := 0
+	// metricsToStorePerMetric := make(map[string][]MeasurementMessagePostgres)
 	pgPartBounds := make(map[string]ExistingPartitionInfo)                  // metric=min/max
 	pgPartBoundsDbName := make(map[string]map[string]ExistingPartitionInfo) // metric=[dbname=min/max]
 	var err error
 
-	for _, msg := range msgs {
-		if len(msg.Data) == 0 {
-			continue
+	slices.SortFunc(msgs, func(a, b metrics.MeasurementEnvelope) int {
+		if a.MetricName < b.MetricName {
+			return -1
+		} else if a.MetricName > b.MetricName {
+			return 1
 		}
+		return 0
+	})
+
+	for _, msg := range msgs {
 		for _, dataRow := range msg.Data {
-			var epochTime time.Time
-
-			tags := make(map[string]string)
-			fields := make(map[string]any)
-
-			totalRows++
-
-			if msg.CustomTags != nil {
-				tags = maps.Clone(msg.CustomTags)
-			}
-			epochTime = time.Unix(0, metrics.Measurement(dataRow).GetEpoch())
-			for k, v := range dataRow {
-				if v == nil || v == "" || k == metrics.EpochColumnName {
-					continue // not storing NULLs
-				}
-				if strings.HasPrefix(k, metrics.TagPrefix) {
-					tag := k[4:]
-					tags[tag] = fmt.Sprintf("%v", v)
-				} else {
-					fields[k] = v
-				}
-			}
-
-			var metricsArr []MeasurementMessagePostgres
-			var ok bool
-
-			metricNameTemp := msg.MetricName
-
-			metricsArr, ok = metricsToStorePerMetric[metricNameTemp]
-			if !ok {
-				metricsToStorePerMetric[metricNameTemp] = make([]MeasurementMessagePostgres, 0)
-			}
-			metricsArr = append(metricsArr, MeasurementMessagePostgres{Time: epochTime, DBName: msg.DBName,
-				Metric: msg.MetricName, Data: fields, TagData: tags})
-			metricsToStorePerMetric[metricNameTemp] = metricsArr
-
-			rowsBatched++
-
+			epochTime := time.Unix(0, metrics.Measurement(dataRow).GetEpoch())
 			switch pgw.metricSchema {
 			case DbStorageSchemaTimescale:
 				// set min/max timestamps to check/create partitions
@@ -317,60 +362,27 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 	default:
 		logger.Fatal("unknown storage schema...")
 	}
-	if forceRecreatePartitions {
-		forceRecreatePartitions = false
-	}
+	forceRecreatePartitions = false
 	if err != nil {
 		pgw.lastError <- err
 	}
 
-	// send data to PG, with a separate COPY for all metrics
+	var rowsBatched, n int64
 	t1 := time.Now()
-
-	for metricName, metrics := range metricsToStorePerMetric {
-
-		getTargetTable := func() pgx.Identifier {
-			return pgx.Identifier{metricName}
-		}
-
-		getTargetColumns := func() []string {
-			return []string{"time", "dbname", "data", "tag_data"}
-		}
-
-		for _, m := range metrics {
-			l := logger.WithField("db", m.DBName).WithField("metric", m.Metric)
-			jsonBytes, err := json.Marshal(m.Data)
-			if err != nil {
-				logger.Errorf("Skipping 1 metric for [%s:%s] due to JSON conversion error: %s", m.DBName, m.Metric, err)
-				continue
+	cfm := newCopyFromMeasurements(msgs)
+	for !cfm.EOF() {
+		n, err = pgw.sinkDb.CopyFrom(context.Background(), cfm.MetricName(), targetColumns[:], cfm)
+		rowsBatched += n
+		if err != nil {
+			logger.Error(err)
+			if PgError, ok := err.(*pgconn.PgError); ok {
+				forceRecreatePartitions = PgError.Code == "23514"
 			}
-
-			getTagData := func() any {
-				if len(m.TagData) > 0 {
-					jsonBytesTags, err := json.Marshal(m.TagData)
-					if err != nil {
-						l.Error(err)
-						return nil
-					}
-					return string(jsonBytesTags)
-				}
-				return nil
-			}
-
-			rows := [][]any{{m.Time, m.DBName, string(jsonBytes), getTagData()}}
-
-			if _, err = pgw.sinkDb.CopyFrom(context.Background(), getTargetTable(), getTargetColumns(), pgx.CopyFromRows(rows)); err != nil {
-				l.Error(err)
-				if PgError, ok := err.(*pgconn.PgError); ok {
-					forceRecreatePartitions = PgError.Code == "23514"
-				}
-				if forceRecreatePartitions {
-					logger.Warning("Some metric partitions might have been removed, halting all metric storage. Trying to re-create all needed partitions on next run")
-				}
+			if forceRecreatePartitions {
+				logger.Warning("Some metric partitions might have been removed, halting all metric storage. Trying to re-create all needed partitions on next run")
 			}
 		}
 	}
-
 	diff := time.Since(t1)
 	if err == nil {
 		logger.WithField("rows", rowsBatched).WithField("elapsed", diff).Info("measurements written")

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/metrics"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -125,4 +126,372 @@ func TestPostgresWriter_EnsureMetricTime(t *testing.T) {
 	err = pgw.EnsureMetricTime(TestPartBounds, true)
 	assert.NoError(t, err)
 	assert.NoError(t, conn.ExpectationsWereMet())
+}
+
+func TestCopyFromMeasurements_Basic(t *testing.T) {
+	// Test basic iteration through single envelope with multiple measurements
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "metric1",
+			DBName:     "db1",
+			CustomTags: map[string]string{"env": "test"},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(1000), "value": 1},
+				{"epoch_ns": int64(2000), "value": 2},
+				{"epoch_ns": int64(3000), "value": 3},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+
+	// Test Next() and Values() for each measurement
+	assert.True(t, cfm.Next(), "Should have first measurement")
+	values, err := cfm.Values()
+	assert.NoError(t, err)
+	assert.Len(t, values, 4) // time, dbname, data, tag_data
+	assert.Equal(t, "db1", values[1])
+
+	assert.True(t, cfm.Next(), "Should have second measurement")
+	values, err = cfm.Values()
+	assert.NoError(t, err)
+	assert.Equal(t, "db1", values[1])
+
+	assert.True(t, cfm.Next(), "Should have third measurement")
+	values, err = cfm.Values()
+	assert.NoError(t, err)
+	assert.Equal(t, "db1", values[1])
+
+	assert.False(t, cfm.Next(), "Should not have more measurements")
+	assert.True(t, cfm.EOF(), "Should be at end")
+	assert.Equal(t, "metric1", cfm.MetricName()[0])
+}
+
+func TestCopyFromMeasurements_MultipleEnvelopes(t *testing.T) {
+	// Test iteration through multiple envelopes of same metric
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "metric1",
+			DBName:     "db1",
+			CustomTags: map[string]string{"env": "test1"},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(1000), "value": 1},
+				{"epoch_ns": int64(2000), "value": 2},
+			},
+		},
+		{
+			MetricName: "metric1",
+			DBName:     "db2",
+			CustomTags: map[string]string{"env": "test2"},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(3000), "value": 3},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+
+	// First envelope, first measurement
+	assert.True(t, cfm.Next())
+	values, err := cfm.Values()
+	assert.NoError(t, err)
+	assert.Equal(t, "db1", values[1])
+	// First envelope, second measurement
+	assert.True(t, cfm.Next())
+	values, err = cfm.Values()
+	assert.NoError(t, err)
+	assert.Equal(t, "db1", values[1])
+
+	// Second envelope, first measurement
+	assert.True(t, cfm.Next())
+	values, err = cfm.Values()
+	assert.NoError(t, err)
+	assert.Equal(t, "db2", values[1])
+
+	assert.False(t, cfm.Next())
+	assert.Equal(t, "metric1", cfm.MetricName()[0])
+}
+
+func TestCopyFromMeasurements_MetricBoundaries(t *testing.T) {
+	// Test metric boundary detection with different metrics
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "metric1",
+			DBName:     "db1",
+			CustomTags: map[string]string{},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(1000), "value": 1},
+				{"epoch_ns": int64(2000), "value": 2},
+			},
+		},
+		{
+			MetricName: "metric2", // Different metric
+			DBName:     "db1",
+			CustomTags: map[string]string{},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(3000), "value": 3},
+			},
+		},
+		{
+			MetricName: "metric2",
+			DBName:     "db2",
+			CustomTags: map[string]string{},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(4000), "value": 4},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+
+	// Process metric1 completely
+	assert.True(t, cfm.Next())
+	assert.Equal(t, "metric1", cfm.MetricName()[0])
+
+	assert.True(t, cfm.Next())
+	assert.Equal(t, "metric1", cfm.MetricName()[0])
+
+	// Should stop at metric boundary
+	assert.False(t, cfm.Next())
+	// After hitting metric boundary, metricName is reset for next metric
+	assert.Empty(t, cfm.MetricName()[0])
+
+	assert.False(t, cfm.EOF(), "Should not be at EOF yet, there's more data")
+
+	assert.True(t, cfm.Next())
+	assert.Equal(t, "metric2", cfm.MetricName()[0])
+
+	assert.True(t, cfm.Next())
+	assert.Equal(t, "metric2", cfm.MetricName()[0])
+
+	assert.False(t, cfm.Next())
+	assert.True(t, cfm.EOF(), "Should be at EOF after processing all measurements")
+}
+
+func TestCopyFromMeasurements_EmptyData(t *testing.T) {
+	// Test with empty envelopes slice
+	cfm := newCopyFromMeasurements([]metrics.MeasurementEnvelope{})
+	assert.False(t, cfm.Next())
+	assert.True(t, cfm.EOF())
+}
+
+func TestCopyFromMeasurements_EmptyMeasurements(t *testing.T) {
+	// Test with envelope containing no measurements
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "metric1",
+			DBName:     "db1",
+			CustomTags: map[string]string{},
+			Data:       metrics.Measurements{}, // Empty measurements
+		},
+		{
+			MetricName: "metric1",
+			DBName:     "db2",
+			CustomTags: map[string]string{},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(1000), "value": 1},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+
+	// Should skip empty envelope and go to second one
+	assert.True(t, cfm.Next())
+	values, err := cfm.Values()
+	assert.NoError(t, err)
+	assert.Equal(t, "db2", values[1])
+
+	assert.False(t, cfm.Next())
+	assert.True(t, cfm.EOF())
+}
+
+func TestCopyFromMeasurements_TagProcessing(t *testing.T) {
+	// Test that tag_ prefixed fields are moved to CustomTags
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "metric1",
+			DBName:     "db1",
+			CustomTags: map[string]string{"existing": "tag"},
+			Data: metrics.Measurements{
+				{
+					"epoch_ns":     int64(1000),
+					"value":        1,
+					"tag_env":      "production",
+					"tag_version":  "1.0",
+					"normal_field": "stays",
+				},
+			},
+		},
+		{
+			MetricName: "metric1",
+			DBName:     "db2",
+			CustomTags: nil,
+			Data: metrics.Measurements{
+				{
+					"epoch_ns":     int64(1000),
+					"value":        1,
+					"tag_env":      "production",
+					"tag_version":  "1.0",
+					"normal_field": "stays",
+				},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+	assert.True(t, cfm.Next())
+
+	values, err := cfm.Values()
+	assert.NoError(t, err)
+	assert.Len(t, values, 4) // Verify structure: time, dbname, data, tag_data
+
+	// Check that custom tags were updated
+	// Check data JSON (should contain normal fields but not tag_ fields)
+	dataJSON, ok := values[2].(string)
+	assert.True(t, ok, "Data should be JSON string")
+
+	var dataMap map[string]any
+	err = jsoniter.ConfigFastest.UnmarshalFromString(dataJSON, &dataMap)
+	assert.NoError(t, err)
+	assert.Contains(t, dataMap, "normal_field")
+	assert.NotContains(t, dataMap, "tag_env", "tag_env should not be in data")
+	assert.NotContains(t, dataMap, "tag_version", "tag_version should not be in data")
+
+	// Check tag JSON (should contain converted tags)
+	tagJSON, ok := values[3].(string)
+	assert.True(t, ok, "Tag data should be JSON string")
+
+	var tagMap map[string]string
+	err = jsoniter.ConfigFastest.UnmarshalFromString(tagJSON, &tagMap)
+	assert.NoError(t, err)
+	assert.Contains(t, tagMap, "existing")
+	assert.Contains(t, tagMap, "env", "tag_env should be converted to env")
+	assert.Contains(t, tagMap, "version", "tag_version should be converted to version")
+	assert.Equal(t, "production", tagMap["env"])
+	assert.Equal(t, "1.0", tagMap["version"])
+
+	assert.True(t, cfm.Next())
+	_, err = cfm.Values()
+	assert.NoError(t, err, "should process nil CustomTags without error")
+}
+
+func TestCopyFromMeasurements_JsonMarshaling(t *testing.T) {
+	// Test that JSON marshaling works correctly
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "metric1",
+			DBName:     "db1",
+			CustomTags: map[string]string{"env": "test"},
+			Data: metrics.Measurements{
+				{
+					"epoch_ns": int64(1000),
+					"value":    42,
+					"name":     "test_measurement",
+				},
+				{
+					"epoch_ns": int64(1000),
+					"value": func() string {
+						return "should produce error while marshaled"
+					},
+					"name": "test_measurement",
+				},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+	assert.True(t, cfm.Next())
+
+	values, err := cfm.Values()
+	assert.NoError(t, err)
+	assert.Len(t, values, 4)
+
+	// Values should be: [time, dbname, data_json, tag_data_json]
+	assert.Equal(t, "db1", values[1])
+
+	// Check that JSON strings are valid
+	dataJSON, ok := values[2].(string)
+	assert.True(t, ok, "Data should be JSON string")
+	assert.Contains(t, dataJSON, `"value":42`)
+	assert.Contains(t, dataJSON, `"name":"test_measurement"`)
+
+	tagJSON, ok := values[3].(string)
+	assert.True(t, ok, "Tag data should be JSON string")
+	assert.Contains(t, tagJSON, `"env":"test"`)
+
+	assert.True(t, cfm.Next())
+	_, err = cfm.Values()
+	assert.Error(t, err, "cannot marshal function value to JSON")
+}
+
+func TestCopyFromMeasurements_ErrorHandling(t *testing.T) {
+	// Test Err() method
+	cfm := newCopyFromMeasurements([]metrics.MeasurementEnvelope{})
+	assert.NoError(t, cfm.Err(), "Err() should always return nil")
+}
+
+func TestCopyFromMeasurements_MetricNameMethod(t *testing.T) {
+	// Test MetricName() method returns correct identifier
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "test_metric_name",
+			DBName:     "db1",
+			CustomTags: map[string]string{},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(1000), "value": 1},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+
+	// Before calling Next(), should have empty metric name
+	identifier := cfm.MetricName()
+	assert.Equal(t, "", identifier[0])
+
+	// After calling Next(), should have correct metric name
+	assert.True(t, cfm.Next())
+	identifier = cfm.MetricName()
+	assert.Equal(t, "test_metric_name", identifier[0])
+}
+
+func TestCopyFromMeasurements_StateManagement(t *testing.T) {
+	// Test that internal state is managed correctly during iteration
+	data := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "metric1",
+			DBName:     "db1",
+			CustomTags: map[string]string{},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(1000), "value": 1},
+			},
+		},
+		{
+			MetricName: "metric2", // Different metric
+			DBName:     "db1",
+			CustomTags: map[string]string{},
+			Data: metrics.Measurements{
+				{"epoch_ns": int64(2000), "value": 2},
+			},
+		},
+	}
+
+	cfm := newCopyFromMeasurements(data)
+
+	// Initial state
+	assert.Equal(t, -1, cfm.envelopeIdx)
+	assert.Equal(t, -1, cfm.measurementIdx)
+	assert.Equal(t, "", cfm.metricName)
+
+	// After first Next()
+	assert.True(t, cfm.Next())
+	assert.Equal(t, 0, cfm.envelopeIdx)
+	assert.Equal(t, 0, cfm.measurementIdx)
+	assert.Equal(t, "metric1", cfm.metricName)
+
+	// After hitting metric boundary
+	assert.False(t, cfm.Next())
+	// State should be positioned to restart on next metric
+	assert.Equal(t, "", cfm.metricName)
 }


### PR DESCRIPTION
Optimize `PostgresWriter.flush()` for better performance. It avoids per-row JSON marshaling overhead.
Introduced `copyFromMeasurements` to batch process `MeasurementEnvelopes` efficiently, grouping by metric and writing directly to PostgreSQL using a streaming approach. New approach reduces memory allocations and temporary objects, speeds up `flush()` with lower GC pressure.