### PR TITLE
[-] add additional checks to `LogParse()`

### DIFF
--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -16,7 +16,7 @@ ARG GIT_TIME
 
 COPY . /pgwatch
 COPY --from=uibuilder /webui/build /pgwatch/internal/webui/build
-RUN cd /pgwatch && CGO_ENABLED=0 go build -ldflags "-X 'main.commit=${GIT_HASH}' -X 'main.date=${GIT_TIME}' -X 'main.version=${VERSION}'" ./cmd/pgwatch
+RUN cd /pgwatch && CGO_ENABLED=0 go build -tags=pprof -ldflags "-X 'main.commit=${GIT_HASH}' -X 'main.date=${GIT_TIME}' -X 'main.version=${VERSION}'" ./cmd/pgwatch
 
 # ----------------------------------------------------------------
 # 3. Build the final image
@@ -80,6 +80,8 @@ EXPOSE 5432
 EXPOSE 3000
 # Prometheus scraping port
 EXPOSE 9187
+# pprof port
+EXPOSE 6060
 
 ### Volumes for easier updating to newer to newer pgwatch containers
 ### Backwards compatibility is not 100% guaranteed so a backup

--- a/docs/tutorial/docker_installation.md
+++ b/docs/tutorial/docker_installation.md
@@ -192,8 +192,8 @@ As mentioned in the [Components](../concept/components.md) chapter, remember tha
 one example how your monitoring setup around the pgwatch metrics
 collector could be organized. For another example how various components
 (as Docker images here) can work together, see a *Docker Compose*
-example with loosely coupled components
-[here](https://github.com/cybertec-postgresql/pgwatch/blob/master/docker-compose.yml).
+[example](https://github.com/cybertec-postgresql/pgwatch/blob/master/docker-compose.yml)
+with loosely coupled components.
 
 ## Example of advanced setup using YAML files and dual sinks
 

--- a/internal/db/conn_test.go
+++ b/internal/db/conn_test.go
@@ -1,10 +1,15 @@
 package db_test
 
 import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/db"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshallParam(t *testing.T) {
@@ -58,6 +63,136 @@ func TestMarshallParam(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := db.MarshallParamToJSONB(tt.v); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MarshallParamToJSONB() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsClientOnSameHost(t *testing.T) {
+	// Create a pgxmock pool
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create pgxmock pool: %v", err)
+	}
+	defer mock.Close()
+	dataDir := t.TempDir()
+	pgControl := filepath.Join(dataDir, "global")
+	require.NoError(t, os.MkdirAll(pgControl, 0755))
+	file, err := os.OpenFile(filepath.Join(pgControl, "pg_control"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	err = binary.Write(file, binary.LittleEndian, uint64(12345))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	// Test cases
+	tests := []struct {
+		name      string
+		setupMock func()
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name: "UNIX socket connection",
+			setupMock: func() {
+				mock.ExpectQuery(`SELECT COALESCE`).WillReturnRows(
+					pgxmock.NewRows([]string{"is_unix_socket"}).AddRow(true),
+				)
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Matching system identifier",
+			setupMock: func() {
+				mock.ExpectQuery(`SELECT COALESCE`).WillReturnRows(
+					pgxmock.NewRows([]string{"is_unix_socket"}).AddRow(false),
+				)
+				mock.ExpectQuery(`SHOW`).WillReturnRows(
+					pgxmock.NewRows([]string{"data_directory"}).AddRow(dataDir),
+				)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(
+					pgxmock.NewRows([]string{"system_identifier"}).AddRow(uint64(12345)),
+				)
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Non-matching system identifier",
+			setupMock: func() {
+				mock.ExpectQuery(`SELECT COALESCE`).WillReturnRows(
+					pgxmock.NewRows([]string{"is_unix_socket"}).AddRow(false),
+				)
+				mock.ExpectQuery(`SHOW`).WillReturnRows(
+					pgxmock.NewRows([]string{"data_directory"}).AddRow(dataDir),
+				)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(
+					pgxmock.NewRows([]string{"system_identifier"}).AddRow(uint64(42)),
+				)
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Error on COALESCE query",
+			setupMock: func() {
+				mock.ExpectQuery(`SELECT COALESCE`).WillReturnError(os.ErrInvalid)
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Error on SHOW query",
+			setupMock: func() {
+				mock.ExpectQuery(`SELECT COALESCE`).WillReturnRows(
+					pgxmock.NewRows([]string{"is_unix_socket"}).AddRow(false),
+				)
+				mock.ExpectQuery(`SHOW`).WillReturnError(os.ErrInvalid)
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Error on SELECT system_identifier query",
+			setupMock: func() {
+				mock.ExpectQuery(`SELECT COALESCE`).WillReturnRows(
+					pgxmock.NewRows([]string{"is_unix_socket"}).AddRow(false),
+				)
+				mock.ExpectQuery(`SHOW`).WillReturnRows(
+					pgxmock.NewRows([]string{"data_directory"}).AddRow(dataDir),
+				)
+				mock.ExpectQuery(`SELECT`).WillReturnError(os.ErrInvalid)
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Error on os.Open",
+			setupMock: func() {
+				mock.ExpectQuery(`SELECT COALESCE`).WillReturnRows(
+					pgxmock.NewRows([]string{"is_unix_socket"}).AddRow(false),
+				)
+				mock.ExpectQuery(`SHOW`).WillReturnRows(
+					pgxmock.NewRows([]string{"data_directory"}).AddRow("invalid/path"),
+				)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(
+					pgxmock.NewRows([]string{"system_identifier"}).AddRow(uint64(12345)),
+				)
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+			got, err := db.IsClientOnSameHost(mock)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsClientOnSameHost() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("IsClientOnSameHost() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/metrics/logparse_test.go
+++ b/internal/metrics/logparse_test.go
@@ -384,6 +384,9 @@ func TestLogParse(t *testing.T) {
 	require.NoError(t, err)
 	defer mock.Close()
 
+	// pretend we're connected via UNIX socket
+	mock.ExpectQuery(`SELECT COALESCE`).WillReturnRows(
+		pgxmock.NewRows([]string{"is_unix_socket"}).AddRow(true))
 	// Mock the language detection query
 	mock.ExpectQuery(`select current_setting\('lc_messages'\)::varchar\(2\) as lc_messages;`).
 		WillReturnRows(pgxmock.NewRows([]string{"lc_messages"}).AddRow("en"))

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -290,7 +290,7 @@ func (r *Reaper) reapMetricMeasurements(ctx context.Context, md *sources.SourceC
 
 	l := r.logger.WithField("source", md.Name).WithField("metric", metricName)
 	if metricName == specialMetricServerLogEventCounts {
-		metrics.ParseLogs(ctx, md, md.RealDbname, md.GetMetricInterval(metricName), r.measurementCh) // no return
+		metrics.ParseLogs(ctx, md, md.RealDbname, md.GetMetricInterval(metricName), r.measurementCh)
 		return
 	}
 


### PR DESCRIPTION
Fix CPU consumption introduced in #fb33d09d. Add additional timer check. Add `pprof` profile to demo Docker image. Add additional check if pgwatch and monitored Postgres are running on the same host. Do not start `LogParse` if pgwatch is unable to read logs.