### PR TITLE
[-] improve Prometheus scrapping, fixes #749

### DIFF
--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -272,8 +273,8 @@ func (c *copyFromMeasurements) EOF() bool {
 }
 
 func (c *copyFromMeasurements) Values() ([]any, error) {
-	row := c.envelopes[c.envelopeIdx].Data[c.measurementIdx]
-	tagRow := c.envelopes[c.envelopeIdx].CustomTags
+	row := maps.Clone(c.envelopes[c.envelopeIdx].Data[c.measurementIdx])
+	tagRow := maps.Clone(c.envelopes[c.envelopeIdx].CustomTags)
 	if tagRow == nil {
 		tagRow = make(map[string]string)
 	}


### PR DESCRIPTION
First make sure all sinks do not modify measurement envelopes, since maps in it reference to the same map in memory. Add improved Prometheus handler in sink, so logs will be populated with all scrapping errors. Clean cached measurements after each scrape, there is no need in serving the same data as it will be ignored anyway. Make sure all non-numeric fields are treated as labels. This will pollute some metrics, e.g. settings. It's better to rewrite metric queries if the number of labels is too high.