### PR TITLE
[+] optimize the size of `metrics.MeasurementEnvelope`

### DIFF
--- a/internal/metrics/logparse.go
+++ b/internal/metrics/logparse.go
@@ -102,7 +102,6 @@ func eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal map[string]i
 	}
 	return MeasurementEnvelope{
 		DBName:     mdb.Name,
-		SourceType: string(mdb.Kind),
 		MetricName: specialMetricServerLogEventCounts,
 		Data:       Measurements{allSeverityCounts},
 		CustomTags: mdb.CustomTags,

--- a/internal/metrics/logparse_test.go
+++ b/internal/metrics/logparse_test.go
@@ -133,7 +133,6 @@ func TestEventCountsToMetricStoreMessages(t *testing.T) {
 	result := eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal, mdb)
 
 	assert.Equal(t, "test-db", result.DBName)
-	assert.Equal(t, string(sources.SourcePostgres), result.SourceType)
 	assert.Equal(t, specialMetricServerLogEventCounts, result.MetricName)
 	assert.Equal(t, map[string]string{"env": "test"}, result.CustomTags)
 

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -147,13 +147,11 @@ func (m Measurements) Touch() {
 }
 
 type MeasurementEnvelope struct {
-	DBName           string
-	SourceType       string
-	MetricName       string
-	CustomTags       map[string]string
-	Data             Measurements
-	RealDbname       string
-	SystemIdentifier string
+	DBName string
+	// SourceType string
+	MetricName string
+	CustomTags map[string]string
+	Data       Measurements
 }
 
 type Metrics struct {

--- a/internal/reaper/database.go
+++ b/internal/reaper/database.go
@@ -490,7 +490,6 @@ func (r *Reaper) CheckForPGObjectChangesAndStore(ctx context.Context, dbUnique s
 		detectedChangesSummary = append(detectedChangesSummary, influxEntry)
 		storageCh <- metrics.MeasurementEnvelope{
 			DBName:     dbUnique,
-			SourceType: string(md.Kind),
 			MetricName: "object_changes",
 			Data:       detectedChangesSummary,
 			CustomTags: md.CustomTags,

--- a/internal/reaper/file.go
+++ b/internal/reaper/file.go
@@ -67,12 +67,9 @@ func (r *Reaper) FetchStatsDirectlyFromOS(ctx context.Context, md *sources.Sourc
 		return nil, err
 	}
 	return &metrics.MeasurementEnvelope{
-		DBName:           md.Name,
-		SourceType:       string(md.Kind),
-		MetricName:       metricName,
-		CustomTags:       md.CustomTags,
-		Data:             data,
-		RealDbname:       md.RealDbname,
-		SystemIdentifier: md.SystemIdentifier,
+		DBName:     md.Name,
+		MetricName: metricName,
+		CustomTags: md.CustomTags,
+		Data:       data,
 	}, nil
 }

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -349,7 +349,6 @@ func (r *Reaper) reapMetricMeasurements(ctx context.Context, md *sources.SourceC
 							detectedChangesSummary = append(detectedChangesSummary, entry)
 							r.measurementCh <- metrics.MeasurementEnvelope{
 								DBName:     md.Name,
-								SourceType: string(md.Kind),
 								MetricName: "object_changes",
 								Data:       detectedChangesSummary,
 								CustomTags: metricStoreMessages.CustomTags,
@@ -499,10 +498,8 @@ func (r *Reaper) FetchMetric(ctx context.Context, md *sources.SourceConn, metric
 	r.AddSysinfoToMeasurements(data, md)
 	l.WithField("cache", fromCache).WithField("rows", len(data)).Info("measurements fetched")
 	return &metrics.MeasurementEnvelope{
-		DBName:           md.Name,
-		MetricName:       cmp.Or(metric.StorageName, metricName),
-		Data:             data,
-		CustomTags:       md.CustomTags,
-		RealDbname:       md.RealDbname,
-		SystemIdentifier: md.SystemIdentifier}, nil
+		DBName:     md.Name,
+		MetricName: cmp.Or(metric.StorageName, metricName),
+		Data:       data,
+		CustomTags: md.CustomTags}, nil
 }


### PR DESCRIPTION
Current sinks implementations do not need to know the source type info. Both real database name and system identifier are already included in the data if appropriate options are specified.