### PR TITLE
[-] fix `--group` command-line option,  #792

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -123,3 +123,9 @@ func GetLogger(ctx context.Context) Logger {
 	}
 	return logger.(Logger)
 }
+
+func NewNoopLogger() Logger {
+	l := logrus.New()
+	l.SetLevel(logrus.PanicLevel) // Noop logger should not output anything
+	return l
+}

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -147,8 +147,7 @@ func (m Measurements) Touch() {
 }
 
 type MeasurementEnvelope struct {
-	DBName string
-	// SourceType string
+	DBName     string
 	MetricName string
 	CustomTags map[string]string
 	Data       Measurements

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -383,7 +383,7 @@ func (r *Reaper) LoadSources() (err error) {
 		return err
 	}
 	srcs = slices.DeleteFunc(srcs, func(s sources.Source) bool {
-		return !s.IsEnabled || s.Group != "" && !slices.Contains(r.Sources.Groups, s.Group)
+		return !s.IsEnabled || !s.IsDefaultGroup() && !slices.Contains(r.Sources.Groups, s.Group)
 	})
 	if newSrcs, err = srcs.ResolveDatabases(); err != nil {
 		return err

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -76,13 +76,14 @@ func TestReaper_LoadSources(t *testing.T) {
 		source1 := sources.Source{Name: "Source 1", IsEnabled: true, Kind: sources.SourcePostgres, Group: ""} // Empty group should not filter
 		source2 := sources.Source{Name: "Source 2", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group1"}
 		source3 := sources.Source{Name: "Source 3", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group2"}
-		reader := &mockReader{toReturn: sources.Sources{source1, source2, source3}}
+		source4 := sources.Source{Name: "Source 4", IsEnabled: true, Kind: sources.SourcePostgres, Group: "default"} // Default group should not filter
+		reader := &mockReader{toReturn: sources.Sources{source1, source2, source3, source4}}
 		r := NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: reader, Sources: sources.CmdOpts{Groups: []string{"group1", "group2"}}})
 		assert.NoError(t, r.LoadSources())
-		assert.Equal(t, 3, len(r.monitoredSources), "Expected three monitored sources after load")
+		assert.Equal(t, 4, len(r.monitoredSources), "Expected three monitored sources after load")
 
 		r.Sources.Groups = []string{"group1"}
 		assert.NoError(t, r.LoadSources())
-		assert.Equal(t, 2, len(r.monitoredSources), "Expected two monitored sources after group filtering")
+		assert.Equal(t, 3, len(r.monitoredSources), "Expected three monitored sources after group filtering")
 	})
 }

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -1,0 +1,88 @@
+package reaper
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cybertec-postgresql/pgwatch/v3/internal/cmdopts"
+	"github.com/cybertec-postgresql/pgwatch/v3/internal/log"
+	"github.com/cybertec-postgresql/pgwatch/v3/internal/metrics"
+	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockReader struct {
+	toReturn sources.Sources
+	toErr    error
+}
+
+func (m *mockReader) GetSources() (sources.Sources, error) {
+	if m.toErr != nil {
+		return nil, m.toErr
+	}
+	return m.toReturn, nil
+}
+
+func (m *mockReader) WriteSources(sources.Sources) error { return nil }
+func (m *mockReader) DeleteSource(string) error          { return nil }
+func (m *mockReader) UpdateSource(sources.Source) error  { return nil }
+
+func TestReaper_LoadSources(t *testing.T) {
+	ctx := log.WithLogger(context.Background(), log.NewNoopLogger())
+
+	t.Run("Test pause trigger file", func(t *testing.T) {
+		pausefile := filepath.Join(t.TempDir(), "pausefile")
+		require.NoError(t, os.WriteFile(pausefile, []byte("foo"), 0644))
+		r := NewReaper(ctx, &cmdopts.Options{Metrics: metrics.CmdOpts{EmergencyPauseTriggerfile: pausefile}})
+		assert.NoError(t, r.LoadSources())
+		assert.True(t, len(r.monitoredSources) == 0, "Expected no monitored sources when pause trigger file exists")
+	})
+
+	t.Run("Test SyncFromReader errror", func(t *testing.T) {
+		reader := &mockReader{toErr: assert.AnError}
+		r := NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: reader})
+		assert.Error(t, r.LoadSources())
+		assert.Equal(t, 0, len(r.monitoredSources), "Expected no monitored sources after error")
+	})
+
+	t.Run("Test SyncFromReader success", func(t *testing.T) {
+		source1 := sources.Source{Name: "Source 1", IsEnabled: true, Kind: sources.SourcePostgres}
+		source2 := sources.Source{Name: "Source 2", IsEnabled: true, Kind: sources.SourcePostgres}
+		reader := &mockReader{toReturn: sources.Sources{source1, source2}}
+		r := NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: reader})
+		assert.NoError(t, r.LoadSources())
+		assert.Equal(t, 2, len(r.monitoredSources), "Expected two monitored sources after successful load")
+		assert.NotNil(t, r.monitoredSources.GetMonitoredDatabase(source1.Name))
+		assert.NotNil(t, r.monitoredSources.GetMonitoredDatabase(source2.Name))
+	})
+
+	t.Run("Test repeated load", func(t *testing.T) {
+		source1 := sources.Source{Name: "Source 1", IsEnabled: true, Kind: sources.SourcePostgres}
+		source2 := sources.Source{Name: "Source 2", IsEnabled: true, Kind: sources.SourcePostgres}
+		reader := &mockReader{toReturn: sources.Sources{source1, source2}}
+		r := NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: reader})
+		assert.NoError(t, r.LoadSources())
+		assert.Equal(t, 2, len(r.monitoredSources), "Expected two monitored sources after first load")
+
+		// Load again with the same sources
+		assert.NoError(t, r.LoadSources())
+		assert.Equal(t, 2, len(r.monitoredSources), "Expected still two monitored sources after second load")
+	})
+
+	t.Run("Test group limited sources", func(t *testing.T) {
+		source1 := sources.Source{Name: "Source 1", IsEnabled: true, Kind: sources.SourcePostgres, Group: ""} // Empty group should not filter
+		source2 := sources.Source{Name: "Source 2", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group1"}
+		source3 := sources.Source{Name: "Source 3", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group2"}
+		reader := &mockReader{toReturn: sources.Sources{source1, source2, source3}}
+		r := NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: reader, Sources: sources.CmdOpts{Groups: []string{"group1", "group2"}}})
+		assert.NoError(t, r.LoadSources())
+		assert.Equal(t, 3, len(r.monitoredSources), "Expected three monitored sources after load")
+
+		r.Sources.Groups = []string{"group1"}
+		assert.NoError(t, r.LoadSources())
+		assert.Equal(t, 2, len(r.monitoredSources), "Expected two monitored sources after group filtering")
+	})
+}

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -265,14 +265,3 @@ func (mds SourceConns) GetMonitoredDatabase(DBUniqueName string) *SourceConn {
 	}
 	return nil
 }
-
-// SyncFromReader will update the monitored databases with the latest configuration from the reader.
-// Any resolution errors will be returned, e.g. etcd unavailability.
-// It's up to the caller to proceed with the databases available or stop the execution due to errors.
-func (mds SourceConns) SyncFromReader(r Reader) (newmds SourceConns, err error) {
-	srcs, err := r.GetSources()
-	if err != nil {
-		return nil, err
-	}
-	return srcs.ResolveDatabases()
-}

--- a/internal/sources/postgres_test.go
+++ b/internal/sources/postgres_test.go
@@ -66,32 +66,6 @@ func TestGetMonitoredDatabases(t *testing.T) {
 	a.NoError(conn.ExpectationsWereMet())
 }
 
-func TestSyncFromReader(t *testing.T) {
-	a := assert.New(t)
-	conn, err := pgxmock.NewPool()
-	a.NoError(err)
-	conn.ExpectPing()
-	conn.ExpectQuery(`select \/\* pgwatch_generated \*\/`).WillReturnRows(pgxmock.NewRows([]string{
-		"name", "group", "dbtype", "connstr", "config", "config_standby", "preset_config",
-		"preset_config_standby", "include_pattern", "exclude_pattern",
-		"custom_tags", "host_config", "only_if_master", "is_enabled",
-	}).AddRow(
-		"db1", "group1", sources.Kind("postgres"), "postgres://user:pass@localhost:5432/db1",
-		map[string]float64{"metric": 60}, map[string]float64{"standby_metric": 60}, "exhaustive", "exhaustive",
-		".*", `\_.+`, map[string]string{"tag": "value"}, nil, true, true,
-	))
-	pgrw, err := sources.NewPostgresSourcesReaderWriterConn(ctx, conn)
-	a.NoError(err)
-
-	md := &sources.SourceConn{}
-	md.Name = "db1"
-	dbs := sources.SourceConns{md}
-	dbs, err = dbs.SyncFromReader(pgrw)
-	a.NoError(err)
-	a.Len(dbs, 1)
-	a.NoError(conn.ExpectationsWereMet())
-}
-
 func TestDeleteDatabase(t *testing.T) {
 	a := assert.New(t)
 	conn, err := pgxmock.NewPool()

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -62,6 +62,10 @@ type (
 	Sources []Source
 )
 
+func (s Source) IsDefaultGroup() bool {
+	return s.Group == "" || s.Group == "default"
+}
+
 func (srcs Sources) Validate() (Sources, error) {
 	names := map[string]any{}
 	for _, src := range srcs {

--- a/internal/sources/types_test.go
+++ b/internal/sources/types_test.go
@@ -31,3 +31,23 @@ func TestKind_IsValid(t *testing.T) {
 		assert.True(t, got == tt.expected, "IsValid(%v) = %v, want %v", tt.kind, got, tt.expected)
 	}
 }
+
+func TestSource_IsDefaultGroup(t *testing.T) {
+	sources := sources.Sources{
+		{
+			Name:  "test_source",
+			Group: "default",
+		},
+		{
+			Name:  "test_source3",
+			Group: "",
+		},
+		{
+			Name:  "test_source2",
+			Group: "custom_group",
+		},
+	}
+	assert.True(t, sources[0].IsDefaultGroup())
+	assert.True(t, sources[1].IsDefaultGroup())
+	assert.False(t, sources[2].IsDefaultGroup())
+}


### PR DESCRIPTION
Rewrite `Reaper.LoadSources` to properly handle Groups. Drop
`SourceConns.SyncFromReader()` as obsolete. Add `TestReaper_LoadSources`
tests.