### PR TITLE
[-] remove unnecessary check from `FetchMetric()`

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -493,7 +493,7 @@ func (r *Reaper) FetchMetric(ctx context.Context, md *sources.SourceConn, metric
 			data, err = r.GetInstanceUpMeasurement(ctx, md)
 		default:
 			sql = metric.GetSQL(md.Version)
-			if sql == "" && !(metricName == specialMetricChangeEvents || metricName == recoMetricName) {
+			if sql == "" {
 				l.Warning("Ignoring fetching because of empty SQL")
 				return nil, nil
 			}


### PR DESCRIPTION
the `&& !(metricName == specialMetricChangeEvents || metricName == recoMetricName)` check is unneccesary as its always handled by the switch case
```
switch metricName {
		case specialMetricChangeEvents:
			...
		case recoMetricName:
			...
		case specialMetricInstanceUp:
			...
		default:
			sql = metric.GetSQL(md.Version)
			if sql == "" && !(metricName == specialMetricChangeEvents || metricName == recoMetricName) {
				...
			}
		}
```