### PR TITLE
[-] fix `Source.Equal()` presets comparison, closes #830

### DIFF
--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -88,15 +88,27 @@ func (s *Source) GetDatabaseName() string {
 }
 
 func (s Source) Equal(s2 Source) bool {
-	return s.Name == s2.Name &&
+	var eq bool 
+	if s.PresetMetrics != "" || s2.PresetMetrics != "" {
+		eq = (s.PresetMetrics == s2.PresetMetrics)
+	} else {
+		eq = reflect.DeepEqual(s.Metrics, s2.Metrics)
+	}
+
+	if s.PresetMetricsStandby != "" || s2.PresetMetricsStandby != "" {
+		eq = eq && (s.PresetMetricsStandby == s2.PresetMetricsStandby)
+	} else {
+		eq = eq && reflect.DeepEqual(s.MetricsStandby, s2.MetricsStandby)
+	}
+
+	return eq && 
+		s.Name == s2.Name &&
 		s.Group == s2.Group &&
 		s.ConnStr == s2.ConnStr &&
 		s.Kind == s2.Kind &&
 		s.IsEnabled == s2.IsEnabled &&
 		s.IncludePattern == s2.IncludePattern &&
 		s.ExcludePattern == s2.ExcludePattern &&
-		(s.PresetMetrics == s2.PresetMetrics || reflect.DeepEqual(s.Metrics, s2.Metrics)) &&
-		(s.PresetMetricsStandby == s2.PresetMetricsStandby || reflect.DeepEqual(s.MetricsStandby, s2.MetricsStandby)) &&
 		s.OnlyIfMaster == s2.OnlyIfMaster &&
 		reflect.DeepEqual(s.CustomTags, s2.CustomTags) &&
 		reflect.DeepEqual(s.HostConfig, s2.HostConfig)

--- a/internal/sources/types_test.go
+++ b/internal/sources/types_test.go
@@ -51,3 +51,92 @@ func TestSource_IsDefaultGroup(t *testing.T) {
 	assert.True(t, sources[1].IsDefaultGroup())
 	assert.False(t, sources[2].IsDefaultGroup())
 }
+
+
+func TestSource_Equal(t *testing.T) {
+	var correctInterval float64 = 60
+	var incorrectInterval float64 = 10
+
+	s1 := sources.Source{
+		Metrics: map[string]float64{"wal" : correctInterval},
+		MetricsStandby: map[string]float64{"wal" : correctInterval},
+	}
+
+	srcs := sources.Sources{
+		{
+			PresetMetrics: "basic",
+			PresetMetricsStandby: "basic",
+		},
+		{
+			PresetMetrics: "basic",
+			PresetMetricsStandby: "basic",
+			Metrics: map[string]float64{"wal" : correctInterval},
+			MetricsStandby: map[string]float64{"wal" : correctInterval},
+		},
+		{
+			PresetMetrics: "basic",
+			PresetMetricsStandby: "basic",
+			Metrics: map[string]float64{"wal" : incorrectInterval},
+			MetricsStandby: map[string]float64{"wal" : incorrectInterval},
+		},
+		{
+			Metrics: map[string]float64{"wal" : incorrectInterval},
+			MetricsStandby: map[string]float64{"wal" : incorrectInterval},
+		},
+		{
+			Metrics: map[string]float64{"wal" : correctInterval, "db_size" : correctInterval},
+			MetricsStandby: map[string]float64{"wal" : correctInterval, "db_size" : correctInterval},
+		},
+		{
+			Metrics: map[string]float64{"wal" : correctInterval},
+			MetricsStandby: map[string]float64{"wal" : correctInterval},
+		},
+	}
+
+	assert.False(t, s1.Equal(srcs[0]))
+	assert.False(t, s1.Equal(srcs[1]))
+	assert.False(t, s1.Equal(srcs[2])) 
+	assert.False(t, s1.Equal(srcs[3])) 
+	assert.False(t, s1.Equal(srcs[4])) 
+	assert.True(t, s1.Equal(srcs[5])) 
+
+	s1 = sources.Source{
+		PresetMetrics: "basic",
+		PresetMetricsStandby : "basic",
+		Metrics: map[string]float64{"wal" : correctInterval},
+		MetricsStandby: map[string]float64{"wal" : correctInterval},
+	}
+
+	srcs = sources.Sources{
+		{
+			PresetMetrics: "basic",
+			PresetMetricsStandby: "basic",
+		},
+		{
+			PresetMetrics: "basic",
+			PresetMetricsStandby: "basic",
+			Metrics: map[string]float64{"wal" : incorrectInterval},
+			MetricsStandby: map[string]float64{"wal" : incorrectInterval},
+		},
+		{
+			PresetMetrics: "azure",
+			PresetMetricsStandby: "azure",
+		},
+		{
+			PresetMetrics: "azure",
+			PresetMetricsStandby: "azure",
+			Metrics: map[string]float64{"wal" : correctInterval},
+			MetricsStandby: map[string]float64{"wal" : correctInterval},
+		},
+		{
+			Metrics: map[string]float64{"wal" : correctInterval},
+			MetricsStandby: map[string]float64{"wal" : correctInterval},
+		},
+	}
+
+	assert.True(t, s1.Equal(srcs[0]))
+	assert.True(t, s1.Equal(srcs[1]))
+	assert.False(t, s1.Equal(srcs[2]))
+	assert.False(t, s1.Equal(srcs[3]))
+	assert.False(t, s1.Equal(srcs[4]))
+}


### PR DESCRIPTION
ensure `SourceConn.Equal()` doesn't mark sources with empty presets as equal directly.
closes: #830 