### PR TITLE
[!] add REST-compliant endpoints with path parameters

### DIFF
--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 )
+
+var ErrSourceNotFound = errors.New("source not found")
 
 type Kind string
 
@@ -88,7 +91,7 @@ func (s *Source) GetDatabaseName() string {
 }
 
 func (s Source) Equal(s2 Source) bool {
-	var eq bool 
+	var eq bool
 	if s.PresetMetrics != "" || s2.PresetMetrics != "" {
 		eq = (s.PresetMetrics == s2.PresetMetrics)
 	} else {
@@ -101,7 +104,7 @@ func (s Source) Equal(s2 Source) bool {
 		eq = eq && reflect.DeepEqual(s.MetricsStandby, s2.MetricsStandby)
 	}
 
-	return eq && 
+	return eq &&
 		s.Name == s2.Name &&
 		s.Group == s2.Group &&
 		s.ConnStr == s2.ConnStr &&

--- a/internal/webserver/metric.go
+++ b/internal/webserver/metric.go
@@ -43,7 +43,7 @@ func (server *WebUIServer) handleMetrics(w http.ResponseWriter, r *http.Request)
 
 	case http.MethodOptions:
 		w.Header().Set("Allow", "GET, POST, DELETE, OPTIONS")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 
 	default:
 		w.Header().Set("Allow", "GET, POST, DELETE, OPTIONS")
@@ -95,7 +95,7 @@ func (server *WebUIServer) handleMetricItem(w http.ResponseWriter, r *http.Reque
 		server.deleteMetricByName(w, name)
 	case http.MethodOptions:
 		w.Header().Set("Allow", "GET, PUT, DELETE, OPTIONS")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 	default:
 		w.Header().Set("Allow", "GET, PUT, DELETE, OPTIONS")
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -149,7 +149,7 @@ func (server *WebUIServer) deleteMetricByName(w http.ResponseWriter, name string
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 }
 
 func (server *WebUIServer) handlePresets(w http.ResponseWriter, r *http.Request) {
@@ -186,7 +186,7 @@ func (server *WebUIServer) handlePresets(w http.ResponseWriter, r *http.Request)
 
 	case http.MethodOptions:
 		w.Header().Set("Allow", "GET, POST, PATCH, DELETE, OPTIONS")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 
 	default:
 		w.Header().Set("Allow", "GET, POST, PATCH, DELETE, OPTIONS")
@@ -238,7 +238,7 @@ func (server *WebUIServer) handlePresetItem(w http.ResponseWriter, r *http.Reque
 		server.deletePresetByName(w, name)
 	case http.MethodOptions:
 		w.Header().Set("Allow", "GET, PUT, DELETE, OPTIONS")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 	default:
 		w.Header().Set("Allow", "GET, PUT, DELETE, OPTIONS")
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -292,5 +292,5 @@ func (server *WebUIServer) deletePresetByName(w http.ResponseWriter, name string
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 }

--- a/internal/webserver/metric_test.go
+++ b/internal/webserver/metric_test.go
@@ -175,7 +175,7 @@ func TestHandleMetrics_Options(t *testing.T) {
 	ts.handleMetrics(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "GET, POST, DELETE, OPTIONS", resp.Header.Get("Allow"))
 }
 
@@ -345,7 +345,7 @@ func TestHandlePreset_Options(t *testing.T) {
 	ts.handlePresets(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "GET, POST, PATCH, DELETE, OPTIONS", resp.Header.Get("Allow"))
 }
 
@@ -483,7 +483,7 @@ func TestHandleMetricItem_DELETE_Success(t *testing.T) {
 	ts.handleMetricItem(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "test-metric", deletedName)
 }
 
@@ -520,7 +520,7 @@ func TestHandleMetricItem_Options(t *testing.T) {
 	ts.handleMetricItem(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "GET, PUT, DELETE, OPTIONS", resp.Header.Get("Allow"))
 }
 
@@ -695,7 +695,7 @@ func TestHandlePresetItem_DELETE_Success(t *testing.T) {
 	ts.handlePresetItem(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "test-preset", deletedName)
 }
 
@@ -732,7 +732,7 @@ func TestHandlePresetItem_Options(t *testing.T) {
 	ts.handlePresetItem(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "GET, PUT, DELETE, OPTIONS", resp.Header.Get("Allow"))
 }
 

--- a/internal/webserver/metric_test.go
+++ b/internal/webserver/metric_test.go
@@ -424,7 +424,7 @@ func TestHandleMetricItem_GET_Success(t *testing.T) {
 
 	var returnedMetric metrics.Metric
 	body, _ := io.ReadAll(resp.Body)
-	jsoniter.ConfigFastest.Unmarshal(body, &returnedMetric)
+	assert.NoError(t, jsoniter.ConfigFastest.Unmarshal(body, &returnedMetric))
 	assert.Equal(t, metric.Description, returnedMetric.Description)
 }
 
@@ -553,7 +553,7 @@ func TestHandleMetricItem_PUT_InvalidRequestBody(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	body, _ := io.ReadAll(resp.Body)
-	assert.Contains(t, string(body), "invalid request body")
+	assert.Contains(t, string(body), "mock read error")
 }
 
 func TestHandleMetricItem_PUT_InvalidJSON(t *testing.T) {
@@ -566,7 +566,7 @@ func TestHandleMetricItem_PUT_InvalidJSON(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	body, _ := io.ReadAll(resp.Body)
-	assert.Contains(t, string(body), "invalid JSON format")
+	assert.Contains(t, string(body), "invalid json")
 }
 
 func TestHandleMetricItem_PUT_UpdateMetricError(t *testing.T) {
@@ -636,7 +636,7 @@ func TestHandlePresetItem_GET_Success(t *testing.T) {
 
 	var returnedPreset metrics.Preset
 	body, _ := io.ReadAll(resp.Body)
-	jsoniter.ConfigFastest.Unmarshal(body, &returnedPreset)
+	assert.NoError(t, jsoniter.ConfigFastest.Unmarshal(body, &returnedPreset))
 	assert.Equal(t, preset.Description, returnedPreset.Description)
 }
 

--- a/internal/webserver/source.go
+++ b/internal/webserver/source.go
@@ -95,7 +95,7 @@ func (server *WebUIServer) handleSourceItem(w http.ResponseWriter, r *http.Reque
 		server.deleteSourceByName(w, name)
 	case http.MethodOptions:
 		w.Header().Set("Allow", "GET, PUT, DELETE, OPTIONS")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 	default:
 		w.Header().Set("Allow", "GET, PUT, DELETE, OPTIONS")
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -157,5 +157,5 @@ func (server *WebUIServer) deleteSourceByName(w http.ResponseWriter, name string
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 }

--- a/internal/webserver/source_test.go
+++ b/internal/webserver/source_test.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,7 +55,7 @@ func TestHandleSources_GET(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, _ := io.ReadAll(resp.Body)
 	var got []sources.Source
-	assert.NoError(t, json.Unmarshal(body, &got))
+	assert.NoError(t, jsoniter.ConfigFastest.Unmarshal(body, &got))
 	assert.Equal(t, "foo", got[0].Name)
 }
 
@@ -84,7 +86,7 @@ func TestHandleSources_POST(t *testing.T) {
 	}
 	ts := newTestSourceServer(mock)
 	src := sources.Source{Name: "bar"}
-	b, _ := json.Marshal(src)
+	b, _ := jsoniter.ConfigFastest.Marshal(src)
 	r := httptest.NewRequest(http.MethodPost, "/source", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	ts.handleSources(w, r)
@@ -119,7 +121,7 @@ func TestHandleSources_POST_Fail(t *testing.T) {
 	}
 	ts := newTestSourceServer(mock)
 	src := sources.Source{Name: "bar"}
-	b, _ := json.Marshal(src)
+	b, _ := jsoniter.ConfigFastest.Marshal(src)
 	r := httptest.NewRequest(http.MethodPost, "/source", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	ts.handleSources(w, r)
@@ -214,4 +216,287 @@ func TestHandleSources_ReadAllError(t *testing.T) {
 	resp := w.Result()
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// Helper function to create HTTP requests with path values for testing individual source endpoints
+func newSourceItemRequest(method, name string, body io.Reader) *http.Request {
+	url := "/source/" + name
+	r := httptest.NewRequest(method, url, body)
+	r.SetPathValue("name", name)
+	return r
+}
+
+// Tests for new REST-compliant source endpoints
+
+func TestHandleSourceItem_GET_Success(t *testing.T) {
+	source := sources.Source{Name: "test-source", ConnStr: "postgresql://test"}
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return sources.Sources{source}, nil
+		},
+	}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodGet, "test-source", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var returnedSource sources.Source
+	body, _ := io.ReadAll(resp.Body)
+	jsoniter.ConfigFastest.Unmarshal(body, &returnedSource)
+	assert.Equal(t, source.Name, returnedSource.Name)
+}
+
+func TestHandleSourceItem_GET_NotFound(t *testing.T) {
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return sources.Sources{}, nil
+		},
+	}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodGet, "nonexistent", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "source not found")
+}
+
+func TestHandleSourceItem_PUT_Success(t *testing.T) {
+	existingSource := sources.Source{Name: "test-source", ConnStr: "postgresql://old"}
+	var updatedSource sources.Source
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return sources.Sources{existingSource}, nil
+		},
+		UpdateSourceFunc: func(md sources.Source) error {
+			updatedSource = md
+			return nil
+		},
+	}
+	ts := newTestSourceServer(mock)
+
+	newSource := sources.Source{Name: "test-source", ConnStr: "postgresql://new"}
+	b, _ := jsoniter.ConfigFastest.Marshal(newSource)
+	r := newSourceItemRequest(http.MethodPut, "test-source", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, newSource.ConnStr, updatedSource.ConnStr)
+}
+
+func TestHandleSourceItem_PUT_CreateNew(t *testing.T) {
+	var updatedSource sources.Source
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return sources.Sources{}, nil // No existing sources
+		},
+		UpdateSourceFunc: func(md sources.Source) error {
+			updatedSource = md
+			return nil
+		},
+	}
+	ts := newTestSourceServer(mock)
+
+	source := sources.Source{Name: "new-source", ConnStr: "postgresql://new"}
+	b, _ := jsoniter.ConfigFastest.Marshal(source)
+	r := newSourceItemRequest(http.MethodPut, "new-source", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, source.Name, updatedSource.Name)
+	assert.Equal(t, source.ConnStr, updatedSource.ConnStr)
+}
+
+func TestHandleSourceItem_PUT_NameMismatch(t *testing.T) {
+	existingSource := sources.Source{Name: "test-source"}
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return sources.Sources{existingSource}, nil
+		},
+	}
+	ts := newTestSourceServer(mock)
+
+	// Body has different name than URL path
+	source := sources.Source{Name: "different-name"}
+	b, _ := jsoniter.ConfigFastest.Marshal(source)
+	r := newSourceItemRequest(http.MethodPut, "test-source", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "name in URL and body must match")
+}
+
+func TestHandleSourceItem_DELETE_Success(t *testing.T) {
+	existingSource := sources.Source{Name: "test-source"}
+	var deletedName string
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return sources.Sources{existingSource}, nil
+		},
+		DeleteSourceFunc: func(name string) error {
+			deletedName = name
+			return nil
+		},
+	}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodDelete, "test-source", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "test-source", deletedName)
+}
+
+func TestHandleSourceItem_DELETE_Idempotent(t *testing.T) {
+	var deletedName string
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return sources.Sources{}, nil // No existing sources
+		},
+		DeleteSourceFunc: func(name string) error {
+			deletedName = name
+			return nil // DELETE is idempotent - succeeds even if source doesn't exist
+		},
+	}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodDelete, "nonexistent", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "nonexistent", deletedName)
+}
+
+func TestHandleSourceItem_EmptyName(t *testing.T) {
+	mock := &mockSourcesReaderWriter{}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodGet, "", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "source name is required")
+}
+
+func TestHandleSourceItem_MethodNotAllowed(t *testing.T) {
+	mock := &mockSourcesReaderWriter{}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodPost, "test", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	assert.Equal(t, "GET, PUT, DELETE, OPTIONS", resp.Header.Get("Allow"))
+}
+
+func TestHandleSourceItem_Options(t *testing.T) {
+	mock := &mockSourcesReaderWriter{}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodOptions, "test", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "GET, PUT, DELETE, OPTIONS", resp.Header.Get("Allow"))
+}
+
+// Error flow tests for xxSourceByName methods
+
+func TestHandleSourceItem_GET_GetSourcesError(t *testing.T) {
+	mock := &mockSourcesReaderWriter{
+		GetSourcesFunc: func() (sources.Sources, error) {
+			return nil, errors.New("database connection failed")
+		},
+	}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodGet, "test-source", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "database connection failed")
+}
+
+func TestHandleSourceItem_PUT_InvalidRequestBody(t *testing.T) {
+	mock := &mockSourcesReaderWriter{}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodPut, "test-source", &errorReader{})
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "invalid request body")
+}
+
+func TestHandleSourceItem_PUT_InvalidJSON(t *testing.T) {
+	mock := &mockSourcesReaderWriter{}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodPut, "test-source", strings.NewReader("invalid json"))
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "invalid JSON format")
+}
+
+func TestHandleSourceItem_PUT_UpdateSourceError(t *testing.T) {
+	mock := &mockSourcesReaderWriter{
+		UpdateSourceFunc: func(sources.Source) error {
+			return errors.New("update operation failed")
+		},
+	}
+	ts := newTestSourceServer(mock)
+
+	source := sources.Source{Name: "test-source", ConnStr: "postgresql://test"}
+	b, _ := jsoniter.ConfigFastest.Marshal(source)
+	r := newSourceItemRequest(http.MethodPut, "test-source", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "update operation failed")
+}
+
+func TestHandleSourceItem_DELETE_DeleteSourceError(t *testing.T) {
+	mock := &mockSourcesReaderWriter{
+		DeleteSourceFunc: func(string) error {
+			return errors.New("delete operation failed")
+		},
+	}
+	ts := newTestSourceServer(mock)
+	r := newSourceItemRequest(http.MethodDelete, "test-source", nil)
+	w := httptest.NewRecorder()
+	ts.handleSourceItem(w, r)
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "delete operation failed")
 }

--- a/internal/webserver/source_test.go
+++ b/internal/webserver/source_test.go
@@ -357,7 +357,7 @@ func TestHandleSourceItem_DELETE_Success(t *testing.T) {
 	ts.handleSourceItem(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "test-source", deletedName)
 }
 
@@ -378,7 +378,7 @@ func TestHandleSourceItem_DELETE_Idempotent(t *testing.T) {
 	ts.handleSourceItem(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "nonexistent", deletedName)
 }
 
@@ -415,7 +415,7 @@ func TestHandleSourceItem_Options(t *testing.T) {
 	ts.handleSourceItem(w, r)
 	resp := w.Result()
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "GET, PUT, DELETE, OPTIONS", resp.Header.Get("Allow"))
 }
 

--- a/internal/webserver/source_test.go
+++ b/internal/webserver/source_test.go
@@ -246,7 +246,7 @@ func TestHandleSourceItem_GET_Success(t *testing.T) {
 
 	var returnedSource sources.Source
 	body, _ := io.ReadAll(resp.Body)
-	jsoniter.ConfigFastest.Unmarshal(body, &returnedSource)
+	assert.NoError(t, jsoniter.ConfigFastest.Unmarshal(body, &returnedSource))
 	assert.Equal(t, source.Name, returnedSource.Name)
 }
 

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -58,6 +58,7 @@ func Init(ctx context.Context, opts CmdOpts, webuifs fs.FS, mrw metrics.ReaderWr
 	}
 
 	mux.Handle("/source", NewEnsureAuth(s.handleSources))
+	mux.Handle("/source/{name}", NewEnsureAuth(s.handleSourceItem))
 	mux.Handle("/test-connect", NewEnsureAuth(s.handleTestConnect))
 	mux.Handle("/metric", NewEnsureAuth(s.handleMetrics))
 	mux.Handle("/preset", NewEnsureAuth(s.handlePresets))

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -61,6 +61,7 @@ func Init(ctx context.Context, opts CmdOpts, webuifs fs.FS, mrw metrics.ReaderWr
 	mux.Handle("/source/{name}", NewEnsureAuth(s.handleSourceItem))
 	mux.Handle("/test-connect", NewEnsureAuth(s.handleTestConnect))
 	mux.Handle("/metric", NewEnsureAuth(s.handleMetrics))
+	mux.Handle("/metric/{name}", NewEnsureAuth(s.handleMetricItem))
 	mux.Handle("/preset", NewEnsureAuth(s.handlePresets))
 	mux.Handle("/log", NewEnsureAuth(s.serveWsLog))
 	mux.HandleFunc("/login", s.handleLogin)

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -63,6 +63,7 @@ func Init(ctx context.Context, opts CmdOpts, webuifs fs.FS, mrw metrics.ReaderWr
 	mux.Handle("/metric", NewEnsureAuth(s.handleMetrics))
 	mux.Handle("/metric/{name}", NewEnsureAuth(s.handleMetricItem))
 	mux.Handle("/preset", NewEnsureAuth(s.handlePresets))
+	mux.Handle("/preset/{name}", NewEnsureAuth(s.handlePresetItem))
 	mux.Handle("/log", NewEnsureAuth(s.serveWsLog))
 	mux.HandleFunc("/login", s.handleLogin)
 	mux.HandleFunc("/liveness", s.handleLiveness)


### PR DESCRIPTION
- Add `/[source|metric|preset]/{name}` routes using Go 1.22+ PathValue
- Implement GET, PUT, DELETE methods with proper HTTP status codes
- Add comprehensive test coverage for new REST endpoints
- Maintain backward compatibility with existing collection endpoints
- Use idempotent PUT/DELETE semantics