### PR TITLE
docker: Update scripts for Podman compatibility and remove deprecated links

### DIFF
--- a/docker/build-docker-demo.sh
+++ b/docker/build-docker-demo.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+source ~/.bashrc
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$(dirname "$SCRIPT_DIR")"

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+source ~/.bashrc
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$(dirname "$SCRIPT_DIR")"

--- a/docker/compose.add-test-db.sh
+++ b/docker/compose.add-test-db.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+source ~/.bashrc
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/docker/compose.pgactivity.sh
+++ b/docker/compose.pgactivity.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+source ~/.bashrc
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/docker/compose.pgbench.sh
+++ b/docker/compose.pgbench.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+source ~/.bashrc
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/docker/compose.postgres.yml
+++ b/docker/compose.postgres.yml
@@ -46,5 +46,3 @@ services:
         pg_basebackup -h postgres --pgdata=/var/lib/postgresql/data --wal-method=stream --progress --write-recovery-conf --slot=standby_slot &&
         chmod 0700 /var/lib/postgresql/data &&
         postgres -cshared_preload_libraries=pg_stat_statements -cpg_stat_statements.track=all -ctrack_io_timing=on -ctrack_functions=pl"
-    links:
-      - postgres


### PR DESCRIPTION
Some minor improvements were made to ensure the Docker-related scripts work properly in environments where Podman is used instead of Docker.

- Changed the shebang lines to use `/usr/bin/env bash` for better portability across systems.
- Added `source ~/.bashrc` at the top of the scripts so that any local shell configurations (like aliases or functions) are loaded properly, especially in non-interactive shells.
- Removed the deprecated `links` section from `compose.postgres.yml`.

These changes help avoid compatibility issues and reduce reliance on deprecated Docker Compose features.