### PR TITLE
[-] monitor all sources if `--group` cmdopt is omitted, fixes #843

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -379,7 +379,7 @@ func (r *Reaper) LoadSources() (err error) {
 		return err
 	}
 	srcs = slices.DeleteFunc(srcs, func(s sources.Source) bool {
-		return !s.IsEnabled || !s.IsDefaultGroup() && !slices.Contains(r.Sources.Groups, s.Group)
+		return !s.IsEnabled || len(r.Sources.Groups) > 0 && !s.IsDefaultGroup() && !slices.Contains(r.Sources.Groups, s.Group)
 	})
 	if newSrcs, err = srcs.ResolveDatabases(); err != nil {
 		return err


### PR DESCRIPTION
When not using the `--group` cmdopt (or envvar `PW_GROUP`), pgwatch should monitor all sources by design