### PR TITLE
[*] fix `DefineMetrics()` err logging

### DIFF
--- a/internal/reaper/metric.go
+++ b/internal/reaper/metric.go
@@ -79,7 +79,10 @@ func (r *Reaper) LoadMetrics() (err error) {
 	}
 	metricDefs.Assign(newDefs)
 	if definer, ok := r.SinksWriter.(sinks.MetricsDefiner); ok {
-		err = definer.DefineMetrics(newDefs)
+		err := definer.DefineMetrics(newDefs)
+		if err != nil {
+			r.logger.Error(err)
+		}
 	}
 	r.logger.
 		WithField("metrics", len(newDefs.MetricDefs)).


### PR DESCRIPTION
the current log msg for error returned by `SinksWriter.DefineMetrics()` looks like
```
2025-07-22 12:01:02.728 [ERROR] [error:rpc error: code = Unimplemented desc = method DefineMetrics not implemented] could not refresh metric definitions, using last valid cache
```
while the error is the method isn't implemented on grpc server side and nothing about refreshing metrics

now it will be
```
2025-07-22 12:04:02.418 [ERROR] rpc error: code = Unimplemented desc = method DefineMetrics not implemented
```