### PR TITLE
[*] optimize maintenance tasks in Postgres sink, closes #786

### DIFF
--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -547,7 +547,7 @@ func (pgw *PostgresWriter) StartMaintenanceActivity(ctx context.Context, activit
 		logger.Errorf("Starting transaction for %s maintenance failed: %w", activity, err)
 		return false
 	}
-	func() {
+	defer func() {
 		if err != nil {
 			_ = tx.Rollback(pgw.ctx)
 		} else {


### PR DESCRIPTION
From now `admin.config` holds information about last successful operation. Maintenance routines will check if any other instance already processed it before starting it's own.