### PR TITLE
[+] add basic auth support to grpc sink

### DIFF
--- a/internal/sinks/rpc.go
+++ b/internal/sinks/rpc.go
@@ -54,7 +54,7 @@ func NewRPCWriter(ctx context.Context, connStr string) (*RPCWriter, error) {
 		return nil, fmt.Errorf("error parsing gRPC URI: %s", err)
 	}
 
-	l := log.GetLogger(ctx).WithField("sink", "grpc").WithField("server", fmt.Sprintf("\"%s\"", uri.Host))
+	l := log.GetLogger(ctx).WithField("sink", "grpc").WithField("address", uri.Host)
 	ctx = log.WithLogger(ctx, l)
 
 	params, err := url.ParseQuery(uri.RawQuery)

--- a/internal/sinks/rpc.go
+++ b/internal/sinks/rpc.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -53,6 +54,9 @@ func NewRPCWriter(ctx context.Context, connStr string) (*RPCWriter, error) {
 		return nil, fmt.Errorf("error parsing gRPC URI: %s", err)
 	}
 
+	l := log.GetLogger(ctx).WithField("sink", "grpc").WithField("server", fmt.Sprintf("\"%s\"", uri.Host))
+	ctx = log.WithLogger(ctx, l)
+
 	params, err := url.ParseQuery(uri.RawQuery)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing gRPC URI parameters: %s", err)
@@ -73,10 +77,17 @@ func NewRPCWriter(ctx context.Context, connStr string) (*RPCWriter, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
+	password, _ := uri.User.Password()
+	md := metadata.Pairs(  
+		"username", uri.User.Username(),  
+		"password", password,
+	)  
+	newCtx := metadata.NewOutgoingContext(ctx, md)
+	
 	client := pb.NewReceiverClient(conn)
 	rw := &RPCWriter{
-		ctx:    ctx,
+		ctx:    newCtx,
 		conn:   conn,
 		client: client,
 	}


### PR DESCRIPTION
- send `username` and `password` contained in the grpc sink uri  `grpc://username:password@...` with each call's metadata to enable authentication for servers