### PR TITLE
[-] remove `host_config` querying from `GetSources()`

### DIFF
--- a/internal/sources/postgres.go
+++ b/internal/sources/postgres.go
@@ -148,7 +148,6 @@ func (r *dbSourcesReaderWriter) GetSources() (Sources, error) {
 	coalesce(include_pattern, '') as include_pattern, 
 	coalesce(exclude_pattern, '') as exclude_pattern,
 	coalesce(custom_tags, '{}'::jsonb) as custom_tags, 
-	coalesce(host_config, '{}') as host_config, 
 	only_if_master,
 	is_enabled
 from


### PR DESCRIPTION
Remove `host_config` querying from `GetSources()`.


The reaper fails to read sources from postgres due to `pgx.CollectRows[Source]` in `GetSources()` giving error about missing `host_config` field from `Source` Struct
```
go run ./cmd/pgwatch --sources=postgres://postgres:postgres@localhost:5432/postgres --sink=jsonfile://file.json
2025-07-24 22:21:47.569 [ERROR] [error:struct doesn't have corresponding row field host_config] could not refresh active sources, using last valid cache
2025-07-24 22:21:47.571 [INFO] [metrics:73] [presets:17] metrics and presets refreshed
```
`host_config` field was removed from source in #859