### PR TITLE
[!] improve Docker-related GitHub Actions and jobs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,75 @@
+# ================================================================
+# Docker Build Context Optimization
+# Exclude unnecessary files to reduce build context size and improve performance
+# ================================================================
+
+# Git and version control
+.git
+.gitignore
+.gitattributes
+.gitmodules
+
+# Documentation and markdown files (except essential ones)
+*.md
+!README.md
+docs/
+site/
+
+# Development files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs and temporary files
+*.log
+*.tmp
+*.temp
+mem_log.txt
+coverage.out
+
+# Node.js (keep essential files, exclude build artifacts)
 **/node_modules
 **/build
-docs
-contrib
+internal/webui/.yarn/
+internal/webui/yarn-error.log
+internal/webui/npm-debug.log*
+internal/webui/lerna-debug.log*
+
+# Go build artifacts (exclude from context, but keep source)
+pgwatch
+cmd/pgwatch/pgwatch
+*.exe
+
+# Test files and test data
+*_test.go
+**/*_test.go
+testdata/
+
+# Docker artifacts
+docker-compose*.yml
+compose*.yml
+
+# CI/CD (GitHub Actions can access these separately)
+.github/
+
+# Local development tools
+etcdctl.exe
+.env
+.env.local
+.env.*.local
+
+# Other build artifacts
+dist/
+out/
+contrib/

--- a/.github/actions/build-docker/README.md
+++ b/.github/actions/build-docker/README.md
@@ -1,0 +1,228 @@
+# Build Docker Action
+
+A reusable GitHub Action for building and pushing multi-architecture Docker images with advanced features like caching, SemVer tagging, and support for multiple registries.
+
+## Features
+
+- ✅ **Multi-platform builds** using Docker Buildx (linux/amd64, linux/arm64)
+- 🏷️ **Automatic SemVer tagging** based on Git tags
+- 🚀 **Build caching** for faster rebuilds using GitHub Actions cache
+- 🐳 **Multiple registry support** (Docker Hub, GHCR, custom registries)
+- 🔄 **Conditional pushing** (build-only mode for testing)
+- 📋 **Rich metadata** with OpenContainer labels
+- 🎯 **Matrix builds** for multiple Dockerfiles
+
+## Usage
+
+### Basic Usage
+
+```yaml
+- name: Build and push Docker image
+  uses: ./.github/actions/build-docker
+  with:
+    dockerfile: docker/Dockerfile
+    image-name: myorg/myapp
+    registry: docker.io
+    username: ${{ secrets.DOCKER_USERNAME }}
+    password: ${{ secrets.DOCKER_PASSWORD }}
+    push: 'true'
+```
+
+### Advanced Usage with Matrix Strategy
+
+```yaml
+jobs:
+  docker:
+    strategy:
+      matrix:
+        image: 
+          - {file: 'docker/Dockerfile', name: 'myorg/myapp'}
+          - {file: 'docker/demo/Dockerfile', name: 'myorg/myapp-demo'}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Build and push
+        uses: ./.github/actions/build-docker
+        with:
+          dockerfile: ${{ matrix.image.file }}
+          image-name: ${{ matrix.image.name }}
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          push: ${{ github.ref_type == 'tag' }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            BUILD_DATE=${{ steps.date.outputs.date }}
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `dockerfile` | Path to Dockerfile (relative to repo root) | ✅ | - |
+| `image-name` | Docker image name (without registry prefix) | ✅ | - |
+| `registry` | Docker registry (docker.io, ghcr.io, etc.) | ❌ | `docker.io` |
+| `username` | Docker registry username | ✅ | - |
+| `password` | Docker registry password/token | ✅ | - |
+| `platforms` | Target platforms for multi-arch build | ❌ | `linux/amd64,linux/arm64` |
+| `push` | Whether to push the image (true/false) | ❌ | `false` |
+| `build-args` | Build arguments (KEY=VALUE, one per line) | ❌ | - |
+| `cache-scope` | Cache scope for build cache | ❌ | `default` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `image-id` | Image ID of the built image |
+| `digest` | Image digest of the built image |
+| `metadata` | Build result metadata |
+
+## Tag Strategy
+
+The action automatically applies tags based on the trigger:
+
+### For Git Tags (Releases)
+
+- `1.2.3` - Exact version
+- `1.2` - Minor version
+- `1` - Major version
+- `latest` - Latest stable release (excludes pre-releases)
+
+**Note**: Pre-release versions (e.g., `1.2.3-beta.1`, `2.0.0-rc.1`) will only get the exact version tag, not `latest` or major/minor tags.
+
+### For Branch Pushes
+
+- `main` or `master` → branch name (no `latest` tag)
+- Other branches → branch name as tag
+
+### For Pull Requests
+
+- `pr-123` - PR number
+
+### Always Applied
+
+- `sha-abc1234` - Short commit SHA
+
+## Registry Examples
+
+### Docker Hub
+
+```yaml
+with:
+  registry: docker.io
+  username: ${{ secrets.DOCKER_USERNAME }}
+  password: ${{ secrets.DOCKER_PASSWORD }}
+```
+
+### GitHub Container Registry (GHCR)
+
+```yaml
+with:
+  registry: ghcr.io
+  image-name: myorg/myapp  # Same name as Docker Hub
+  username: ${{ github.actor }}
+  password: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Note**: Use consistent image names across registries for better user experience.
+
+### Custom Registry
+
+```yaml
+with:
+  registry: my-registry.com
+  username: ${{ secrets.CUSTOM_REGISTRY_USER }}
+  password: ${{ secrets.CUSTOM_REGISTRY_TOKEN }}
+```
+
+## Build-Only Mode
+
+To test builds without pushing (useful in PR workflows):
+
+```yaml
+- name: Test Docker build
+  uses: ./.github/actions/build-docker
+  with:
+    dockerfile: docker/Dockerfile
+    image-name: myorg/myapp
+    registry: docker.io
+    username: dummy  # Not used when push=false
+    password: dummy  # Not used when push=false
+    push: 'false'
+```
+
+## Build Arguments
+
+Pass build arguments to Docker:
+
+```yaml
+with:
+  build-args: |
+    VERSION=${{ github.ref_name }}
+    GIT_HASH=${{ github.sha }}
+    BUILD_DATE=${{ steps.date.outputs.date }}
+    ENVIRONMENT=production
+```
+
+## Caching
+
+The action uses GitHub Actions cache for Docker layer caching. Use different `cache-scope` values for different build contexts:
+
+```yaml
+with:
+  cache-scope: main-app     # For main application
+  # vs
+  cache-scope: demo-app     # For demo application
+```
+
+## Security Notes
+
+- Registry credentials are only used when `push: 'true'`
+- Build-only mode doesn't require valid credentials
+- Use repository secrets for sensitive data
+- GHCR automatically uses `GITHUB_TOKEN` which has appropriate permissions
+
+## Conditional Pushing
+
+Common patterns for when to push images:
+
+```yaml
+# Push only on tags (releases)
+push: ${{ github.ref_type == 'tag' }}
+
+# Push on tags or main branch
+push: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
+
+# Push only on releases (not pre-releases)
+push: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'beta') }}
+```
+
+## Workflow Integration
+
+### Avoiding Conflicts
+
+When using this action in multiple workflows, be careful about triggers to avoid conflicts:
+
+```yaml
+# ✅ Good: Release workflow (official releases)
+on:
+  release:
+    types: [created]
+# Uses: push: 'true' for Docker Hub
+
+# ✅ Good: Build workflow (testing)
+on:
+  pull_request:
+# Uses: push: 'false' (build-only)
+
+# ❌ Bad: Both workflows triggering on same tag
+# Don't use both of these:
+on: { push: { tags: ['v*'] } }  # Workflow 1
+on: { release: { types: [created] } }  # Workflow 2 (GitHub creates tag automatically)
+```
+
+### Recommended Setup
+
+- **Release Workflow**: Handle official releases to Docker Hub
+- **Build Workflow**: Test builds on PRs (no push)  
+- **Multi-Registry Workflow**: Manual builds for alternative registries

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -99,7 +99,7 @@ runs:
         context: .
         file: ${{ inputs.dockerfile }}
         platforms: ${{ inputs.platforms }}
-        push: ${{ inputs.push }}
+        push: ${{ inputs.push == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: ${{ inputs.build-args }}

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -65,7 +65,7 @@ runs:
       if: inputs.push == 'true'
       uses: docker/login-action@v3
       with:
-        registry: ${{ inputs.registry }}
+        registry: ${{ inputs.registry == 'docker.io' && '' || inputs.registry }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
@@ -73,7 +73,7 @@ runs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ inputs.registry }}/${{ inputs.image-name }}
+        images: ${{ inputs.image-name }}
         tags: |
           # For releases: apply SemVer tags and latest (excludes pre-releases automatically)
           type=semver,pattern={{version}}

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,0 +1,118 @@
+name: 'Build and Push Docker Images'
+description: 'Builds multi-arch Docker images with caching and SemVer tagging using official Docker actions'
+
+inputs:
+  dockerfile:
+    description: 'Path to Dockerfile (relative to repository root)'
+    required: true
+  image-name:
+    description: 'Docker image name (without registry prefix)'
+    required: true
+  registry:
+    description: 'Docker registry (docker.io or ghcr.io)'
+    required: false
+    default: 'docker.io'
+  username:
+    description: 'Docker registry username'
+    required: true
+  password:
+    description: 'Docker registry password/token'
+    required: true
+  platforms:
+    description: 'Target platforms for multi-arch build'
+    required: false
+    default: 'linux/amd64,linux/arm64'
+  push:
+    description: 'Whether to push the image (true/false)'
+    required: false
+    default: 'false'
+  build-args:
+    description: 'Build arguments as KEY=VALUE pairs (one per line)'
+    required: false
+    default: ''
+
+  cache-scope:
+    description: 'Cache scope for build cache'
+    required: false
+    default: 'default'
+
+outputs:
+  image-id:
+    description: 'Image ID of the built image'
+    value: ${{ steps.build.outputs.imageid }}
+  digest:
+    description: 'Image digest of the built image'
+    value: ${{ steps.build.outputs.digest }}
+  metadata:
+    description: 'Build result metadata'
+    value: ${{ steps.build.outputs.metadata }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver-opts: |
+          network=host
+
+    - name: Log in to Docker Registry
+      if: inputs.push == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image-name }}
+        tags: |
+          # For releases: apply SemVer tags and latest (excludes pre-releases automatically)
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=semver,pattern=latest
+          # For branches: branch name as tag  
+          type=ref,event=branch
+          # For PRs: pr-<number>
+          type=ref,event=pr
+          # SHA for unique identification
+          type=sha,prefix=sha-,format=short
+        labels: |
+          org.opencontainers.image.title=${{ inputs.image-name }}
+          org.opencontainers.image.description=PgWatch - PostgreSQL monitoring solution
+          org.opencontainers.image.vendor=Cybertec PostgreSQL International GmbH
+          org.opencontainers.image.licenses=BSD-3-Clause
+
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.platforms }}
+        push: ${{ inputs.push }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: ${{ inputs.build-args }}
+        cache-from: type=gha,scope=${{ inputs.cache-scope }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
+        provenance: false
+        sbom: false
+
+    - name: Output image details
+      shell: bash
+      run: |
+        echo "🐳 Built image: ${{ inputs.image-name }}"
+        echo "📋 Tags:"
+        echo "${{ steps.meta.outputs.tags }}" | sed 's/^/  - /'
+        echo "🔍 Digest: ${{ steps.build.outputs.digest }}"
+        echo "🆔 Image ID: ${{ steps.build.outputs.imageid }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,9 @@
 name: Build and Test
+
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Go Build & Test
+name: Build and Test
 on:
   push:
     branches:
@@ -133,22 +133,32 @@ jobs:
   test-docker-images:
     if: true # false to skip job during debug
     needs: [build, test, goreleaser]
-    name: Build Docker Image
+    name: Test Docker Image Build
     runs-on: ubuntu-latest
     steps:
 
     - name: Check out code
       uses: actions/checkout@v4
-    
-    - name: Build Docker Image
-      shell: bash
+
+    - name: Prepare build metadata
+      id: meta
       run: |
-        docker build \
-        --build-arg GIT_TIME=`git show -s --format=%cI HEAD` \
-        --build-arg GIT_HASH=`git show -s --format=%H HEAD` \
-        --build-arg VERSION=`git rev-parse --abbrev-ref HEAD` \
-        -t cybertecpostgresql/pgwatch:latest \
-        -f docker/Dockerfile .   
+        echo "GIT_HASH=${{ github.sha }}" >> $GITHUB_OUTPUT
+        echo "GIT_TIME=$(git show -s --format=%cI HEAD)" >> $GITHUB_OUTPUT
+        echo "VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+    
+    - name: Test build Docker image (fast, amd64 only)
+      uses: ./.github/actions/build-docker
+      with:
+        dockerfile: docker/Dockerfile
+        image-name: cybertecpostgresql/pgwatch
+        platforms: linux/amd64
+        push: 'false'
+        cache-scope: test-build
+        build-args: |
+          GIT_HASH=${{ steps.meta.outputs.GIT_HASH }}
+          GIT_TIME=${{ steps.meta.outputs.GIT_TIME }}
+          VERSION=${{ steps.meta.outputs.VERSION }}   
 
   build-docs:
     if: true # false to skip job during debug

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,8 @@
-name: Docker Manual Multi-Registry Build
+name: Docker Multi-Registry Build
 permissions:
   contents: read
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -29,24 +31,42 @@ jobs:
     outputs:
       registry: ${{ steps.config.outputs.registry }}
       should-push: ${{ steps.config.outputs.should-push }}
+      cache-key: ${{ steps.config.outputs.cache-key }}
+      webui-hash: ${{ steps.config.outputs.webui-hash }}
+      go-hash: ${{ steps.config.outputs.go-hash }}
     steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
       - name: Configure registry and push settings
         id: config
         run: |
-          # Manual workflow: use inputs directly
           REGISTRY="${{ github.event.inputs.registry }}"
           SHOULD_PUSH="${{ github.event.inputs.push }}"
           
+          # Create cache keys based on content hashes for better cache efficiency
+          WEBUI_HASH=$(find internal/webui -name "*.json" -o -name "*.lock" | sort | xargs cat | sha256sum | cut -d' ' -f1 | cut -c1-12)
+          GO_HASH=$(cat go.mod go.sum | sha256sum | cut -d' ' -f1 | cut -c1-12)
+          CACHE_KEY="${{ github.ref_name }}-$(date +%Y%m%d)"
+          
           echo "registry=$REGISTRY" >> $GITHUB_OUTPUT
           echo "should-push=$SHOULD_PUSH" >> $GITHUB_OUTPUT
+          echo "cache-key=$CACHE_KEY" >> $GITHUB_OUTPUT
+          echo "webui-hash=$WEBUI_HASH" >> $GITHUB_OUTPUT
+          echo "go-hash=$GO_HASH" >> $GITHUB_OUTPUT
           
           echo "🚀 Registry: $REGISTRY"
           echo "📤 Push: $SHOULD_PUSH"
+          echo "🔧 Cache Key: $CACHE_KEY"
+          echo "🔧 WebUI Hash: $WEBUI_HASH"
+          echo "🔧 Go Hash: $GO_HASH"
 
   docker:
-    name: Build Docker Images
+    name: Build Docker Images  
     needs: prepare
     strategy:
+      # Build sequentially to allow cache sharing between images
+      max-parallel: 1
       fail-fast: false
       matrix:
         image: [ 
@@ -77,7 +97,7 @@ jobs:
           echo "password=${{ secrets.DOCKER_PASSWORD }}" >> $GITHUB_OUTPUT
         fi
 
-    - name: Build and push to selected registry
+    - name: Build and push with optimized caching
       uses: ./.github/actions/build-docker
       with:
         dockerfile: ${{ matrix.image.file }}
@@ -87,7 +107,7 @@ jobs:
         password: ${{ steps.creds.outputs.password }}
         platforms: linux/amd64,linux/arm64
         push: ${{ needs.prepare.outputs.should-push }}
-        cache-scope: ${{ needs.prepare.outputs.registry }}-${{ matrix.image.name }}
+        cache-scope: ${{ needs.prepare.outputs.registry }}-${{ matrix.image.name }}-${{ needs.prepare.outputs.webui-hash }}-${{ needs.prepare.outputs.go-hash }}
         build-args: |
           GIT_HASH=${{ steps.meta.outputs.GIT_HASH }}
           GIT_TIME=${{ steps.meta.outputs.GIT_TIME }}
@@ -105,13 +125,17 @@ jobs:
           echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Registry | \`${{ needs.prepare.outputs.registry }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Push Enabled | ${{ needs.prepare.outputs.should-push }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Push Enabled | \`${{ needs.prepare.outputs.should-push }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cache Key | \`${{ needs.prepare.outputs.cache-key }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| WebUI Hash | \`${{ needs.prepare.outputs.webui-hash }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Go Hash | \`${{ needs.prepare.outputs.go-hash }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Trigger | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Ref | \`${{ github.ref }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Images | \`cybertecpostgresql/pgwatch\`, \`cybertecpostgresql/pgwatch-demo\` |" >> $GITHUB_STEP_SUMMARY
           
           if [ "${{ needs.docker.result }}" = "success" ]; then
-            echo "✅ All Docker builds completed successfully!" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "✅ **All Docker builds completed successfully!**" >> $GITHUB_STEP_SUMMARY
           else
-            echo "❌ Some Docker builds failed. Check the logs above." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **Some Docker builds failed. Check the logs above.**" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,11 +1,10 @@
-name: Docker Multi-Registry Build
+name: Build Docker Images
+description: Build and push Docker images for pgwatch and pgwatch-demo with caching and multi-arch support.
 permissions:
   contents: read
   packages: write
 
 on:
-  push:  # FOR TESTS ONLY
-    branches: [ improve-docker-gha ]
   workflow_dispatch:
     inputs:
       registry:
@@ -109,7 +108,7 @@ jobs:
         password: ${{ steps.creds.outputs.password }}
         platforms: linux/amd64,linux/arm64
         push: ${{ needs.prepare.outputs.should-push }}
-        cache-scope: ${{ needs.prepare.outputs.registry }}-${{ matrix.image.name }}-${{ needs.prepare.outputs.webui-hash }}-${{ needs.prepare.outputs.go-hash }}
+        cache-scope: ${{ needs.prepare.outputs.registry }}-shared-${{ needs.prepare.outputs.webui-hash }}-${{ needs.prepare.outputs.go-hash }}
         build-args: |
           GIT_HASH=${{ steps.meta.outputs.GIT_HASH }}
           GIT_TIME=${{ steps.meta.outputs.GIT_TIME }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,8 @@ permissions:
   packages: write
 
 on:
+  push:  # FOR TESTS ONLY
+    branches: [ improve-docker-gha ]
   workflow_dispatch:
     inputs:
       registry:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: Docker Manual Multi-Registry Build
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,115 @@
+name: Docker Manual Multi-Registry Build
+on:
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: 'Docker registry to use'
+        required: true
+        default: 'docker.io'
+        type: choice
+        options:
+          - docker.io
+          - ghcr.io
+      push:
+        description: 'Push images to registry'
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare Build Settings
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.config.outputs.registry }}
+      should-push: ${{ steps.config.outputs.should-push }}
+    steps:
+      - name: Configure registry and push settings
+        id: config
+        run: |
+          # Manual workflow: use inputs directly
+          REGISTRY="${{ github.event.inputs.registry }}"
+          SHOULD_PUSH="${{ github.event.inputs.push }}"
+          
+          echo "registry=$REGISTRY" >> $GITHUB_OUTPUT
+          echo "should-push=$SHOULD_PUSH" >> $GITHUB_OUTPUT
+          
+          echo "🚀 Registry: $REGISTRY"
+          echo "📤 Push: $SHOULD_PUSH"
+
+  docker:
+    name: Build Docker Images
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ 
+          {file: 'docker/Dockerfile', name: 'pgwatch'}, 
+          {file: 'docker/demo/Dockerfile', name: 'pgwatch-demo'}
+        ]
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out source code
+      uses: actions/checkout@v4
+
+    - name: Prepare build metadata
+      id: meta
+      run: |
+        echo "GIT_HASH=${{ github.sha }}" >> $GITHUB_OUTPUT
+        echo "GIT_TIME=$(git show -s --format=%cI HEAD)" >> $GITHUB_OUTPUT
+        echo "VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+
+    - name: Set registry credentials
+      id: creds
+      run: |
+        if [ "${{ needs.prepare.outputs.registry }}" = "ghcr.io" ]; then
+          echo "username=${{ github.actor }}" >> $GITHUB_OUTPUT
+          echo "password=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+        else
+          echo "username=${{ secrets.DOCKER_USERNAME }}" >> $GITHUB_OUTPUT
+          echo "password=${{ secrets.DOCKER_PASSWORD }}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Build and push to selected registry
+      uses: ./.github/actions/build-docker
+      with:
+        dockerfile: ${{ matrix.image.file }}
+        image-name: cybertecpostgresql/${{ matrix.image.name }}
+        registry: ${{ needs.prepare.outputs.registry }}
+        username: ${{ steps.creds.outputs.username }}
+        password: ${{ steps.creds.outputs.password }}
+        platforms: linux/amd64,linux/arm64
+        push: ${{ needs.prepare.outputs.should-push }}
+        cache-scope: ${{ needs.prepare.outputs.registry }}-${{ matrix.image.name }}
+        build-args: |
+          GIT_HASH=${{ steps.meta.outputs.GIT_HASH }}
+          GIT_TIME=${{ steps.meta.outputs.GIT_TIME }}
+          VERSION=${{ steps.meta.outputs.VERSION }}
+
+  summary:
+    name: Build Summary
+    needs: [prepare, docker]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report build results
+        run: |
+          echo "## 🐳 Docker Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Registry | \`${{ needs.prepare.outputs.registry }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Push Enabled | ${{ needs.prepare.outputs.should-push }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Trigger | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Ref | \`${{ github.ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Images | \`cybertecpostgresql/pgwatch\`, \`cybertecpostgresql/pgwatch-demo\` |" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ needs.docker.result }}" = "success" ]; then
+            echo "✅ All Docker builds completed successfully!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ Some Docker builds failed. Check the logs above." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         platforms: linux/amd64,linux/arm64
         push: ${{ steps.meta.outputs.SHOULD_PUSH }}
-        cache-scope: ${{ matrix.image.name }}
+        cache-scope: shared-release
         build-args: |
           GIT_HASH=${{ steps.meta.outputs.GIT_HASH }}
           GIT_TIME=${{ steps.meta.outputs.GIT_TIME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,9 @@
 name: Release
+
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types: [created]
@@ -40,75 +45,41 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker:
+    name: Build and Push Docker Images
     if: true # false to skip job during debug
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         image: [ 
-          {file: 'Dockerfile', prefix: ''}, 
-          {file: 'demo/Dockerfile', prefix: '-demo'}
+          {file: 'docker/Dockerfile', name: 'cybertecpostgresql/pgwatch'}, 
+          {file: 'docker/demo/Dockerfile', name: 'cybertecpostgresql/pgwatch-demo'}
         ]
     runs-on: ubuntu-latest
     steps:
 
-    - name: Check out code
+    - name: Check out source code
       uses: actions/checkout@v4
 
-    - name: Version strings
-      id: version
+    - name: Prepare build metadata
+      id: meta
       run: |
-        echo "RELEASE_TIME=$(git show -s --format=%cI HEAD)" >> $GITHUB_OUTPUT
+        echo "GIT_HASH=${{ github.sha }}" >> $GITHUB_OUTPUT
+        echo "GIT_TIME=$(git show -s --format=%cI HEAD)" >> $GITHUB_OUTPUT
+        echo "VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+        echo "SHOULD_PUSH=${{ github.ref_type == 'tag' }}" >> $GITHUB_OUTPUT
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3  
-
-    - name: Publish beta version to Registry
-      if: ${{ contains(github.ref_name, 'beta') }}
-      uses: elgohr/Publish-Docker-Github-Action@v5
-      env:
-        GIT_HASH: ${{ github.sha }}
-        VERSION: ${{ github.ref_name }}
-        GIT_TIME: ${{ steps.version.outputs.RELEASE_TIME }}     
+    - name: Build and push Docker image
+      uses: ./.github/actions/build-docker
       with:
-        name: cybertecpostgresql/pgwatch${{ matrix.image.prefix }}
+        dockerfile: ${{ matrix.image.file }}
+        image-name: ${{ matrix.image.name }}
+        registry: docker.io
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: docker/${{ matrix.image.file }}
-        buildargs: GIT_HASH,GIT_TIME
-        tags: ${{ github.ref_name }}
         platforms: linux/amd64,linux/arm64
-
-    - name: Publish "latest" tag to Registry
-      if: ${{ !contains(github.ref_name, 'beta') }}
-      uses: elgohr/Publish-Docker-Github-Action@v5
-      env:
-        GIT_HASH: ${{ github.sha }}
-        VERSION: ${{ github.ref_name }}
-        GIT_TIME: ${{ steps.version.outputs.RELEASE_TIME }}     
-      with:
-        name: cybertecpostgresql/pgwatch${{ matrix.image.prefix }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: docker/${{ matrix.image.file }}
-        buildargs: GIT_HASH,GIT_TIME
-        tags: latest
-        platforms: linux/amd64,linux/arm64
-
-    - name: Publish "X.X.X, X.X, X" tags to Registry
-      if: ${{ !contains(github.ref_name, 'beta') }}
-      uses: elgohr/Publish-Docker-Github-Action@v5
-      env:
-        GIT_HASH: ${{ github.sha }}
-        VERSION: ${{ github.ref_name }}
-        GIT_TIME: ${{ steps.version.outputs.RELEASE_TIME }}     
-      with:
-        name: cybertecpostgresql/pgwatch${{ matrix.image.prefix }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: docker/${{ matrix.image.file }}
-        buildargs: GIT_HASH,GIT_TIME
-        tag_semver: true
-        platforms: linux/amd64,linux/arm64      
+        push: ${{ steps.meta.outputs.SHOULD_PUSH }}
+        cache-scope: ${{ matrix.image.name }}
+        build-args: |
+          GIT_HASH=${{ steps.meta.outputs.GIT_HASH }}
+          GIT_TIME=${{ steps.meta.outputs.GIT_TIME }}
+          VERSION=${{ steps.meta.outputs.VERSION }}      

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,40 +1,67 @@
-# ----------------------------------------------------------------
-# 1. Build Web UI
-# ----------------------------------------------------------------
-FROM node:22 AS uibuilder
-ADD internal/webui /webui
-RUN cd webui && yarn install --network-timeout 100000 && yarn build
+# ================================================================
+# PRODUCTION PGWATCH IMAGE - OPTIMIZED VERSION
+# Uses shared base stages for faster builds and better caching
+# ================================================================
 
 # ----------------------------------------------------------------
-# 2. Build gatherer
+# 1. WebUI Dependencies (cached separately for better performance)
 # ----------------------------------------------------------------
-FROM golang:1.24 AS builder
+FROM node:22 AS webui-deps
+WORKDIR /webui
+# Copy only package files first for optimal layer caching
+COPY internal/webui/package.json internal/webui/yarn.lock ./
+RUN yarn install --network-timeout 100000 --frozen-lockfile
 
-ARG VERSION
-ARG GIT_HASH
-ARG GIT_TIME
+# ----------------------------------------------------------------
+# 2. WebUI Builder (rebuilds only when source changes)
+# ----------------------------------------------------------------
+FROM webui-deps AS webui-builder
+# Copy source files and build
+COPY internal/webui/ ./
+RUN yarn build
 
+# ----------------------------------------------------------------
+# 3. Go Dependencies and Tools (cached separately)
+# ----------------------------------------------------------------
+FROM golang:1.24 AS go-deps
 # Install protoc and required tools for protobuf generation
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
-COPY . /pgwatch
-COPY --from=uibuilder /webui/build /pgwatch/internal/webui/build
-RUN cd /pgwatch \
-    && go generate ./api/pb/ \
-    && CGO_ENABLED=0 go build -ldflags "\
+# Pre-download Go modules for better caching
+WORKDIR /pgwatch
+COPY go.mod go.sum ./
+RUN go mod download
+
+# ----------------------------------------------------------------
+# 4. Go Builder (application compilation)
+# ----------------------------------------------------------------
+FROM go-deps AS go-builder
+
+ARG VERSION
+ARG GIT_HASH
+ARG GIT_TIME
+
+# Copy source code
+COPY . .
+# Copy built WebUI from previous stage
+COPY --from=webui-builder /webui/build ./internal/webui/build
+
+# Generate protobuf and build the application
+RUN go generate ./api/pb/ && \
+    CGO_ENABLED=0 go build -ldflags "\
         -X 'main.commit=${GIT_HASH}' \
         -X 'main.date=${GIT_TIME}' \
         -X 'main.version=${VERSION}'" ./cmd/pgwatch
 
 # ----------------------------------------------------------------
-# 3. Build the final image
+# 5. Final production image
 # ----------------------------------------------------------------
 FROM alpine
 
 # Copy over the compiled gatherer
-COPY --from=builder /pgwatch/pgwatch /pgwatch/
+COPY --from=go-builder /pgwatch/pgwatch /pgwatch/
 COPY internal/metrics/metrics.yaml /pgwatch/metrics/metrics.yaml
 
 # Admin UI for configuring servers to be monitored

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -1,40 +1,67 @@
-# ----------------------------------------------------------------
-# 1. Build Web UI
-# ----------------------------------------------------------------
-FROM node:22 AS uibuilder
-COPY internal/webui /webui
-RUN cd webui && yarn install --network-timeout 100000 && yarn build
+# ================================================================
+# DEMO PGWATCH IMAGE - OPTIMIZED VERSION
+# Uses shared base stages + PostgreSQL/Grafana demo setup
+# ================================================================
 
 # ----------------------------------------------------------------
-# 2. Build gatherer
+# 1. WebUI Dependencies (cached separately for better performance)
 # ----------------------------------------------------------------
-FROM golang:1.24 AS builder
+FROM node:22 AS webui-deps
+WORKDIR /webui
+# Copy only package files first for optimal layer caching
+COPY internal/webui/package.json internal/webui/yarn.lock ./
+RUN yarn install --network-timeout 100000 --frozen-lockfile
 
-ARG VERSION
-ARG GIT_HASH
-ARG GIT_TIME
+# ----------------------------------------------------------------
+# 2. WebUI Builder (rebuilds only when source changes)
+# ----------------------------------------------------------------
+FROM webui-deps AS webui-builder
+# Copy source files and build
+COPY internal/webui/ ./
+RUN yarn build
 
+# ----------------------------------------------------------------
+# 3. Go Dependencies and Tools (cached separately)
+# ----------------------------------------------------------------
+FROM golang:1.24 AS go-deps
 # Install protoc and required tools for protobuf generation
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
-COPY . /pgwatch
-COPY --from=uibuilder /webui/build /pgwatch/internal/webui/build
-RUN cd /pgwatch \
-    && go generate ./api/pb/ \
-    && CGO_ENABLED=0 go build -ldflags "\
+# Pre-download Go modules for better caching
+WORKDIR /pgwatch
+COPY go.mod go.sum ./
+RUN go mod download
+
+# ----------------------------------------------------------------
+# 4. Go Builder (application compilation)
+# ----------------------------------------------------------------
+FROM go-deps AS go-builder
+
+ARG VERSION
+ARG GIT_HASH
+ARG GIT_TIME
+
+# Copy source code
+COPY . .
+# Copy built WebUI from previous stage
+COPY --from=webui-builder /webui/build ./internal/webui/build
+
+# Generate protobuf and build the application
+RUN go generate ./api/pb/ && \
+    CGO_ENABLED=0 go build -ldflags "\
         -X 'main.commit=${GIT_HASH}' \
         -X 'main.date=${GIT_TIME}' \
         -X 'main.version=${VERSION}'" ./cmd/pgwatch
         
 # ----------------------------------------------------------------
-# 3. Build the final image
+# 5. Demo Image with PostgreSQL + Grafana
 # ----------------------------------------------------------------
-FROM postgres:17-bullseye AS releaser
+FROM postgres:17-bullseye AS demo
 
 # Copy over the compiled gatherer
-COPY --from=builder /pgwatch/pgwatch /pgwatch/
+COPY --from=go-builder /pgwatch/pgwatch /pgwatch/
 COPY internal/metrics/metrics.yaml /pgwatch/metrics/metrics.yaml
 
 # Install TimescaleDB and extensions


### PR DESCRIPTION
- use official Docker actions (`docker/build-push-action@v5`, `docker/metadata-action@v5`, etc.)
- automatic SemVer tagging with `docker/metadata-action`
- test builds without registry authentication
- add custom Docker Manual Multi-Registry Build action and reuse it