### PR TITLE
[*] fix `updateSources()` query parameters number

### DIFF
--- a/internal/sources/postgres.go
+++ b/internal/sources/postgres.go
@@ -67,7 +67,7 @@ func (r *dbSourcesReaderWriter) updateSource(conn db.PgxIface, md Source) (err e
 	only_if_master,
 	is_enabled) 
 values 
-	($1, $2, $3, $4, $5, $6, NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13, $14) 
+	($1, $2, $3, $4, $5, $6, NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13)
 on conflict (name) do update set
 	"group" = $2, 
 	dbtype = $3, 


### PR DESCRIPTION
- Change number of sql query parameters in `updateSources()` to be `13` not `14` 
---
After removing `host_config` from sources in #859 `updateSources()` sql query should take `13` parameters not `14`. 
currently any sources update gives the following error:
```
[err:ERROR: INSERT has more expressions than target columns (SQLSTATE 42601)] [pid:39828] [time:686.266µs] Query
```