### PR TITLE
[+] allow metrics loading from folder, closes #882

### DIFF
--- a/internal/metrics/yaml.go
+++ b/internal/metrics/yaml.go
@@ -69,7 +69,7 @@ func (fmr *fileMetricReader) GetMetrics() (metrics *Metrics, err error) {
 	return
 }
 
-func (fcr *fileMetricReader) getMetrics(metricsFilePath string) (metrics *Metrics, err error) {
+func (fmr *fileMetricReader) getMetrics(metricsFilePath string) (metrics *Metrics, err error) {
 	var yamlFile []byte
 	if yamlFile, err = os.ReadFile(metricsFilePath); err != nil {
 		return

--- a/internal/metrics/yaml.go
+++ b/internal/metrics/yaml.go
@@ -48,7 +48,7 @@ func (fmr *fileMetricReader) GetMetrics() (*Metrics, error) {
 }
 
 // Loads a Metrics struct from a file or a folder of YAML files
-// located at the file metric reader path.
+// located at the fileMetricReader path.
 func (fmr *fileMetricReader) loadMetricsFromYaml() (*Metrics, error) {
 	fi, err := os.Stat(fmr.path)
 	if err != nil {

--- a/internal/sources/resolver_test.go
+++ b/internal/sources/resolver_test.go
@@ -56,7 +56,7 @@ func TestMonitoredDatabase_ResolveDatabasesFromPostgres(t *testing.T) {
 func TestMonitoredDatabase_ResolveDatabasesFromPatroni(t *testing.T) {
 	etcdContainer, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14",
 		testcontainers.WithWaitStrategy(wait.ForLog("ready to serve client requests").
-			WithStartupTimeout(5*time.Second)))
+			WithStartupTimeout(15*time.Second)))
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, etcdContainer.Terminate(ctx)) }()
 

--- a/internal/sources/yaml.go
+++ b/internal/sources/yaml.go
@@ -80,8 +80,8 @@ func (fcr *fileSourcesReaderWriter) GetSources() (dbs Sources, err error) {
 			if err != nil {
 				return err
 			}
-			name := strings.ToLower(d.Name())
-			if d.IsDir() || !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			ext := strings.ToLower(filepath.Ext(d.Name()))
+			if d.IsDir() || ext != ".yaml" && ext != ".yml" {
 				return nil
 			}
 			var mdbs Sources


### PR DESCRIPTION
add `loadMetricsFromYaml()` to load metrics from file or folder of yaml files
  - read single yaml file or all yaml files in folder, unmarshal it/them, then copy it/them to the global `metrics.MetricDefs` and `metrics.PresetDefs` maps 
---
another PR that builds on top of this to make `Create[Metric|Preset]()`, `Update[Metric|Preset]()`, `Delete[Metric|Preset]()` functions handle metrics folder will be provided.        



closes: #882  