### PR TITLE
[-] do not fail on db resolve error, just log an error, fixes #890

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -384,7 +384,7 @@ func (r *Reaper) LoadSources() (err error) {
 		return !s.IsEnabled || len(r.Sources.Groups) > 0 && !s.IsDefaultGroup() && !slices.Contains(r.Sources.Groups, s.Group)
 	})
 	if newSrcs, err = srcs.ResolveDatabases(); err != nil {
-		return err
+		r.logger.WithError(err).Error("could not resolve databases from sources")
 	}
 
 	for i, newMD := range newSrcs {


### PR DESCRIPTION
If some source is not available for resolving then it blocks all other sources. So just log the error and proceed with sources available at the moment. Re-sync on the next iteration.