### PR TITLE
[+] improve recommendation metrics,  #764

### DIFF
--- a/contrib/sample.metrics.yaml
+++ b/contrib/sample.metrics.yaml
@@ -19,7 +19,7 @@
 #        is_instance_level: true
 #        node_status: primary
 #        statement_timeout_seconds: 300
-#        metric_storage_name: optional_metric_storage_name
+#        storage_name: optional_metric_storage_name
 # presets:
 #    preset_name:
 #        description: custom preset for some metrics
@@ -61,7 +61,7 @@ metrics:
     gauges:
       - '*'
     is_instance_level: false
-    metric_storage_name: buffer_cache_hit_ratio
+    storage_name: buffer_cache_hit_ratio
 presets:
   default:
     description: minimal example preset

--- a/docker/compose.pgwatch.yml
+++ b/docker/compose.pgwatch.yml
@@ -8,6 +8,7 @@ services:
     container_name: pgwatch
     environment:
       PW_SOURCES: postgresql://pgwatch@postgres:5432/pgwatch
+      # PW_METRICS: /etc/pgwatch/metrics.yml
     command:
       - "--sink=postgresql://pgwatch@postgres:5432/pgwatch_metrics"
       - "--sink=prometheus://pgwatch:9187/pgwatch"
@@ -15,6 +16,8 @@ services:
       - "8080:8080"
       - "9187:9187"
       # - "6060:6060" # Uncomment for profiling
+    volumes:
+      - "../internal/metrics/metrics.yaml:/etc/pgwatch/metrics.yml"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/compose.postgres.yml
+++ b/docker/compose.postgres.yml
@@ -11,7 +11,7 @@ services:
     image: &pgimage postgres-plpython3u:latest
     container_name: postgres
     command:
-      - "-cshared_preload_libraries=pg_stat_statements"
+      - "-cshared_preload_libraries=pg_stat_statements,pg_qualstats"
       - "-cpg_stat_statements.track=all"
       - "-cpg_stat_statements.track_planning=on"
       - "-ctrack_io_timing=on"

--- a/docs/reference/metric_definitions.md
+++ b/docs/reference/metric_definitions.md
@@ -136,7 +136,7 @@ Here is the structure of a metric definition in YAML format:
         is_instance_level: true
         node_status: primary/standby
         statement_timeout_seconds: 300
-        metric_storage_name: some_other_metric_name
+        storage_name: some_other_metric_name
 ```
 
 - *init_sql*
@@ -199,7 +199,7 @@ Here is the structure of a metric definition in YAML format:
     The maximum time in seconds the metric query is allowed to run
     before it's killed. The default is 5 seconds.
 
-- *metric_storage_name*
+- *storage_name*
 
     Enables dynamic "renaming" of metrics at the storage level, i.e.
     declaring almost similar metrics with different names, but the data

--- a/grafana/postgres/v12/recommendations.json
+++ b/grafana/postgres/v12/recommendations.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 15,
+  "id": 26,
   "links": [],
   "panels": [
     {
@@ -27,7 +27,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "pgwatch-metrics"
       },
-      "description": "More than 10 superusers is already suspicious",
+      "description": "All database recommendations from automated analysis",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -36,9 +36,10 @@
           "custom": {
             "align": "auto",
             "cellOptions": {
-              "type": "auto"
+              "type": "auto",
+              "wrapText": false
             },
-            "inspect": false
+            "inspect": true
           },
           "mappings": [],
           "thresholds": {
@@ -59,38 +60,108 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Time"
+              "options": "Database"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "Time"
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Category"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
               },
               {
-                "id": "unit",
-                "value": "time: YYYY-MM-DD HH:mm:ss"
-              },
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "add_index": {
+                        "text": "Missing Indexes"
+                      },
+                      "create_index": {
+                        "text": "Missing Indexes"
+                      },
+                      "default_public_schema_privs": {
+                        "text": "Security: Public Schema"
+                      },
+                      "disabled_triggers": {
+                        "text": "Disabled Triggers"
+                      },
+                      "drop_index": {
+                        "text": "Unused Indexes"
+                      },
+                      "overly_nested_views": {
+                        "text": "Complex Views"
+                      },
+                      "partial_index_candidates": {
+                        "text": "Partial Index Opportunities"
+                      },
+                      "sprocs_wo_search_path": {
+                        "text": "Security: Search Path"
+                      },
+                      "superuser_count": {
+                        "text": "Security: Superusers"
+                      },
+                      "superusers": {
+                        "text": "Security: Superusers"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Objects"
+            },
+            "properties": [
               {
-                "id": "custom.align"
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recommendation"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
               }
             ]
           }
         ]
       },
       "gridPos": {
-        "h": 5,
+        "h": 20,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 3,
+      "id": 1,
       "options": {
-        "cellHeight": "sm",
+        "cellHeight": "md",
         "footer": {
-          "countRows": false,
+          "countRows": true,
+          "enablePagination": false,
           "fields": "",
           "reducer": [
-            "sum"
+            "count"
           ],
           "show": false
         },
@@ -108,7 +179,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  data->>'major_ver' AS pg_major_ver,\n  tag_data->>'object_name' AS object_name,\n  data->>'recommendation' AS recommendation,\n  data->>'extra_info' AS extra_info\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname)\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' = 'superuser_count'\nORDER BY\n  dbname, object_name",
+          "rawSql": "SELECT\n  dbname AS \"Source\",\n  tag_data->>'reco_topic' AS \"Category\",\n  tag_data->>'object_name' AS \"Objects\",\n  data->>'recommendation' AS \"Recommendation\",\n  data->>'extra_info' AS \"Additional Info\"\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname, tag_data->>'reco_topic')\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' IS NOT NULL\nORDER BY\n  dbname, tag_data->>'reco_topic'",
           "refId": "A",
           "select": [
             [
@@ -147,7 +218,7 @@
           ]
         }
       ],
-      "title": "Overusage of SUPERUSER",
+      "title": "Database Recommendations",
       "transformations": [
         {
           "id": "merge",
@@ -217,125 +288,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 5
-      },
-      "id": 4,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "pgwatch-metrics"
-          },
-          "format": "table",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  '-' AS pg_major_ver,\n  '-' AS object_name,\n  'long running queries block autovacuum and thereby cause bloat' AS recommendation,\n  'longest_query_seconds: '|| max((data->>'longest_query_seconds')::int)::text AS extra_info\nFROM\n  backends\nWHERE\n  $__timeFilter(time)\n  AND dbname IN ($dbname)\n  AND (data->>'longest_query_seconds')::int > 6\nGROUP BY\n  dbname\nORDER BY\n  max((data->>'longest_query_seconds')::int) DESC NULLS LAST, dbname",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "title": "Overly long queries",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "pgwatch-metrics"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Time"
-              },
-              {
-                "id": "unit",
-                "value": "time: YYYY-MM-DD HH:mm:ss"
-              },
-              {
-                "id": "custom.align"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 10
+        "y": 20
       },
       "id": 10,
       "options": {
@@ -357,11 +310,12 @@
             "type": "grafana-postgresql-datasource",
             "uid": "pgwatch-metrics"
           },
+          "editorMode": "code",
           "format": "table",
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  (select data->>'server_version' from settings s where s.dbname = x.dbname order by time desc limit 1) AS pg_major_ver,\n  'autovacuum_max_workers' as object_name,\n  'if most / all autovacuum worker slots are busy or AV runs for hourse then this could hint at incorrect AV params or too much workload' as recommendation,\n  'max. active autovacuum workers: ' || max_av_workers || ' (of total ' || (select (data->>'autovacuum_max_workers')::int from settings s where s.dbname = x.dbname order by time desc limit 1) || '); max. AV duration (seconds): ' || longest_autovacuum_seconds as extra_info\nFROM (\nSELECT\n  dbname,\n  max((data->>'av_workers')::int) as max_av_workers,\n  coalesce(max((data->>'longest_autovacuum_seconds')::int), 0) as longest_autovacuum_seconds\nFROM\n  backends\nWHERE\n  $__timeFilter(time)\n  AND dbname IN ($dbname)\nGROUP BY\n  dbname\n) x\nWHERE\n  (max_av_workers > 1 AND max_av_workers::numeric / (select (data->>'autovacuum_max_workers')::int from settings s where s.dbname = x.dbname order by time desc limit 1)  >= 0.6)\n  OR\n  (longest_autovacuum_seconds > 1800)",
+          "rawSql": "SELECT\n  dbname AS \"Source\",\n  (select data->>'server_version' from settings s where s.dbname = x.dbname order by time desc limit 1) AS \"PostgreSQL Version\",\n  'AUTOVACUUM Workers' AS \"Category\",\n  'If most / all autovacuum worker slots are busy or AV runs for hours then this could hint at incorrect AV params or too much workload' AS \"Recommendation\",\n  'Max. active autovacuum workers: ' || max_av_workers || ' (of total ' || (select (data->>'autovacuum_max_workers')::int from settings s where s.dbname = x.dbname order by time desc limit 1) || '); Max. AV duration (seconds): ' || longest_autovacuum_seconds AS \"Additional Info\"\nFROM (\nSELECT\n  dbname,\n  max((data->>'av_workers')::int) as max_av_workers,\n  coalesce(max((data->>'longest_autovacuum_seconds')::int), 0) as longest_autovacuum_seconds\nFROM\n  backends\nWHERE\n  $__timeFilter(time)\n  AND dbname IN ($dbname)\nGROUP BY\n  dbname\n) x\nWHERE\n  (max_av_workers > 1 AND max_av_workers::numeric / (select (data->>'autovacuum_max_workers')::int from settings s where s.dbname = x.dbname order by time desc limit 1)  >= 0.6)\n  OR\n  (longest_autovacuum_seconds > 1800)",
           "refId": "A",
           "select": [
             [
@@ -373,6 +327,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "time",
           "where": [
             {
@@ -453,281 +424,9 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 15
-      },
-      "id": 5,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "pgwatch-metrics"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  data->>'major_ver' AS pg_major_ver,\n  tag_data->>'object_name' AS object_name,\n  data->>'recommendation' AS recommendation,\n  data->>'extra_info' AS extra_info\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname)\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' = 'sprocs_wo_search_path'\nORDER BY\n  dbname, object_name",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          },
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "title": "SECURITY DEFINER without fixed \"search_path\"",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "pgwatch-metrics"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Time"
-              },
-              {
-                "id": "unit",
-                "value": "time: YYYY-MM-DD HH:mm:ss"
-              },
-              {
-                "id": "custom.align"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 6,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "pgwatch-metrics"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  data->>'major_ver' AS pg_major_ver,\n  tag_data->>'object_name' AS object_name,\n  data->>'recommendation' AS recommendation,\n  data->>'extra_info' AS extra_info\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname)\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' = 'default_public_schema_privs'\nORDER BY\n  dbname, object_name",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          },
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "title": "PUBLIC schemas with default privileges",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "pgwatch-metrics"
-      },
-      "description": "Assumes that \"pg_qualstats\" extension and superuser or according access grants on the monitored host",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Time"
-              },
-              {
-                "id": "unit",
-                "value": "time: YYYY-MM-DD HH:mm:ss"
-              },
-              {
-                "id": "custom.align"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
         "y": 25
       },
-      "id": 7,
+      "id": 4,
       "options": {
         "cellHeight": "sm",
         "footer": {
@@ -752,7 +451,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  data->>'major_ver' AS pg_major_ver,\n  tag_data->>'object_name' AS object_name,\n  data->>'recommendation' AS recommendation,\n  data->>'extra_info' AS extra_info\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname)\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' = 'create_index'\nORDER BY\n  dbname, object_name",
+          "rawSql": "SELECT\n  dbname AS \"Source\",\n  'Performance Issue' AS \"Category\",\n  'Long Running Queries' AS \"Objects\",\n  'Long running queries block autovacuum and thereby cause bloat' AS \"Recommendation\",\n  'Longest query duration: '|| max((data->>'longest_query_seconds')::int)::text || ' seconds' AS \"Additional Info\"\nFROM\n  backends\nWHERE\n  $__timeFilter(time)\n  AND dbname IN ($dbname)\n  AND (data->>'longest_query_seconds')::int > 0\nGROUP BY\n  dbname\nORDER BY\n  max((data->>'longest_query_seconds')::int) DESC NULLS LAST, dbname",
           "refId": "A",
           "select": [
             [
@@ -791,415 +490,7 @@
           ]
         }
       ],
-      "title": "Possibly missing indexes",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "pgwatch-metrics"
-      },
-      "description": "Unused indexes bigger than 0.5% of total DB size",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Time"
-              },
-              {
-                "id": "unit",
-                "value": "time: YYYY-MM-DD HH:mm:ss"
-              },
-              {
-                "id": "custom.align"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 30
-      },
-      "id": 8,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "pgwatch-metrics"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  data->>'major_ver' AS pg_major_ver,\n  tag_data->>'object_name' AS object_name,\n  data->>'recommendation' AS recommendation,\n  data->>'extra_info' AS extra_info\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname)\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' = 'drop_index'\nORDER BY\n  dbname, object_name",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          },
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "title": "Unused indexes",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "pgwatch-metrics"
-      },
-      "description": "A lot of space / performance can be won on replacing columns that contain mostly NULL-s but are  fully indexed with partial indexes, leaving out NULL-s",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Time"
-              },
-              {
-                "id": "unit",
-                "value": "time: YYYY-MM-DD HH:mm:ss"
-              },
-              {
-                "id": "custom.align"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 12,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "pgwatch-metrics"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  data->>'major_ver' AS pg_major_ver,\n  tag_data->>'object_name' AS object_name,\n  data->>'recommendation' AS recommendation,\n  data->>'extra_info' AS extra_info\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname)\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' = 'partial_index_candidates'\nORDER BY\n  dbname, object_name",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          },
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "title": "Partial index suggestions",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "pgwatch-metrics"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Time"
-              },
-              {
-                "id": "unit",
-                "value": "time: YYYY-MM-DD HH:mm:ss"
-              },
-              {
-                "id": "custom.align"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 40
-      },
-      "id": 2,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "pgwatch-metrics"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  data->>'major_ver' AS pg_major_ver,\n  tag_data->>'object_name' AS object_name,\n  data->>'recommendation' AS recommendation,\n  data->>'extra_info' AS extra_info\nFROM\n  $table_name\nWHERE\n  time IN (SELECT max(time) FROM $table_name WHERE $__timeFilter(time) GROUP BY dbname)\n  AND dbname IN ($dbname)\n  AND tag_data->>'reco_topic' = 'overly_nested_views'\nORDER BY\n  dbname, object_name",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          },
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "title": "Deeply nested views",
+      "title": "Overly long queries",
       "transformations": [
         {
           "id": "merge",
@@ -1269,7 +560,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 30
       },
       "id": 11,
       "options": {
@@ -1291,11 +582,12 @@
             "type": "grafana-postgresql-datasource",
             "uid": "pgwatch-metrics"
           },
+          "editorMode": "code",
           "format": "table",
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  dbname,\n  (select data->>'server_version' from settings s where s.dbname = y.dbname order by s.time desc limit 1) as pg_major_ver,\n  'global server settings' as object_name,\n  'Increase checkpoint_timeout or max_wal_size for more infrequent checkpoints, thereby reducing total IO' AS recommendation,\n  'avg. seconds between checkpoint requests: ' || avg_seconds_between_checkpoints_reqs::int8 as extra_info\nFROM (\nSELECT\n  dbname,\n  round((extract(epoch from max_time - min_time) / (max_req - min_req))::numeric, 1) as avg_seconds_between_checkpoints_reqs\nFROM (\n  SELECT\n    dbname,\n    min(time) as min_time,\n    max(time) as max_time,\n    min((data->>'checkpoints_req')::int8) as min_req,\n    max((data->>'checkpoints_req')::int8) as max_req\n  FROM\n    bgwriter\n  WHERE\n    $__timeFilter(time)\n  AND dbname IN ($dbname)\nGROUP BY\n  dbname\nHAVING\n  max((data->>'checkpoints_req')::int8) > min((data->>'checkpoints_req')::int8)\n) x\n) y\nWHERE\n  avg_seconds_between_checkpoints_reqs < (select extract(epoch from (data->>'checkpoint_timeout')::interval) / 2.0 from settings s where s.dbname = y.dbname order by s.time desc limit 1)\nORDER BY\n  avg_seconds_between_checkpoints_reqs\nLIMIT\n  25",
+          "rawSql": "SELECT\n  dbname AS \"Source\",\n  (select data->>'server_version' from settings s where s.dbname = y.dbname order by s.time desc limit 1) AS \"PostgreSQL Version\",\n  'Global Server Settings' AS \"Category\",\n  'Increase checkpoint_timeout or max_wal_size for more infrequent checkpoints, thereby reducing total IO' AS \"Recommendation\",\n  'Avg. seconds between checkpoint requests: ' || avg_seconds_between_checkpoints_reqs::int8 AS \"Additional Info\"\nFROM (\nSELECT\n  dbname,\n  round((extract(epoch from max_time - min_time) / (max_req - min_req))::numeric, 1) as avg_seconds_between_checkpoints_reqs\nFROM (\n  SELECT\n    dbname,\n    min(time) as min_time,\n    max(time) as max_time,\n    min((data->>'checkpoints_req')::int8) as min_req,\n    max((data->>'checkpoints_req')::int8) as max_req\n  FROM\n    bgwriter\n  WHERE\n    $__timeFilter(time)\n  AND dbname IN ($dbname)\nGROUP BY\n  dbname\nHAVING\n  max((data->>'checkpoints_req')::int8) > min((data->>'checkpoints_req')::int8)\n) x\n) y\nWHERE\n  avg_seconds_between_checkpoints_reqs < (select extract(epoch from (data->>'checkpoint_timeout')::interval) / 2.0 from settings s where s.dbname = y.dbname order by s.time desc limit 1)\nORDER BY\n  avg_seconds_between_checkpoints_reqs\nLIMIT\n  25",
           "refId": "A",
           "select": [
             [
@@ -1307,6 +599,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "time",
           "where": [
             {
@@ -1338,7 +647,7 @@
         "h": 4,
         "w": 9,
         "x": 0,
-        "y": 50
+        "y": 35
       },
       "id": 9,
       "options": {
@@ -1377,6 +686,7 @@
         },
         "definition": "SELECT DISTINCT dbname FROM admin.all_distinct_dbname_metrics ORDER BY 1;",
         "includeAll": true,
+        "label": "Monitored Source",
         "multi": true,
         "name": "dbname",
         "options": [],
@@ -1409,5 +719,5 @@
   "timezone": "",
   "title": "Recommendations",
   "uid": "recommendations",
-  "version": 1
+  "version": 22
 }

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -19,7 +19,7 @@
 #        is_instance_level: true
 #        node_status: primary
 #        statement_timeout_seconds: 300
-#        metric_storage_name: db_stats
+#        storage_name: db_stats
 
 metrics:
     archiver:
@@ -485,7 +485,7 @@ metrics:
                   ) as catalog_size_b
         gauges:
             - '*'
-        metric_storage_name: db_size
+        storage_name: db_size
     db_stats:
         description: >
             Retrieves key statistics from the PostgreSQL `pg_stat_database` view, providing insights into the current database's performance.
@@ -748,7 +748,7 @@ metrics:
             - postmaster_uptime_s
             - backup_duration_s
             - checksum_last_failure_s
-        metric_storage_name: db_stats
+        storage_name: db_stats
     index_hashes:
         description: >
             Retrieves the hash of index definitions in the PostgreSQL database, providing a way to track changes in index definitions over time.
@@ -1553,7 +1553,7 @@ metrics:
         init_sql: "CREATE EXTENSION IF NOT EXISTS pg_qualstats;"
         node_status: primary
         is_private: true
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     reco_default_public_schema:
         description: >
             Retrieves recommendations for revoking the CREATE privilege on the public schema from PUBLIC.
@@ -1583,7 +1583,7 @@ metrics:
                 from rr, last_reco
                 where tag_object_name > '';
         node_status: primary
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     reco_disabled_triggers:
         description: >
             Retrieves recommendations for reviewing and potentially dropping disabled triggers in the PostgreSQL database.
@@ -1614,7 +1614,7 @@ metrics:
                 from rr, last_reco
                 where tag_object_name > '';
         node_status: primary
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     reco_drop_index:
         description: >
             Retrieves recommendations for dropping unused or invalid indexes in the PostgreSQL database.
@@ -1656,7 +1656,7 @@ metrics:
                 where tag_object_name > '';
         init_sql: "CREATE EXTENSION IF NOT EXISTS pg_qualstats;"
         node_status: primary
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     reco_nested_views:
         description: >
             Retrieves recommendations for overly nested views in the PostgreSQL database.
@@ -1732,7 +1732,7 @@ metrics:
                 from rr, last_reco
                 where tag_object_name > '';
         node_status: primary
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     reco_partial_index_candidates:
         description: >
             Retrieves recommendations for creating partial indexes on columns with a high fraction of NULL values.
@@ -1775,7 +1775,7 @@ metrics:
                     extra_info
                 from rr, last_reco
                 where tag_object_name > '';
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     reco_sprocs_wo_search_path:
         description: >
             Retrieves recommendations for stored procedures that do not have a fixed `search_path` set.
@@ -1807,7 +1807,7 @@ metrics:
                 from rr, last_reco
                 where tag_object_name > '';
         node_status: primary
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     reco_superusers:
         description: >
             Retrieves recommendations for reviewing the number of superusers in the PostgreSQL database.
@@ -1831,7 +1831,7 @@ metrics:
                 where
                   r.su >= 10
         node_status: primary
-        metric_storage_name: "recommendations"
+        storage_name: "recommendations"
     replication:
         description: >
             This metric collects replication statistics from the `pg_stat_replication` view.
@@ -3242,7 +3242,7 @@ metrics:
                     temp_blks_written desc
                   limit 100
                 ) a;
-        metric_storage_name: stat_statements
+        storage_name: stat_statements
     subscription_stats:
         description: >
             This metric collects statistics from the `pg_stat_subscription_stats` view, which provides information about the status of logical replication subscriptions.
@@ -4369,7 +4369,7 @@ metrics:
             - seconds_since_last_analyze
             - n_live_tup
             - n_dead_tup
-        metric_storage_name: table_stats
+        storage_name: table_stats
     unused_indexes:
         description: >
             This metric collects information about unused indexes in the database.

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -1528,25 +1528,28 @@ metrics:
             This metric helps administrators optimize database performance by suggesting index creation.
         sqls:
             11: |-
-                select /* pgwatch_generated */
-                  epoch_ns,
-                  tag_reco_topic,
-                  tag_object_name,
-                  recommendation,
-                  case when exists (select * from pg_inherits
-                                    where inhrelid = regclass(tag_object_name)
-                                    ) then 'Partitioned table, create the index on parent' else extra_info
-                  end as extra_info
-                FROM (
-                         SELECT (extract(epoch from now()) * 1e9)::int8    as epoch_ns,
-                                'create_index'::text                       as tag_reco_topic,
-                                (regexp_matches(v::text, E'ON (.*?) '))[1] as tag_object_name,
-                                v::text                                    as recommendation,
-                                ''                                         as extra_info
-                         FROM json_array_elements(
-                                      pg_qualstats_index_advisor() -> 'indexes') v
-                     ) x
-                ORDER BY tag_object_name
+                with r as (select /* pgwatch_generated */
+                    (regexp_matches(v::text, E'ON (.*?) '))[1] as object_name,
+                    v::text as recommendation
+                    from json_array_elements(pg_qualstats_index_advisor() -> 'indexes') v),
+                rr as (select
+                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                    'create_index'::text as tag_reco_topic,
+                    string_agg(object_name, ',') as tag_object_name,
+                    'create indexes for better query performance'::text as recommendation,
+                    'Use CREATE INDEX CONCURRENTLY <index_name> ON <table_name> (<columns>);'::text as extra_info
+                    from r 
+                    limit 50),
+                last_reco(s) as (
+                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                select 
+                    epoch_ns,
+                    tag_reco_topic,
+                    concat(tag_object_name, s) as tag_object_name,
+                    recommendation,
+                    extra_info
+                from rr, last_reco
+                where tag_object_name > '';
         init_sql: "CREATE EXTENSION IF NOT EXISTS pg_qualstats;"
         node_status: primary
         is_private: true
@@ -1557,17 +1560,28 @@ metrics:
             This metric helps enhance security by ensuring that only authorized users can create new objects in the public schema.
         sqls:
             11: |
-                select /* pgwatch_generated */
-                  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-                  'default_public_schema_privs'::text as tag_reco_topic,
-                  nspname::text as tag_object_name,
-                  'REVOKE CREATE ON SCHEMA public FROM PUBLIC;'::text as recommendation,
-                  'only authorized users should be allowed to create new objects'::text as extra_info
-                from
-                  pg_namespace
-                where
-                  nspname = 'public'
-                  and nspacl::text ~ E'[,\\{]+=U?C/'
+                with r as (select /* pgwatch_generated */
+                    nspname::text as object_name
+                    from pg_namespace
+                    where nspname = 'public' and nspacl::text ~ E'[,\\{]+=U?C/'),
+                rr as (select
+                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                    'default_public_schema_privs'::text as tag_reco_topic,
+                    string_agg(object_name, ',') as tag_object_name,
+                    'REVOKE CREATE ON SCHEMA public FROM PUBLIC;'::text as recommendation,
+                    'only authorized users should be allowed to create new objects'::text as extra_info
+                    from r 
+                    limit 50),
+                last_reco(s) as (
+                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                select 
+                    epoch_ns,
+                    tag_reco_topic,
+                    concat(tag_object_name, s) as tag_object_name,
+                    recommendation,
+                    extra_info
+                from rr, last_reco
+                where tag_object_name > '';
         node_status: primary
         metric_storage_name: "recommendations"
     reco_disabled_triggers:
@@ -1577,21 +1591,28 @@ metrics:
             This metric helps maintain database performance and reduce clutter by suggesting the removal of unused triggers.
         sqls:
             11: |
-                /* "temporarily" disabled triggers might be forgotten about... */
-                select /* pgwatch_generated */
+                with r as (select /* pgwatch_generated */
+                    c.oid 
+                    from pg_trigger t join pg_class c on c.oid = t.tgrelid
+                    where tgenabled = 'D'),
+                rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'disabled_triggers'::text as tag_reco_topic,
-                    quote_ident(nspname)||'.'||quote_ident(relname) as tag_object_name,
-                    'review usage of trigger and consider dropping it if not needed anymore'::text as recommendation,
-                    ''::text as extra_info
-                from
-                    pg_trigger t
-                    join
-                    pg_class c on c.oid = t.tgrelid
-                    join
-                    pg_namespace n on n.oid = c.relnamespace
-                where
-                    tgenabled = 'D'
+                    string_agg(oid::regclass::text, ',') as tag_object_name,
+                    'review usage of triggers and consider dropping them if not needed anymore'::text as recommendation,
+                    'Enable: ALTER TABLE <table_name> ENABLE TRIGGER <trigger_name>; Drop: DROP TRIGGER <trigger_name> ON <table_name>;'::text as extra_info
+                    from r 
+                    limit 50),
+                last_reco(s) as (
+                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                select 
+                    epoch_ns,
+                    tag_reco_topic,
+                    concat(tag_object_name, s) as tag_object_name,
+                    recommendation,
+                    extra_info
+                from rr, last_reco
+                where tag_object_name > '';
         node_status: primary
         metric_storage_name: "recommendations"
     reco_drop_index:
@@ -1601,29 +1622,38 @@ metrics:
             This metric helps administrators optimize database performance by suggesting the removal of unnecessary indexes.
         sqls:
             11: |
-                /* assumes the pg_qualstats extension */
                 with q_database_size as (
                   select pg_database_size(current_database()) as database_size_b
-                )
-                select /* pgwatch_generated */
-                  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-                  'drop_index'::text as tag_reco_topic,
-                  quote_ident(schemaname)||'.'||quote_ident(indexrelname) as tag_object_name,
-                  ('DROP INDEX ' || quote_ident(schemaname)||'.'||quote_ident(indexrelname) || ';')::text as recommendation,
-                  'Make sure to also check replica pg_stat_user_indexes.idx_scan count if using them for queries'::text as extra_info
-                from
-                  pg_stat_user_indexes
-                  join
-                  pg_index using (indexrelid)
-                  join
-                  q_database_size on true
-                where
-                  idx_scan = 0
-                  and ((pg_relation_size(indexrelid)::numeric / database_size_b) > 0.005 /* 0.5% DB size threshold */
-                    or indisvalid)
-                  and not indisprimary
-                  and not indisreplident
-                  and not schemaname like '_timescaledb%'
+                ),
+                r as (select /* pgwatch_generated */
+                    indexrelid::regclass::text as object_name
+                    from pg_stat_user_indexes
+                    join pg_index using (indexrelid)
+                    join q_database_size on true
+                    where idx_scan = 0
+                    and ((pg_relation_size(indexrelid)::numeric / database_size_b) > 0.005 /* 0.5% DB size threshold */
+                      or not indisvalid)
+                    and not indisprimary
+                    and not indisreplident
+                    and not schemaname like '_timescaledb%'),
+                rr as (select
+                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                    'drop_index'::text as tag_reco_topic,
+                    string_agg(object_name, ',') as tag_object_name,
+                    'drop unused or invalid indexes to improve performance'::text as recommendation,
+                    'Make sure to also check replica pg_stat_user_indexes.idx_scan count if using them for queries'::text as extra_info
+                    from r 
+                    limit 50),
+                last_reco(s) as (
+                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                select 
+                    epoch_ns,
+                    tag_reco_topic,
+                    concat(tag_object_name, s) as tag_object_name,
+                    recommendation,
+                    extra_info
+                from rr, last_reco
+                where tag_object_name > '';
         init_sql: "CREATE EXTENSION IF NOT EXISTS pg_qualstats;"
         node_status: primary
         metric_storage_name: "recommendations"
@@ -1672,17 +1702,35 @@ metrics:
                      AND d.refclassid = 'pg_class'::regclass
                      AND d.deptype = 'n'
                      AND v.oid <> views.view  -- avoid loop
-                )
-                select /* pgwatch_generated */
-                  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-                  'overly_nested_views'::text AS tag_reco_topic,
-                  full_name::text as tag_object_name,
-                  'overly nested views can affect performance'::text recommendation,
-                  'nesting_depth: ' || coalesce(max(level)::text, '-') AS extra_info
-                FROM views
-                GROUP BY 1, 2, 3
-                HAVING max(level) > 3
-                ORDER BY max(level) DESC, full_name::text
+                ),
+                nested_views AS (
+                    SELECT full_name::text as object_name,
+                           max(level) as max_level
+                    FROM views
+                    GROUP BY full_name
+                    HAVING max(level) > 3
+                ),
+                r as (select /* pgwatch_generated */
+                    object_name
+                    from nested_views),
+                rr as (select
+                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                    'overly_nested_views'::text as tag_reco_topic,
+                    string_agg(object_name, ',') as tag_object_name,
+                    'overly nested views can affect performance'::text as recommendation,
+                    'Consider flattening views by creating materialized views or combining view logic to reduce dependency depth'::text as extra_info
+                    from r 
+                    limit 50),
+                last_reco(s) as (
+                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                select 
+                    epoch_ns,
+                    tag_reco_topic,
+                    concat(tag_object_name, s) as tag_object_name,
+                    recommendation,
+                    extra_info
+                from rr, last_reco
+                where tag_object_name > '';
         node_status: primary
         metric_storage_name: "recommendations"
     reco_partial_index_candidates:
@@ -1692,31 +1740,41 @@ metrics:
             This metric helps optimize index usage and improve query performance by suggesting the creation of partial indexes.
         sqls:
             11: |
-                select distinct /* pgwatch_generated */
-                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-                    'partial_index_candidates'::text as tag_reco_topic,
-                    quote_ident(ni.nspname)||'.'||quote_ident(ci.relname) as tag_object_name,
-                    ('index ' || quote_ident(ni.nspname)||'.'||quote_ident(ci.relname) || ' on ' || quote_ident(s.schemaname) || '.' || quote_ident(s.tablename) || ' column ' || quote_ident(s.attname)  || ' could possibly be declared partial leaving out NULL-s')::text as recommendation,
-                    'NULL fraction: ' || round((null_frac * 100)::numeric, 1) || '%, rowcount estimate: ' || (c.reltuples)::int8 || ', current definition: ' ||  pg_get_indexdef(i.indexrelid) as extra_info
-                from
-                    pg_stats s
+                with r as (select distinct /* pgwatch_generated */
+                    ci.oid::regclass::text as object_name
+                    from pg_stats s
                     join pg_attribute a using (attname)
                     join pg_index i on i.indkey[0] = a.attnum and i.indrelid = a.attrelid
                     join pg_class c on c.oid = i.indrelid
                     join pg_class ci on ci.oid = i.indexrelid
-                    join pg_namespace ni on ni.oid = ci.relnamespace
-                where
-                  not indisprimary
-                  and not indisunique
-                  and indisready
-                  and indisvalid
-                  and i.indnatts = 1 /* simple 1 column indexes */
-                  and null_frac > 0.5 /* 50% empty */
-                  and not pg_get_indexdef(i.indexrelid) like '% WHERE %'
-                  and c.reltuples >= 1e5 /* ignore smaller tables */
-                  and not exists ( /* leave out sub-partitions */
-                      select * from pg_inherits where inhrelid = c.oid
-                    )
+                    where not indisprimary
+                    and not indisunique
+                    and indisready
+                    and indisvalid
+                    and i.indnatts = 1 /* simple 1 column indexes */
+                    and null_frac > 0.5 /* 50% empty */
+                    and not pg_get_indexdef(i.indexrelid) like '% WHERE %'
+                    and c.reltuples >= 1e5 /* ignore smaller tables */
+                    and not exists ( /* leave out sub-partitions */
+                        select * from pg_inherits where inhrelid = c.oid)),
+                rr as (select
+                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                    'partial_index_candidates'::text as tag_reco_topic,
+                    string_agg(object_name, ',') as tag_object_name,
+                    'indexes could possibly be declared partial leaving out NULL-s'::text as recommendation,
+                    'CREATE INDEX CONCURRENTLY <index_name> ON <table_name> (<column>) WHERE <column> IS NOT NULL;'::text as extra_info
+                    from r 
+                    limit 50),
+                last_reco(s) as (
+                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                select 
+                    epoch_ns,
+                    tag_reco_topic,
+                    concat(tag_object_name, s) as tag_object_name,
+                    recommendation,
+                    extra_info
+                from rr, last_reco
+                where tag_object_name > '';
         metric_storage_name: "recommendations"
     reco_sprocs_wo_search_path:
         description: >
@@ -1725,26 +1783,29 @@ metrics:
             This metric helps enhance security by suggesting the setting of a fixed search_path for stored procedures.
         sqls:
             11: |-
-                with q_sprocs as (
-                select /* pgwatch_generated */
-                  format('%s.%s', quote_ident(nspname), quote_ident(proname)) as sproc_name,
-                  'alter function ' || proname || '(' || pg_get_function_arguments(p.oid) || ') set search_path = X;' as fix_sql
-                from
-                  pg_proc p
-                  join pg_namespace n on n.oid = p.pronamespace
-                  where prosecdef and not 'search_path' = ANY(coalesce(proconfig, '{}'::text[]))
-                  and not pg_catalog.obj_description(p.oid, 'pg_proc') ~ 'pgwatch'
-                )
-                select /* pgwatch_generated */
-                  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-                  'sprocs_wo_search_path'::text as tag_reco_topic,
-                  sproc_name::text as tag_object_name,
-                  fix_sql::text as recommendation,
-                  'functions without fixed search_path can be potentially abused by malicious users if used objects are not fully qualified'::text as extra_info
-                from
-                  q_sprocs
-                order by
-                   tag_object_name, extra_info
+                with r as (select /* pgwatch_generated */
+                    p.oid::regproc::text as object_name
+                    from pg_proc p
+                    where prosecdef and not 'search_path' = ANY(coalesce(proconfig, '{}'::text[]))
+                    and not pg_catalog.obj_description(p.oid, 'pg_proc') ~ 'pgwatch'),
+                rr as (select
+                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                    'sprocs_wo_search_path'::text as tag_reco_topic,
+                    string_agg(object_name, ',') as tag_object_name,
+                    'functions without fixed search_path can be potentially abused by malicious users if used objects are not fully qualified'::text as recommendation,
+                    'ALTER FUNCTION <function_name> SET search_path = pg_catalog, pg_temp;'::text as extra_info
+                    from r 
+                    limit 50),
+                last_reco(s) as (
+                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                select 
+                    epoch_ns,
+                    tag_reco_topic,
+                    concat(tag_object_name, s) as tag_object_name,
+                    recommendation,
+                    extra_info
+                from rr, last_reco
+                where tag_object_name > '';
         node_status: primary
         metric_storage_name: "recommendations"
     reco_superusers:
@@ -1754,22 +1815,21 @@ metrics:
             This metric helps maintain database security by suggesting a review of superuser accounts.
         sqls:
             11: |
-                with q_su as (
-                  select count(*) from pg_roles where rolcanlogin and rolsuper
-                ),
-                q_total as (
-                  select count(*) from pg_roles where rolcanlogin
+                with r as (select  /* pgwatch_generated */
+                	count(*) filter (where rolcanlogin and rolsuper) as su,
+                	count(*) filter (where rolcanlogin) as users 
+                	from pg_roles 
                 )
-                select /* pgwatch_generated */
+                select
                   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                   'superuser_count'::text as tag_reco_topic,
                   '-'::text as tag_object_name,
                   'too many superusers detected - review recommended'::text as recommendation,
-                  format('%s active superusers, %s total active users', q_su.count, q_total.count) as extra_info
+                  format('%s active superusers, %s total active users', r.su, r.users) as extra_info
                 from
-                  q_su, q_total
+                  r
                 where
-                  q_su.count >= 10
+                  r.su >= 10
         node_status: primary
         metric_storage_name: "recommendations"
     replication:

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -1530,18 +1530,19 @@ metrics:
             11: |-
                 with r as (select /* pgwatch_generated */
                     (regexp_matches(v::text, E'ON (.*?) '))[1] as object_name,
-                    v::text as recommendation
+                    COALESCE(v->>'ddl', v::text) as recommendation,
+                    v->>'queryids' as queryids
                     from json_array_elements(pg_qualstats_index_advisor() -> 'indexes') v),
-                limited_r as (select * from r limit 25),
+                limited_r as (select * from r limit 10),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'create_index'::text as tag_reco_topic,
                     string_agg(object_name, ',') as tag_object_name,
-                    'create indexes for better query performance'::text as recommendation,
-                    'Use CREATE INDEX CONCURRENTLY <index_name> ON <table_name> (<columns>);'::text as extra_info
+                    string_agg(recommendation, ', ') as recommendation,
+                    string_agg(queryids, ', ') as extra_info
                     from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                    select case when count(*) > 10 then format(' and found %s more...', count(*)-10) end from r),
                 total_count as (
                     select count(*) as total from r)
                 select 
@@ -1549,7 +1550,7 @@ metrics:
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info,
+                    case when extra_info > '' then 'affected queries: ' || extra_info end,
                     total as total_recommendations
                 from rr, last_reco, total_count
                 where tag_object_name > '';

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -1532,23 +1532,26 @@ metrics:
                     (regexp_matches(v::text, E'ON (.*?) '))[1] as object_name,
                     v::text as recommendation
                     from json_array_elements(pg_qualstats_index_advisor() -> 'indexes') v),
+                limited_r as (select * from r limit 25),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'create_index'::text as tag_reco_topic,
                     string_agg(object_name, ',') as tag_object_name,
                     'create indexes for better query performance'::text as recommendation,
                     'Use CREATE INDEX CONCURRENTLY <index_name> ON <table_name> (<columns>);'::text as extra_info
-                    from r 
-                    limit 50),
+                    from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                total_count as (
+                    select count(*) as total from r)
                 select 
                     epoch_ns,
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info
-                from rr, last_reco
+                    extra_info,
+                    total as total_recommendations
+                from rr, last_reco, total_count
                 where tag_object_name > '';
         init_sql: "CREATE EXTENSION IF NOT EXISTS pg_qualstats;"
         node_status: primary
@@ -1564,23 +1567,26 @@ metrics:
                     nspname::text as object_name
                     from pg_namespace
                     where nspname = 'public' and nspacl::text ~ E'[,\\{]+=U?C/'),
+                limited_r as (select * from r limit 25),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'default_public_schema_privs'::text as tag_reco_topic,
                     string_agg(object_name, ',') as tag_object_name,
                     'REVOKE CREATE ON SCHEMA public FROM PUBLIC;'::text as recommendation,
                     'only authorized users should be allowed to create new objects'::text as extra_info
-                    from r 
-                    limit 50),
+                    from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                total_count as (
+                    select count(*) as total from r)
                 select 
                     epoch_ns,
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info
-                from rr, last_reco
+                    extra_info,
+                    total as total_recommendations
+                from rr, last_reco, total_count
                 where tag_object_name > '';
         node_status: primary
         storage_name: "recommendations"
@@ -1592,26 +1598,29 @@ metrics:
         sqls:
             11: |
                 with r as (select /* pgwatch_generated */
-                    c.oid 
+                    c.oid::regclass::text as object_name
                     from pg_trigger t join pg_class c on c.oid = t.tgrelid
                     where tgenabled = 'D'),
+                limited_r as (select * from r limit 25),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'disabled_triggers'::text as tag_reco_topic,
-                    string_agg(oid::regclass::text, ',') as tag_object_name,
+                    string_agg(object_name, ',') as tag_object_name,
                     'review usage of triggers and consider dropping them if not needed anymore'::text as recommendation,
                     'Enable: ALTER TABLE <table_name> ENABLE TRIGGER <trigger_name>; Drop: DROP TRIGGER <trigger_name> ON <table_name>;'::text as extra_info
-                    from r 
-                    limit 50),
+                    from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                total_count as (
+                    select count(*) as total from r)
                 select 
                     epoch_ns,
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info
-                from rr, last_reco
+                    extra_info,
+                    total as total_recommendations
+                from rr, last_reco, total_count
                 where tag_object_name > '';
         node_status: primary
         storage_name: "recommendations"
@@ -1636,23 +1645,26 @@ metrics:
                     and not indisprimary
                     and not indisreplident
                     and not schemaname like '_timescaledb%'),
+                limited_r as (select * from r limit 25),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'drop_index'::text as tag_reco_topic,
                     string_agg(object_name, ',') as tag_object_name,
                     'drop unused or invalid indexes to improve performance'::text as recommendation,
                     'Make sure to also check replica pg_stat_user_indexes.idx_scan count if using them for queries'::text as extra_info
-                    from r 
-                    limit 50),
+                    from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                total_count as (
+                    select count(*) as total from r)
                 select 
                     epoch_ns,
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info
-                from rr, last_reco
+                    extra_info,
+                    total as total_recommendations
+                from rr, last_reco, total_count
                 where tag_object_name > '';
         init_sql: "CREATE EXTENSION IF NOT EXISTS pg_qualstats;"
         node_status: primary
@@ -1713,23 +1725,26 @@ metrics:
                 r as (select /* pgwatch_generated */
                     object_name
                     from nested_views),
+                limited_r as (select * from r limit 25),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'overly_nested_views'::text as tag_reco_topic,
                     string_agg(object_name, ',') as tag_object_name,
                     'overly nested views can affect performance'::text as recommendation,
                     'Consider flattening views by creating materialized views or combining view logic to reduce dependency depth'::text as extra_info
-                    from r 
-                    limit 50),
+                    from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                total_count as (
+                    select count(*) as total from r)
                 select 
                     epoch_ns,
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info
-                from rr, last_reco
+                    extra_info,
+                    total as total_recommendations
+                from rr, last_reco, total_count
                 where tag_object_name > '';
         node_status: primary
         storage_name: "recommendations"
@@ -1757,23 +1772,26 @@ metrics:
                     and c.reltuples >= 1e5 /* ignore smaller tables */
                     and not exists ( /* leave out sub-partitions */
                         select * from pg_inherits where inhrelid = c.oid)),
+                limited_r as (select * from r limit 25),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'partial_index_candidates'::text as tag_reco_topic,
                     string_agg(object_name, ',') as tag_object_name,
                     'indexes could possibly be declared partial leaving out NULL-s'::text as recommendation,
                     'CREATE INDEX CONCURRENTLY <index_name> ON <table_name> (<column>) WHERE <column> IS NOT NULL;'::text as extra_info
-                    from r 
-                    limit 50),
+                    from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                total_count as (
+                    select count(*) as total from r)
                 select 
                     epoch_ns,
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info
-                from rr, last_reco
+                    extra_info,
+                    total as total_recommendations
+                from rr, last_reco, total_count
                 where tag_object_name > '';
         storage_name: "recommendations"
     reco_sprocs_wo_search_path:
@@ -1788,23 +1806,26 @@ metrics:
                     from pg_proc p
                     where prosecdef and not 'search_path' = ANY(coalesce(proconfig, '{}'::text[]))
                     and not pg_catalog.obj_description(p.oid, 'pg_proc') ~ 'pgwatch'),
+                limited_r as (select * from r limit 25),
                 rr as (select
                     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
                     'sprocs_wo_search_path'::text as tag_reco_topic,
                     string_agg(object_name, ',') as tag_object_name,
                     'functions without fixed search_path can be potentially abused by malicious users if used objects are not fully qualified'::text as recommendation,
                     'ALTER FUNCTION <function_name> SET search_path = pg_catalog, pg_temp;'::text as extra_info
-                    from r 
-                    limit 50),
+                    from limited_r),
                 last_reco(s) as (
-                    select case when count(*) > 50 then format(' and found %s more...', count(*)-50) end from r)
+                    select case when count(*) > 25 then format(' and found %s more...', count(*)-25) end from r),
+                total_count as (
+                    select count(*) as total from r)
                 select 
                     epoch_ns,
                     tag_reco_topic,
                     concat(tag_object_name, s) as tag_object_name,
                     recommendation,
-                    extra_info
-                from rr, last_reco
+                    extra_info,
+                    total as total_recommendations
+                from rr, last_reco, total_count
                 where tag_object_name > '';
         node_status: primary
         storage_name: "recommendations"
@@ -1825,7 +1846,8 @@ metrics:
                   'superuser_count'::text as tag_reco_topic,
                   '-'::text as tag_object_name,
                   'too many superusers detected - review recommended'::text as recommendation,
-                  format('%s active superusers, %s total active users', r.su, r.users) as extra_info
+                  format('%s active superusers, %s total active users', r.su, r.users) as extra_info,
+                  1 as total_recommendations
                 from
                   r
                 where


### PR DESCRIPTION
Refactor PostgreSQL recommendation metrics to consolidate multiple
findings per metric type.

The changes consolidate all 8 recommendation metrics to use
an aggregation pattern that combines multiple database objects into
comma-separated strings instead of separate rows, limiting results to
50 items with overflow indicators, and actionable guidance templates
were added to extra_info fields.