### PR TITLE
[+] improve `change_events` metric processing

### DIFF
--- a/internal/reaper/database_test.go
+++ b/internal/reaper/database_test.go
@@ -3,12 +3,38 @@ package reaper
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/metrics"
 	"github.com/cybertec-postgresql/pgwatch/v3/internal/sources"
 	pgxmock "github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// Helper function to create a test SourceConn with pgxmock
+func createTestSourceConn(t *testing.T) (*sources.SourceConn, pgxmock.PgxPoolIface) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+
+	md := &sources.SourceConn{
+		Conn:   mock,
+		Source: sources.Source{Name: "testdb"},
+		RuntimeInfo: sources.RuntimeInfo{
+			Version:     120000,
+			ChangeState: make(map[string]map[string]string),
+		},
+	}
+	return md, mock
+}
+
+// Helper function to set up transaction expectations for PostgreSQL sources
+func expectTransaction(mock pgxmock.PgxPoolIface, queryRows *pgxmock.Rows) {
+	mock.ExpectBegin()
+	mock.ExpectExec("SET LOCAL lock_timeout").WillReturnResult(pgxmock.NewResult("SET", 0))
+	mock.ExpectQuery("SELECT").WillReturnRows(queryRows)
+	mock.ExpectCommit()
+}
 
 func TestTryCreateMetricsFetchingHelpers(t *testing.T) {
 	ctx := context.Background()
@@ -45,4 +71,390 @@ func TestTryCreateMetricsFetchingHelpers(t *testing.T) {
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
 
+}
+
+func TestDetectSprocChanges(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up simple test metric (instead of complex real one)
+	metricDefs.MetricDefs["sproc_hashes"] = metrics.Metric{
+		SQLs: map[int]string{
+			120000: "SELECT",
+		},
+	}
+
+	// Create single connection and reaper to maintain state across calls
+	md, mock := createTestSourceConn(t)
+	defer mock.Close()
+
+	reaper := &Reaper{
+		measurementCh: make(chan metrics.MeasurementEnvelope, 10),
+	}
+
+	// First run - establish baseline
+	initialRows := pgxmock.NewRows([]string{"tag_sproc", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("func1", "123", "hash1", time.Now().UnixNano()).
+		AddRow("func2", "456", "hash2", time.Now().UnixNano())
+	expectTransaction(mock, initialRows)
+
+	result := reaper.DetectSprocChanges(ctx, md)
+	assert.Equal(t, 0, result.Created) // First run should not count anything as created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+
+	// State should now be populated
+	assert.NotEmpty(t, md.ChangeState["sproc_hashes"])
+
+	// Second run - detect altered sproc (different hash for func1)
+	modifiedRows := pgxmock.NewRows([]string{"tag_sproc", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("func1", "123", "new_hash", time.Now().UnixNano()).
+		AddRow("func2", "456", "hash2", time.Now().UnixNano())
+	expectTransaction(mock, modifiedRows)
+
+	result = reaper.DetectSprocChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 1, result.Altered) // func1 was altered
+	assert.Equal(t, 0, result.Dropped)
+
+	// Third run - detect new sproc (func3 added)
+	newSprocRows := pgxmock.NewRows([]string{"tag_sproc", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("func1", "123", "new_hash", time.Now().UnixNano()).
+		AddRow("func2", "456", "hash2", time.Now().UnixNano()).
+		AddRow("func3", "789", "hash3", time.Now().UnixNano()) // new sproc
+	expectTransaction(mock, newSprocRows)
+
+	result = reaper.DetectSprocChanges(ctx, md)
+	assert.Equal(t, 1, result.Created) // func3 was created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+
+	// Verify measurement is sent
+	select {
+	case <-reaper.measurementCh:
+		// Good, measurement was sent
+	default:
+		t.Error("Expected measurement to be sent")
+	}
+
+	// Fourth run - detect dropped sproc (func2 removed)
+	droppedSprocRows := pgxmock.NewRows([]string{"tag_sproc", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("func1", "123", "new_hash", time.Now().UnixNano()).
+		AddRow("func3", "789", "hash3", time.Now().UnixNano()) // func2 dropped
+	expectTransaction(mock, droppedSprocRows)
+
+	result = reaper.DetectSprocChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 1, result.Dropped) // func2 was dropped
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDetectTableChanges(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up simple test metric
+	metricDefs.MetricDefs["table_hashes"] = metrics.Metric{
+		SQLs: map[int]string{
+			120000: "SELECT",
+		},
+	}
+
+	// Create single connection and reaper to maintain state across calls
+	md, mock := createTestSourceConn(t)
+	defer mock.Close()
+
+	reaper := &Reaper{
+		measurementCh: make(chan metrics.MeasurementEnvelope, 10),
+	}
+
+	// First run - establish baseline
+	initialRows := pgxmock.NewRows([]string{"tag_table", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("table1", "123", "hash1", time.Now().UnixNano()).
+		AddRow("table2", "456", "hash2", time.Now().UnixNano())
+	expectTransaction(mock, initialRows)
+
+	result := reaper.DetectTableChanges(ctx, md)
+	assert.Equal(t, 0, result.Created) // First run should not count anything as created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+	assert.NotEmpty(t, md.ChangeState["table_hashes"])
+
+	// Second run - detect altered table (different hash for table1)
+	modifiedRows := pgxmock.NewRows([]string{"tag_table", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("table1", "123", "new_hash", time.Now().UnixNano()).
+		AddRow("table2", "456", "hash2", time.Now().UnixNano())
+	expectTransaction(mock, modifiedRows)
+
+	result = reaper.DetectTableChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 1, result.Altered) // table1 was altered
+	assert.Equal(t, 0, result.Dropped)
+
+	// Third run - detect new table (table3 added)
+	newTableRows := pgxmock.NewRows([]string{"tag_table", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("table1", "123", "new_hash", time.Now().UnixNano()).
+		AddRow("table2", "456", "hash2", time.Now().UnixNano()).
+		AddRow("table3", "789", "hash3", time.Now().UnixNano()) // new table
+	expectTransaction(mock, newTableRows)
+
+	result = reaper.DetectTableChanges(ctx, md)
+	assert.Equal(t, 1, result.Created) // table3 was created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+
+	// Verify measurement is sent
+	select {
+	case msg := <-reaper.measurementCh:
+		assert.Equal(t, "table_changes", msg.MetricName)
+		assert.Equal(t, "testdb", msg.DBName)
+	default:
+		t.Error("Expected measurement to be sent")
+	}
+
+	// Fourth run - detect dropped table (table2 removed)
+	droppedTableRows := pgxmock.NewRows([]string{"tag_table", "tag_oid", "md5", "epoch_ns"}).
+		AddRow("table1", "123", "new_hash", time.Now().UnixNano()).
+		AddRow("table3", "789", "hash3", time.Now().UnixNano()) // table2 dropped
+	expectTransaction(mock, droppedTableRows)
+
+	result = reaper.DetectTableChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 1, result.Dropped) // table2 was dropped
+
+	// Check that table2 was removed from state
+	_, exists := md.ChangeState["table_hashes"]["table2"]
+	assert.False(t, exists)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDetectIndexChanges(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up simple test metric
+	metricDefs.MetricDefs["index_hashes"] = metrics.Metric{
+		SQLs: map[int]string{
+			120000: "SELECT",
+		},
+	}
+
+	// Create single connection and reaper to maintain state across calls
+	md, mock := createTestSourceConn(t)
+	defer mock.Close()
+
+	reaper := &Reaper{
+		measurementCh: make(chan metrics.MeasurementEnvelope, 10),
+	}
+
+	// First run - establish baseline
+	initialRows := pgxmock.NewRows([]string{"tag_index", "table", "md5", "is_valid", "epoch_ns"}).
+		AddRow("idx1", "table1", "hash1", "t", time.Now().UnixNano()).
+		AddRow("idx2", "table1", "hash2", "t", time.Now().UnixNano())
+	expectTransaction(mock, initialRows)
+
+	result := reaper.DetectIndexChanges(ctx, md)
+	assert.Equal(t, 0, result.Created) // First run should not count anything as created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+	assert.NotEmpty(t, md.ChangeState["index_hashes"])
+
+	// Second run - detect altered index (is_valid changed for idx1)
+	modifiedRows := pgxmock.NewRows([]string{"tag_index", "table", "md5", "is_valid", "epoch_ns"}).
+		AddRow("idx1", "table1", "hash1", "f", time.Now().UnixNano()). // now invalid
+		AddRow("idx2", "table1", "hash2", "t", time.Now().UnixNano())
+	expectTransaction(mock, modifiedRows)
+
+	result = reaper.DetectIndexChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 1, result.Altered) // idx1 was altered
+	assert.Equal(t, 0, result.Dropped)
+
+	// Third run - detect new index (idx3 added)
+	newIndexRows := pgxmock.NewRows([]string{"tag_index", "table", "md5", "is_valid", "epoch_ns"}).
+		AddRow("idx1", "table1", "hash1", "f", time.Now().UnixNano()).
+		AddRow("idx2", "table1", "hash2", "t", time.Now().UnixNano()).
+		AddRow("idx3", "table2", "hash3", "t", time.Now().UnixNano()) // new index
+	expectTransaction(mock, newIndexRows)
+
+	result = reaper.DetectIndexChanges(ctx, md)
+	assert.Equal(t, 1, result.Created) // idx3 was created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+
+	// Verify measurement is sent
+	select {
+	case msg := <-reaper.measurementCh:
+		assert.Equal(t, "index_changes", msg.MetricName)
+		assert.Equal(t, "testdb", msg.DBName)
+	default:
+		t.Error("Expected measurement to be sent")
+	}
+
+	// Fourth run - detect dropped index (idx2 removed)
+	droppedIndexRows := pgxmock.NewRows([]string{"tag_index", "table", "md5", "is_valid", "epoch_ns"}).
+		AddRow("idx1", "table1", "hash1", "f", time.Now().UnixNano()).
+		AddRow("idx3", "table2", "hash3", "t", time.Now().UnixNano()) // idx2 dropped
+	expectTransaction(mock, droppedIndexRows)
+
+	result = reaper.DetectIndexChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 1, result.Dropped) // idx2 was dropped
+
+	// Check that idx2 was removed from state
+	_, exists := md.ChangeState["index_hashes"]["idx2"]
+	assert.False(t, exists)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDetectPrivilegeChanges(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up simple test metric
+	metricDefs.MetricDefs["privilege_changes"] = metrics.Metric{
+		SQLs: map[int]string{
+			120000: "SELECT",
+		},
+	}
+
+	// Create single connection and reaper to maintain state across calls
+	md, mock := createTestSourceConn(t)
+	defer mock.Close()
+
+	reaper := &Reaper{
+		measurementCh: make(chan metrics.MeasurementEnvelope, 10),
+	}
+
+	// First run - establish baseline
+	initialRows := pgxmock.NewRows([]string{"object_type", "tag_role", "tag_object", "privilege_type", "epoch_ns"}).
+		AddRow("table", "user1", "table1", "SELECT", time.Now().UnixNano()).
+		AddRow("table", "user2", "table2", "INSERT", time.Now().UnixNano())
+	expectTransaction(mock, initialRows)
+
+	result := reaper.DetectPrivilegeChanges(ctx, md)
+	assert.Equal(t, 0, result.Created) // First run should not count anything as created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+	assert.NotEmpty(t, md.ChangeState["object_privileges"])
+
+	// Second run - detect new privilege grant (user1 gets INSERT privilege on table1)
+	newPrivilegeRows := pgxmock.NewRows([]string{"object_type", "tag_role", "tag_object", "privilege_type", "epoch_ns"}).
+		AddRow("table", "user1", "table1", "SELECT", time.Now().UnixNano()).
+		AddRow("table", "user1", "table1", "INSERT", time.Now().UnixNano()). // new privilege
+		AddRow("table", "user2", "table2", "INSERT", time.Now().UnixNano())
+	expectTransaction(mock, newPrivilegeRows)
+
+	result = reaper.DetectPrivilegeChanges(ctx, md)
+	assert.Equal(t, 1, result.Created) // new privilege was granted
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+
+	// Verify measurement is sent
+	select {
+	case msg := <-reaper.measurementCh:
+		assert.Equal(t, "privilege_changes", msg.MetricName)
+		assert.Equal(t, "testdb", msg.DBName)
+	default:
+		t.Error("Expected measurement to be sent")
+	}
+
+	// Third run - detect privilege revoke (user1 loses INSERT privilege on table1)
+	revokedPrivilegeRows := pgxmock.NewRows([]string{"object_type", "tag_role", "tag_object", "privilege_type", "epoch_ns"}).
+		AddRow("table", "user1", "table1", "SELECT", time.Now().UnixNano()).
+		AddRow("table", "user2", "table2", "INSERT", time.Now().UnixNano()) // user1 INSERT privilege revoked
+	expectTransaction(mock, revokedPrivilegeRows)
+
+	result = reaper.DetectPrivilegeChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 1, result.Dropped) // privilege was revoked
+
+	// Check that revoked privilege was removed from state
+	_, exists := md.ChangeState["object_privileges"]["table#:#user1#:#table1#:#INSERT"]
+	assert.False(t, exists)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDetectConfigurationChanges(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up simple test metric
+	metricDefs.MetricDefs["configuration_hashes"] = metrics.Metric{
+		SQLs: map[int]string{
+			120000: "SELECT",
+		},
+	}
+
+	// Create direct mock connection without transaction expectations
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	md := &sources.SourceConn{
+		Conn:   mock,
+		Source: sources.Source{Name: "testdb"},
+		RuntimeInfo: sources.RuntimeInfo{
+			Version:     120000,
+			ChangeState: make(map[string]map[string]string),
+		},
+	}
+
+	reaper := &Reaper{
+		measurementCh: make(chan metrics.MeasurementEnvelope, 10),
+	}
+
+	// First run - establish baseline configuration
+	initialRows := pgxmock.NewRows([]string{"epoch_ns", "setting", "value"}).
+		AddRow(time.Now().UnixNano(), "max_connections", "100").
+		AddRow(time.Now().UnixNano(), "shared_buffers", "128MB")
+	mock.ExpectQuery("SELECT").WillReturnRows(initialRows)
+
+	result := reaper.DetectConfigurationChanges(ctx, md)
+	assert.Equal(t, 0, result.Created) // First run should not count anything as created
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+	assert.NotEmpty(t, md.ChangeState["configuration_hashes"])
+
+	// Second run - detect new configuration setting
+	newSettingRows := pgxmock.NewRows([]string{"epoch_ns", "setting", "value"}).
+		AddRow(time.Now().UnixNano(), "max_connections", "100").
+		AddRow(time.Now().UnixNano(), "shared_buffers", "128MB").
+		AddRow(time.Now().UnixNano(), "work_mem", "4MB") // new setting
+	mock.ExpectQuery("SELECT").WillReturnRows(newSettingRows)
+
+	result = reaper.DetectConfigurationChanges(ctx, md)
+	assert.Equal(t, 1, result.Created) // new setting was added
+	assert.Equal(t, 0, result.Altered)
+	assert.Equal(t, 0, result.Dropped)
+
+	// Verify measurement is sent
+	select {
+	case msg := <-reaper.measurementCh:
+		assert.Equal(t, "configuration_changes", msg.MetricName)
+		assert.Equal(t, "testdb", msg.DBName)
+	default:
+		t.Error("Expected measurement to be sent")
+	}
+
+	// Third run - detect configuration change
+	changedValueRows := pgxmock.NewRows([]string{"epoch_ns", "setting", "value"}).
+		AddRow(time.Now().UnixNano(), "max_connections", "200").  // changed value
+		AddRow(time.Now().UnixNano(), "shared_buffers", "256MB"). // changed value
+		AddRow(time.Now().UnixNano(), "work_mem", "4MB")
+	mock.ExpectQuery("SELECT").WillReturnRows(changedValueRows)
+
+	result = reaper.DetectConfigurationChanges(ctx, md)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 2, result.Altered) // two settings were changed
+	assert.Equal(t, 0, result.Dropped)
+
+	// Check that state was updated
+	assert.Equal(t, "200", md.ChangeState["configuration_hashes"]["max_connections"])
+	assert.Equal(t, "256MB", md.ChangeState["configuration_hashes"]["shared_buffers"])
+
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/reaper/metric.go
+++ b/internal/reaper/metric.go
@@ -1,6 +1,7 @@
 package reaper
 
 import (
+	"fmt"
 	"maps"
 	"sync"
 	"time"
@@ -62,6 +63,14 @@ type ChangeDetectionResults struct { // for passing around DDL/index/config chan
 	Created int
 	Altered int
 	Dropped int
+}
+
+func (cdr *ChangeDetectionResults) Total() int {
+	return cdr.Created + cdr.Altered + cdr.Dropped
+}
+
+func (cdr *ChangeDetectionResults) String() string {
+	return fmt.Sprintf("%d/%d/%d", cdr.Created, cdr.Altered, cdr.Dropped)
 }
 
 type ExistingPartitionInfo struct {

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -277,7 +277,6 @@ func (r *Reaper) ShutdownOldWorkers(ctx context.Context, hostsToShutDownDueToRol
 }
 
 func (r *Reaper) reapMetricMeasurements(ctx context.Context, md *sources.SourceConn, metricName string) {
-	hostState := make(map[string]map[string]string)
 	var lastUptimeS int64 = -1 // used for "server restarted" event detection
 	var lastErrorNotificationTime time.Time
 	var err error
@@ -317,7 +316,7 @@ func (r *Reaper) reapMetricMeasurements(ctx context.Context, md *sources.SourceC
 		}
 		t1 := time.Now()
 		if metricStoreMessages == nil {
-			metricStoreMessages, err = r.FetchMetric(ctx, md, metricName, hostState)
+			metricStoreMessages, err = r.FetchMetric(ctx, md, metricName)
 		}
 
 		if time.Since(t1) > (time.Second * time.Duration(interval)) {
@@ -458,7 +457,7 @@ func (r *Reaper) AddSysinfoToMeasurements(data metrics.Measurements, md *sources
 	}
 }
 
-func (r *Reaper) FetchMetric(ctx context.Context, md *sources.SourceConn, metricName string, hostState map[string]map[string]string) (_ *metrics.MeasurementEnvelope, err error) {
+func (r *Reaper) FetchMetric(ctx context.Context, md *sources.SourceConn, metricName string) (_ *metrics.MeasurementEnvelope, err error) {
 	var sql string
 	var data metrics.Measurements
 	var metric metrics.Metric
@@ -483,7 +482,7 @@ func (r *Reaper) FetchMetric(ctx context.Context, md *sources.SourceConn, metric
 		}
 		switch metricName {
 		case specialMetricChangeEvents:
-			r.CheckForPGObjectChangesAndStore(ctx, md.Name, md, hostState)
+			r.CheckForPGObjectChangesAndStore(ctx, md)
 			return nil, nil
 		case specialMetricInstanceUp:
 			data, err = r.GetInstanceUpMeasurement(ctx, md)

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -37,6 +37,7 @@ type RuntimeInfo struct {
 	Extensions       map[string]int
 	ExecEnv          string
 	ApproxDbSize     int64
+	ChangeState      map[string]map[string]string // ["category"][object_identifier] = state
 }
 
 // SourceConn represents a single connection to monitor. Unlike source, it contains a database connection.
@@ -156,7 +157,8 @@ func (md *SourceConn) FetchRuntimeInfo(ctx context.Context, forceRefetch bool) (
 	}
 
 	dbNewSettings := RuntimeInfo{
-		Extensions: make(map[string]int),
+		Extensions:  make(map[string]int),
+		ChangeState: make(map[string]map[string]string),
 	}
 
 	switch md.Kind {


### PR DESCRIPTION
Move `HostState` to `RuntimeInfo.ChangeState` for better data organization.

Convert standalone detection functions to `Reaper` methods for consistency. Replace verbose `Info` logs with structured `Debug` logs using `WithField()`.

Eliminate `hostState` parameter passing throughout detection methods.

Add `Total()` and `String()` helper methods to `ChangeDetectionResults`.

Improve change summary with structured logging fields instead of string concatenation. Simplify deletion tracking by removing intermediate arrays