### PR TITLE
feat: Increase default partitions_to_precreate from 0 to 3

### DIFF
--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION admin.ensure_partition_metric_dbname_time(
     metric text,
     dbname text,
     metric_timestamp timestamptz,
-    partitions_to_precreate int default 0,
+    partitions_to_precreate int default 3,
     OUT part_available_from timestamptz,
     OUT part_available_to timestamptz)
 RETURNS record AS


### PR DESCRIPTION
Change default `partitions_to_precreate` from 0 to 3 to avoid partition creation delays during active monitoring. Improves performance and reduces blocking operations under high load.

Creates current + 3 future partitions by default instead of on-demand creation.

- Current partition (e.g., metric_dbname_y2024w01)
- +3 future partitions (y2024w02, y2024w03, y2024w04)