### PR TITLE
[-] fix assignment to entry in nil map, fixes #968

### DIFF
--- a/internal/cmdopts/cmdsource.go
+++ b/internal/cmdopts/cmdsource.go
@@ -57,7 +57,7 @@ func (cmd *SourcePingCommand) Execute(args []string) error {
 		case sources.SourcePostgresContinuous:
 			_, e = sources.ResolveDatabasesFromPostgres(s)
 		default:
-			mdb := &sources.SourceConn{Source: s}
+			mdb := sources.NewSourceConn(s)
 			e = mdb.Connect(context.Background(), cmd.owner.Sources)
 		}
 		if e != nil {

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -54,6 +54,16 @@ type (
 	SourceConns []*SourceConn
 )
 
+func NewSourceConn(s Source) *SourceConn {
+	return &SourceConn{
+		Source: s,
+		RuntimeInfo: RuntimeInfo{
+			Extensions:  make(map[string]int),
+			ChangeState: make(map[string]map[string]string),
+		},
+	}
+}
+
 // Ping will try to ping the server to ensure the connection is still alive
 func (md *SourceConn) Ping(ctx context.Context) (err error) {
 	if md.Kind == SourcePgBouncer {
@@ -155,15 +165,9 @@ func (md *SourceConn) FetchRuntimeInfo(ctx context.Context, forceRefetch bool) (
 	if !forceRefetch && md.LastCheckedOn.After(time.Now().Add(time.Minute*-2)) { // use cached version for 2 min
 		return nil
 	}
-
-	dbNewSettings := RuntimeInfo{
-		Extensions:  make(map[string]int),
-		ChangeState: make(map[string]map[string]string),
-	}
-
 	switch md.Kind {
 	case SourcePgBouncer, SourcePgPool:
-		if dbNewSettings.VersionStr, dbNewSettings.Version, err = md.FetchVersion(ctx, func() string {
+		if md.VersionStr, md.Version, err = md.FetchVersion(ctx, func() string {
 			if md.Kind == SourcePgBouncer {
 				return "SHOW VERSION"
 			}
@@ -183,15 +187,15 @@ FROM
 	pg_control_system()`
 
 		err = md.Conn.QueryRow(ctx, sql).
-			Scan(&dbNewSettings.Version, &dbNewSettings.VersionStr,
-				&dbNewSettings.IsInRecovery, &dbNewSettings.RealDbname,
-				&dbNewSettings.SystemIdentifier, &dbNewSettings.IsSuperuser)
+			Scan(&md.Version, &md.VersionStr,
+				&md.IsInRecovery, &md.RealDbname,
+				&md.SystemIdentifier, &md.IsSuperuser)
 		if err != nil {
 			return err
 		}
 
-		dbNewSettings.ExecEnv = md.DiscoverPlatform(ctx)
-		dbNewSettings.ApproxDbSize = md.FetchApproxSize(ctx)
+		md.ExecEnv = md.DiscoverPlatform(ctx)
+		md.ApproxDbSize = md.FetchApproxSize(ctx)
 
 		sqlExtensions := `select /* pgwatch_generated */ extname::text, (regexp_matches(extversion, $$\d+\.?\d+?$$))[1]::text as extversion from pg_extension order by 1;`
 		var res pgx.Rows
@@ -204,14 +208,13 @@ FROM
 				if extver == 0 {
 					return fmt.Errorf("unexpected extension %s version input: %s", ext, ver)
 				}
-				dbNewSettings.Extensions[ext] = extver
+				md.Extensions[ext] = extver
 				return nil
 			})
 		}
 
 	}
-	dbNewSettings.LastCheckedOn = time.Now()
-	md.RuntimeInfo = dbNewSettings // store the new settings in the struct
+	md.LastCheckedOn = time.Now()
 	return err
 }
 

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -243,10 +243,8 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 	t.Run("pgbouncer version fetch", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
-		md := &sources.SourceConn{
-			Conn:   mock,
-			Source: sources.Source{Kind: sources.SourcePgBouncer},
-		}
+		md := sources.NewSourceConn(sources.Source{Kind: sources.SourcePgBouncer})
+		md.Conn = mock
 		mock.ExpectQuery("SHOW VERSION").
 			WithArgs(pgx.QueryExecModeSimpleProtocol).
 			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("PgBouncer 1.12.0"))
@@ -260,10 +258,8 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 	t.Run("pgpool version fetch", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
-		md := &sources.SourceConn{
-			Conn:   mock,
-			Source: sources.Source{Kind: sources.SourcePgPool},
-		}
+		md := sources.NewSourceConn(sources.Source{Kind: sources.SourcePgPool})
+		md.Conn = mock
 		mock.ExpectQuery("SHOW POOL_VERSION").
 			WithArgs(pgx.QueryExecModeSimpleProtocol).
 			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("4.1.2"))
@@ -277,10 +273,8 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 	t.Run("postgres version and extensions", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
-		md := &sources.SourceConn{
-			Conn:   mock,
-			Source: sources.Source{Kind: sources.SourcePostgres},
-		}
+		md := sources.NewSourceConn(sources.Source{Kind: sources.SourcePostgres})
+		md.Conn = mock
 		mock.ExpectQuery("select").WillReturnRows(
 			pgxmock.NewRows([]string{"ver", "version", "pg_is_in_recovery", "current_database", "system_identifier", "is_superuser"}).
 				AddRow(13, "PostgreSQL 13.3", false, "testdb", "42424242", true),
@@ -306,10 +300,8 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 	t.Run("query error", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
-		md := &sources.SourceConn{
-			Conn:   mock,
-			Source: sources.Source{Kind: sources.SourcePgBouncer},
-		}
+		md := sources.NewSourceConn(sources.Source{Kind: sources.SourcePgBouncer})
+		md.Conn = mock
 		mock.ExpectQuery("SHOW VERSION").
 			WithArgs(pgx.QueryExecModeSimpleProtocol).
 			WillReturnError(fmt.Errorf("db error"))

--- a/internal/sources/resolver.go
+++ b/internal/sources/resolver.go
@@ -47,7 +47,7 @@ func (s Source) ResolveDatabases() (SourceConns, error) {
 	case SourcePostgresContinuous:
 		return ResolveDatabasesFromPostgres(s)
 	}
-	return SourceConns{&SourceConn{Source: s}}, nil
+	return SourceConns{NewSourceConn(s)}, nil
 }
 
 type PatroniClusterMember struct {
@@ -329,7 +329,7 @@ func ResolveDatabasesFromPostgres(s Source) (resolvedDbs SourceConns, err error)
 		if err = rows.Scan(&dbname); err != nil {
 			return nil, err
 		}
-		rdb := &SourceConn{Source: *s.Clone()}
+		rdb := NewSourceConn(*s.Clone())
 		rdb.Name += "_" + dbname
 		rdb.SetDatabaseName(dbname)
 		resolvedDbs = append(resolvedDbs, rdb)


### PR DESCRIPTION
Add `NewSourceConn()` constructor and use direct access in `FetchRuntimeInfo()` without temp `RuntimeInfo` var