### PR TITLE
[-] fix weekly partition naming at year boundaries

### DIFF
--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -65,7 +65,7 @@ BEGIN
   -- 3. level
   FOR i IN 0..partitions_to_precreate LOOP
 
-      l_year := extract(isoyear from (metric_timestamp + '1month'::interval * i));
+      l_year := extract(isoyear from (metric_timestamp + '1week'::interval * i));
       l_week := extract(week from (metric_timestamp + '1week'::interval * i));
 
       IF i = 0 THEN


### PR DESCRIPTION
Extract both ISO year and week from the same date shifted by weeks only. This ensures correct partition names for all weeks, especially in December and January.