### PR TITLE
[*] refactor object changes metric

### DIFF
--- a/internal/reaper/metric.go
+++ b/internal/reaper/metric.go
@@ -60,6 +60,7 @@ func (cmd *ConcurrentMetricDefs) Assign(newDefs *metrics.Metrics) {
 }
 
 type ChangeDetectionResults struct { // for passing around DDL/index/config change detection results
+	Target  string
 	Created int
 	Altered int
 	Dropped int
@@ -70,7 +71,7 @@ func (cdr *ChangeDetectionResults) Total() int {
 }
 
 func (cdr *ChangeDetectionResults) String() string {
-	return fmt.Sprintf("%d/%d/%d", cdr.Created, cdr.Altered, cdr.Dropped)
+	return fmt.Sprintf("%s: %d/%d/%d", cdr.Target, cdr.Created, cdr.Altered, cdr.Dropped)
 }
 
 type ExistingPartitionInfo struct {

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -484,8 +484,7 @@ func (r *Reaper) FetchMetric(ctx context.Context, md *sources.SourceConn, metric
 		}
 		switch metricName {
 		case specialMetricChangeEvents:
-			r.CheckForPGObjectChangesAndStore(ctx, md)
-			return nil, nil
+			data, err = r.GetObjectChangesMeasurement(ctx, md)
 		case specialMetricInstanceUp:
 			data, err = r.GetInstanceUpMeasurement(ctx, md)
 		default:
@@ -496,7 +495,7 @@ func (r *Reaper) FetchMetric(ctx context.Context, md *sources.SourceConn, metric
 			}
 			data, err = QueryMeasurements(ctx, md, sql)
 		}
-		if err != nil {
+		if err != nil || len(data) == 0 {
 			return nil, err
 		}
 		r.measurementCache.Put(cacheKey, data)


### PR DESCRIPTION
Rewrite the function so it follows the common calling conventions. Make sure `Reaper.FetchMetric()` exits if none measurements collected