### PR TITLE
[-] fix pgbouncer dashboard

### DIFF
--- a/grafana/postgres/v12/pgbouncer-stats.json
+++ b/grafana/postgres/v12/pgbouncer-stats.json
@@ -2147,7 +2147,7 @@
         },
         "definition": "select distinct (data->>'database') as database from pgbouncer_stats where dbname = '$monitoredsource' and $__timeFilter(time) ;",
         "includeAll": true,
-        "label": "DB Name",
+        "label": "Databases",
         "multi": true,
         "name": "databases",
         "options": [],


### PR DESCRIPTION
Fix the database name lookup in the pgbouncer dashboard

 - since the metrics database model has changed, the actual database name is inside the JSON field data
 - also clean some old and unused sql queries