### PR TITLE
[-] fix webui password hiding regex

### DIFF
--- a/internal/webui/src/pages/SourcesPage/components/SourcesGrid/components/MaskConnectionString.tsx
+++ b/internal/webui/src/pages/SourcesPage/components/SourcesGrid/components/MaskConnectionString.tsx
@@ -11,8 +11,8 @@ type MaskedTextProps = {
 const mask = (connStr: string) => {
   if (connStr.includes("://")) {
     return connStr.replace(
-      /(postgresql:\/\/[^:]+:)([^@]+)(@.*)/,
-      (_, start, pass, end) => `${start}${"•".repeat(8)}${end}`
+      /((postgresql|postgres):\/\/[^:]+:)([^@]+)(@.*)/,
+      (_, start, __, pass, end) => `${start}${"•".repeat(8)}${end}`
     );
   } else {
     return connStr.replace(


### PR DESCRIPTION
- Fixes the regex to match both `postgres://...` and `postgresql://...` schemes

Both are hidden now:
<img width="1528" height="182" alt="image" src="https://github.com/user-attachments/assets/289ee5f7-ab6e-40ba-b431-af415d0d7b57" />

closes: #1008 