### PR TITLE
[-] fix default dashboard path in `pgwatch-demo`

### DIFF
--- a/docker/demo/grafana.ini
+++ b/docker/demo/grafana.ini
@@ -15,7 +15,7 @@ org_name = Main Org.
 org_role = Editor
 
 [dashboards]
-default_home_dashboard_path = /var/lib/grafana/dashboards/1-global-db-overview.json
+default_home_dashboard_path = /var/lib/grafana/dashboards/postgres/1-global-db-overview.json
 
 [metrics]
 enabled = false


### PR DESCRIPTION
Sorry, I forgot to fix the default dashboard path in grafana config after change dashboards path in Dockerfile.
Fix #1032