### PR TITLE
[-] remove deprecated db types from webui, fixes #1044

### DIFF
--- a/internal/webui/src/containers/SourceFormDialog/components/SourceForm/SourceForm.consts.ts
+++ b/internal/webui/src/containers/SourceFormDialog/components/SourceForm/SourceForm.consts.ts
@@ -6,7 +6,7 @@ export enum SourceFormSteps {
   Tags = "Tags",
 };
 
-const kindValues = ["postgres", "postgres-continuous-discovery", "pgbouncer", "pgpool", "patroni", "patroni-continuous-discovery", "patroni-namespace-discovery"];
+const kindValues = ["postgres", "postgres-continuous-discovery", "pgbouncer", "pgpool", "patroni"];
 
 export const KindOptions = kindValues.map((val) => ({ label: val }));
 


### PR DESCRIPTION
- Remove deprecated `patroni-continuous-discovery` and `patroni-namespace-discovery` from the webui db type form, as they were deprecated in v4.

Closes #1044 