### PR TITLE
[-] pin `pgwatch-metrics` data source to all panels and vars.

### DIFF
--- a/grafana/postgres/v12/0-health-check.json
+++ b/grafana/postgres/v12/0-health-check.json
@@ -5041,10 +5041,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/3-query-performance-analysis.json
+++ b/grafana/postgres/v12/3-query-performance-analysis.json
@@ -1148,10 +1148,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/4-tables-overview.json
+++ b/grafana/postgres/v12/4-tables-overview.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 35,
+  "id": 26,
   "links": [],
   "panels": [
     {
@@ -1346,7 +1346,8 @@
     },
     {
       "datasource": {
-        "type": "postgres"
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
       },
       "description": "Interactive treemap visualization showing relative sizes of tables and their indexes. Larger rectangles represent bigger tables.",
       "fieldConfig": {
@@ -1388,7 +1389,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "postgres"
+            "type": "grafana-postgresql-datasource",
+            "uid": "pgwatch-metrics"
           },
           "format": "table",
           "rawQuery": true,
@@ -1401,7 +1403,8 @@
     },
     {
       "datasource": {
-        "type": "postgres"
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
       },
       "description": "Interactive treemap visualization showing table data sizes excluding indexes and TOAST. Useful for identifying tables with large amounts of actual data.",
       "fieldConfig": {
@@ -1439,7 +1442,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "postgres"
+            "type": "grafana-postgresql-datasource",
+            "uid": "pgwatch-metrics"
           },
           "format": "table",
           "rawQuery": true,
@@ -1452,7 +1456,8 @@
     },
     {
       "datasource": {
-        "type": "postgres"
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
       },
       "description": "Interactive treemap visualization showing index sizes. Helps identify large indexes that may need optimization or rebuilding.",
       "fieldConfig": {
@@ -1494,7 +1499,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "postgres"
+            "type": "grafana-postgresql-datasource",
+            "uid": "pgwatch-metrics"
           },
           "format": "table",
           "rawQuery": true,
@@ -1541,12 +1547,9 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
-          "type": "postgres"
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
         },
         "definition": "",
         "includeAll": false,

--- a/grafana/postgres/v12/5-table-details.json
+++ b/grafana/postgres/v12/5-table-details.json
@@ -2657,10 +2657,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -2677,10 +2673,6 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "pgwatch.metric",
-          "value": "pgwatch.metric"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/change-events.json
+++ b/grafana/postgres/v12/change-events.json
@@ -1233,10 +1233,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/checkpointer-bgwriter-stats.json
+++ b/grafana/postgres/v12/checkpointer-bgwriter-stats.json
@@ -855,10 +855,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/global-health.json
+++ b/grafana/postgres/v12/global-health.json
@@ -2034,6 +2034,10 @@
         "type": "custom"
       },
       {
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
+        },
         "allowCustomValue": false,
         "current": {
           "text": "db_stats",

--- a/grafana/postgres/v12/pgbouncer-stats.json
+++ b/grafana/postgres/v12/pgbouncer-stats.json
@@ -2121,9 +2121,9 @@
     "list": [
       {
         "allowCustomValue": false,
-        "current": {
-          "text": "",
-          "value": ""
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
         },
         "definition": "select dbname as monitoredsource from admin.all_distinct_dbname_metrics where metric = 'pgbouncer_stats';",
         "label": "Monitored Source",
@@ -2137,10 +2137,6 @@
       },
       {
         "allowCustomValue": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/postgres-version-overview.json
+++ b/grafana/postgres/v12/postgres-version-overview.json
@@ -241,10 +241,6 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "170004",
-          "value": "170004"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/sessions-overview.json
+++ b/grafana/postgres/v12/sessions-overview.json
@@ -1364,10 +1364,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/single-query-details.json
+++ b/grafana/postgres/v12/single-query-details.json
@@ -1235,10 +1235,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -1253,10 +1249,6 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -1332,10 +1324,6 @@
       },
       {
         "allowCustomValue": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/sproc-details.json
+++ b/grafana/postgres/v12/sproc-details.json
@@ -357,10 +357,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -375,10 +371,6 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "public.get_load_average",
-          "value": "public.get_load_average"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/sprocs-top.json
+++ b/grafana/postgres/v12/sprocs-top.json
@@ -1187,10 +1187,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/stat-statements-sql-search.json
+++ b/grafana/postgres/v12/stat-statements-sql-search.json
@@ -233,10 +233,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/stat-statements-top-fast.json
+++ b/grafana/postgres/v12/stat-statements-top-fast.json
@@ -1317,10 +1317,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/stat-statements-top-visual.json
+++ b/grafana/postgres/v12/stat-statements-top-visual.json
@@ -313,10 +313,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/stat-statements-top.json
+++ b/grafana/postgres/v12/stat-statements-top.json
@@ -1001,10 +1001,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/system-stats-time-lag.json
+++ b/grafana/postgres/v12/system-stats-time-lag.json
@@ -887,10 +887,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v12/system-stats.json
+++ b/grafana/postgres/v12/system-stats.json
@@ -1245,10 +1245,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"


### PR DESCRIPTION
This:
1. Pins the `pgwatch-metrics` data source in all panels and vars in Grafana 12 postgres dashboards.
2. Removes dummy `"current": ...` tags to ensure users with problems in data sources won't see weird hard-coded values.
---
The same for the Grafana 11 postgres dashboard will be done in a separate PR to avoid having a huge number of changed files = more potential for unintentionally breaking smth.