### PR TITLE
[-] pin `pgwatch-metrics` data source to all v11 panels and vars

### DIFF
--- a/grafana/postgres/v11/biggest-relations.json
+++ b/grafana/postgres/v11/biggest-relations.json
@@ -32,7 +32,8 @@
   "panels": [
     {
       "datasource": {
-        "type": "postgres"
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
       },
       "description": "",
       "fieldConfig": {
@@ -75,7 +76,8 @@
         {
           "alias": "$tag_table_name",
           "datasource": {
-            "type": "postgres"
+            "type": "grafana-postgresql-datasource",
+            "uid": "pgwatch-metrics"
           },
           "format": "table",
           "group": [],
@@ -130,7 +132,8 @@
     },
     {
       "datasource": {
-        "type": "postgres"
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
       },
       "description": "",
       "fieldConfig": {
@@ -173,7 +176,8 @@
         {
           "alias": "$tag_table_name",
           "datasource": {
-            "type": "postgres"
+            "type": "grafana-postgresql-datasource",
+            "uid": "pgwatch-metrics"
           },
           "format": "table",
           "group": [],
@@ -241,7 +245,8 @@
     },
     {
       "datasource": {
-        "type": "postgres"
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
       },
       "description": "",
       "fieldConfig": {
@@ -284,7 +289,8 @@
         {
           "alias": "$tag_index_name",
           "datasource": {
-            "type": "postgres"
+            "type": "grafana-postgresql-datasource",
+            "uid": "pgwatch-metrics"
           },
           "format": "table",
           "group": [],
@@ -339,7 +345,8 @@
     },
     {
       "datasource": {
-        "type": "postgres"
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
       },
       "editable": true,
       "error": false,
@@ -371,7 +378,8 @@
       {
         "current": {},
         "datasource": {
-          "type": "postgres"
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
         },
         "definition": "",
         "hide": 0,

--- a/grafana/postgres/v11/change-events.json
+++ b/grafana/postgres/v11/change-events.json
@@ -1229,12 +1229,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/checkpointer-bgwriter-stats.json
+++ b/grafana/postgres/v11/checkpointer-bgwriter-stats.json
@@ -858,11 +858,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/db-overview-developer.json
+++ b/grafana/postgres/v11/db-overview-developer.json
@@ -2708,12 +2708,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/db-overview-time-lag.json
+++ b/grafana/postgres/v11/db-overview-time-lag.json
@@ -1738,12 +1738,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/db-overview.json
+++ b/grafana/postgres/v11/db-overview.json
@@ -2685,12 +2685,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/health-check.json
+++ b/grafana/postgres/v11/health-check.json
@@ -28,7 +28,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "PRIMARY - accepting writes, REPLICA - read-only",
       "format": "none",
@@ -161,7 +164,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Time from last Postgres process restart.  < 5m Error, < 30m Warn thresholds by default",
       "format": "dtdurations",
@@ -295,7 +301,10 @@
         "#FA6400",
         "#299c46"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "\"SHOW server_version_num;\"\n110005 => 11.5",
       "format": "none",
@@ -429,7 +438,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Longest query duration during last $online_interval",
       "format": "dtdurations",
@@ -563,7 +575,10 @@
         "#299c46",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Connected sessions, including Postgres internal processes like Autovacuum. < 1 Warn / > 300 Error thresholds by default",
       "format": "short",
@@ -703,7 +718,10 @@
         "#FA6400",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "\"max_connections\" configuration setting. Changing requires re-start. 500/1000 Warn / Error thresholds by default",
       "format": "short",
@@ -843,7 +861,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Max number of queries waiting on resources locked by other sessions.  1 Warn / 5 Err thresholds by default",
       "format": "short",
@@ -983,7 +1004,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Shared Buffers is the Postgres -managed file cache and 90%+ is what you normally want to see for best performance.",
       "format": "percent",
@@ -1123,7 +1147,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "0.5% Warn / 1% Error thresholds by default",
       "format": "percent",
@@ -1257,7 +1284,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Transactions per Second. Last $online_interval average. <0.1 % Error / < 1.0 Warn thresholds by default",
       "format": "short",
@@ -1391,7 +1421,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Queries per Second based on  \"pg_stat_statements\" extension info. Last $online_interval avg. < 0.1 Error / < 1 Warning thresholds by default",
       "format": "short",
@@ -1525,7 +1558,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Transactions opened but where no queries are being executed.",
       "format": "short",
@@ -1665,7 +1701,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Size for selected DB only",
       "format": "bytes",
@@ -1799,7 +1838,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "",
       "format": "bytes",
@@ -1933,7 +1975,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Assumes get_psutil_disk wrapper being installed. 10/50GB Warn/Error thresholds by default",
       "format": "bytes",
@@ -2073,7 +2118,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Last $online_interval avg. based on \"pg_stat_statements\" info.  > 0.5s Warning / > 5s  Error thresholds by default",
       "format": "ms",
@@ -2207,7 +2255,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Server configuration changes.  >1 Warn thresholds by default",
       "format": "short",
@@ -2347,7 +2398,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Number of DDL changes i.e. new or changed tables, columns, functions etc.  >1 Warn thresholds by default",
       "format": "short",
@@ -2487,7 +2541,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Based on pg_stat_archiver. N/A when archiving is not enabled.",
       "format": "none",
@@ -2631,7 +2688,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Transaction Log Folder size.  Assumes get_wal_size helper being installed. 1/10 GB Warn / 50  Error  thresholds by default",
       "format": "bytes",
@@ -2765,7 +2825,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Invalid indexes should be dropped as they're updated on DML operations but cannot be used for speeding up queries. In case multiple indexes of same structure Postgres will use the smallest so the others can be dropped. 'N/A' displayed both when no duplicate indexes or no metrics data for index_stats.",
       "format": "short",
@@ -2893,7 +2956,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "i.e. AUTOVACUUM disabled globally or per table.",
       "format": "short",
@@ -3021,7 +3087,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Checkpoints should normally be performed by the background \"Checkpointer\" process. If seeing high numbers then adjusting server configuration is recommended.",
       "format": "none",
@@ -3161,7 +3230,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Estimated extra space held by tables (excluding indexes) that would disappear after \"compacting\".",
       "format": "bytes",
@@ -3289,7 +3361,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Transaction logs generation velocity.",
       "format": "bytes",
@@ -3435,7 +3510,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Postgres writes temporary files to disk when sorting / grouping  big amounts of data that doesn't fit into \"work_mem\".  10/100 MB Warn / Error by default",
       "format": "bytes",
@@ -3581,7 +3659,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Long running AUTOVACUUM processes can hint at workload or configuration  problems",
       "format": "dtdurations",
@@ -3715,7 +3796,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Frequent sequential scans on bigger tables should usually be avoided. Warn / Error thresholds: 10 / 100",
       "format": "short",
@@ -3861,7 +3945,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "On non-temporary  tables",
       "format": "short",
@@ -4007,7 +4094,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "On non-temporary  tables",
       "format": "short",
@@ -4153,7 +4243,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "On non-temporary  tables",
       "format": "short",
@@ -4299,7 +4392,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Based on db_stats.backup_duration_s  / pg_backup_start_time() [9.3+] function. N/A if no backup in progress.",
       "format": "dtdurations",
@@ -4433,7 +4529,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Max. age since last VACUUM FREEZE. Could hint at problems when going into 100s of millions",
       "format": "short",
@@ -4567,7 +4666,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "In TX. Holds back VACUUM",
       "format": "short",
@@ -4707,7 +4809,10 @@
         "#bf1b00",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 0,
       "description": "Inactive repl. slots accumulate WAL files until disk space runs out. Re-animate the replica or use  pg_drop_replication_slot() to remove the slot so that Postgres can delete the un-needed WALs.",
       "format": "none",
@@ -4841,7 +4946,10 @@
         "#FA6400",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": null,
       "description": "\"Apply\" (data made visible to queries on replica)  lag in bytes",
       "format": "bytes",
@@ -5012,7 +5120,10 @@
           "text": null,
           "value": null
         },
-        "datasource": null,
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
+        },
         "definition": "",
         "hide": 0,
         "includeAll": false,

--- a/grafana/postgres/v11/lock-details.json
+++ b/grafana/postgres/v11/lock-details.json
@@ -185,11 +185,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/pgbouncer-stats.json
+++ b/grafana/postgres/v11/pgbouncer-stats.json
@@ -2012,12 +2012,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/postgres-version-overview.json
+++ b/grafana/postgres/v11/postgres-version-overview.json
@@ -279,11 +279,6 @@
         "useTags": false
       },
       {
-        "current": {
-          "selected": false,
-          "text": "160002",
-          "value": "160002"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/sessions-overview.json
+++ b/grafana/postgres/v11/sessions-overview.json
@@ -1267,11 +1267,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/single-query-details.json
+++ b/grafana/postgres/v11/single-query-details.json
@@ -1335,11 +1335,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -1361,12 +1356,6 @@
         "useTags": false
       },
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/sproc-details.json
+++ b/grafana/postgres/v11/sproc-details.json
@@ -345,11 +345,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -371,11 +366,6 @@
         "useTags": false
       },
       {
-        "current": {
-          "selected": false,
-          "text": "_timescaledb_functions.policy_job_error_retention",
-          "value": "_timescaledb_functions.policy_job_error_retention"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/sprocs-top.json
+++ b/grafana/postgres/v11/sprocs-top.json
@@ -1220,11 +1220,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/stat-activity.json
+++ b/grafana/postgres/v11/stat-activity.json
@@ -189,12 +189,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/stat-statements-sql-search.json
+++ b/grafana/postgres/v11/stat-statements-sql-search.json
@@ -247,10 +247,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/stat-statements-top-fast.json
+++ b/grafana/postgres/v11/stat-statements-top-fast.json
@@ -21,7 +21,10 @@
   "panels": [
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "description": "",
       "fontSize": "90%",
       "gridPos": {
@@ -219,7 +222,10 @@
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "description": "",
       "fontSize": "90%",
       "gridPos": {
@@ -383,7 +389,10 @@
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "description": "",
       "fontSize": "90%",
       "gridPos": {
@@ -564,7 +573,10 @@
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "description": "total_time - blk_read_time -blk_write_time. Requires track_io_timing=on",
       "fontSize": "100%",
       "gridPos": {
@@ -720,7 +732,10 @@
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "description": "Does not include Shared Buffer activities. Same as 'By total runtime' if no direct IO was performed. Requires track_io_timing=on",
       "fontSize": "100%",
       "gridPos": {
@@ -876,7 +891,10 @@
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "description": "Shared buffer + temp buffer reading / writing",
       "fontSize": "100%",
       "gridPos": {
@@ -1050,7 +1068,10 @@
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "description": "Based on pg_stat_statements.temp_blks_written",
       "fontSize": "100%",
       "gridPos": {
@@ -1241,7 +1262,10 @@
     },
     {
       "content": "<h2>Brought to you by</h2><div style=\"padding: 25px;\"><a href=\"https://www.cybertec-postgresql.com/en/\"><img src=\"https://www.cybertec-postgresql.com/wp-content/uploads/2025/02/cybertec-logo-white-blue.svg\" alt=\"Cybertec – The PostgreSQL Database Company\"></a></div>",
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "editable": true,
       "error": false,
       "gridPos": {
@@ -1266,7 +1290,10 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1380,12 +1407,10 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "tags": [],
-          "text": null,
-          "value": null
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
         },
-        "datasource": null,
         "definition": "",
         "hide": 0,
         "includeAll": false,

--- a/grafana/postgres/v11/stat-statements-top-visual.json
+++ b/grafana/postgres/v11/stat-statements-top-visual.json
@@ -315,10 +315,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "demo",
-          "value": "demo"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/stat-statements-top.json
+++ b/grafana/postgres/v11/stat-statements-top.json
@@ -1279,11 +1279,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "isNone": true,
-          "text": "None",
-          "value": ""
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/system-stats-time-lag.json
+++ b/grafana/postgres/v11/system-stats-time-lag.json
@@ -23,7 +23,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -159,7 +162,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -295,7 +301,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "(total - available) /  total * 100",
       "fill": 1,
@@ -432,7 +441,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": null,
       "fill": 1,
       "fillGradient": 0,
@@ -567,7 +579,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -702,7 +717,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -838,7 +856,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -979,7 +1000,10 @@
     "list": [
       {
         "allValue": null,
-        "datasource": null,
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
+        },
         "definition": "SELECT DISTINCT dbname FROM admin.all_distinct_dbname_metrics WHERE metric LIKE 'psutil%' ORDER BY 1;",
         "hide": 0,
         "includeAll": false,

--- a/grafana/postgres/v11/system-stats.json
+++ b/grafana/postgres/v11/system-stats.json
@@ -30,7 +30,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "a.k.a. CPU run  queue length or Load Average, reported e.g. by the \"uptime\" command",
       "fill": 1,
@@ -178,7 +181,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "System-wide CPU utilization as reported by psutil.cpu_percent()",
       "fill": 1,
@@ -330,7 +336,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "fill": 1,
       "gridPos": {
@@ -469,7 +478,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Doesn't have to necessarily equal 100%  to values reported by the \"free\" command - see [here](https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory) for more",
       "fill": 1,
@@ -608,7 +620,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "Doesn't have to necessarily equal 100%  to values reported by the \"free\" command - see [here](https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory) for more",
       "fill": 1,
@@ -747,7 +762,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "For all disks on the host, not only Postgres related",
       "fill": 1,
@@ -892,7 +910,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "For Postgres data / WAL / log folder partitions and user defined tablespace partitions",
       "fill": 1,
@@ -1044,7 +1065,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "pgwatch-metrics"
+      },
       "decimals": 1,
       "description": "For Postgres data / WAL / log folder partitions and user defined tablespace partitions",
       "fill": 1,
@@ -1218,10 +1242,10 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "text": null
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "pgwatch-metrics"
         },
-        "datasource": null,
         "definition": "",
         "hide": 0,
         "includeAll": false,

--- a/grafana/postgres/v11/table-details-time-lag.json
+++ b/grafana/postgres/v11/table-details-time-lag.json
@@ -1524,11 +1524,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -1550,11 +1545,6 @@
         "useTags": false
       },
       {
-        "current": {
-          "selected": false,
-          "text": "pgwatch.metric",
-          "value": "pgwatch.metric"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/table-details.json
+++ b/grafana/postgres/v11/table-details.json
@@ -1105,11 +1105,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"
@@ -1129,11 +1124,6 @@
         "useTags": false
       },
       {
-        "current": {
-          "selected": false,
-          "text": "pgwatch.metric",
-          "value": "pgwatch.metric"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"

--- a/grafana/postgres/v11/tables-top.json
+++ b/grafana/postgres/v11/tables-top.json
@@ -1997,11 +1997,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "test",
-          "value": "test"
-        },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "pgwatch-metrics"


### PR DESCRIPTION
This:

1. Pins the `pgwatch-metrics` data source in all panels and vars in Grafana 11 postgres dashboards.
2. Removes dummy `"current": ...` tags to ensure users with problems in data sources won't see weird hard-coded values.