### PR TITLE
[-] fix sql of `Shared Buffers hit pct` panel

### DIFF
--- a/grafana/postgres/v12/0-health-check.json
+++ b/grafana/postgres/v12/0-health-check.json
@@ -1020,7 +1020,7 @@
           "orderByTime": "ASC",
           "policy": "default",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  ((hit-hit_lag)::numeric / ((hit-hit_lag) + (read-read_lag)))*100 as \"Shared buffers hit ratio\"\nfrom (\n        select \n          (data->>'blks_hit')::int8 as hit, lag((data->>'blks_hit')::int8) over w as hit_lag,\n          (data->>'blks_read')::int8 as read, lag((data->>'blks_read')::int8) over w as read_lag,\n          (data->>'xact_rollback')::int8 as roll, lag((data->>'xact_rollback')::int8) over w as roll_lag,\n          (data->>'xact_commit')::int8 as comm, lag((data->>'xact_commit')::int8) over w as comm_lag,\n          time\n        from db_stats\n        where dbname = '$dbname' and $__timeFilter(time)\n        window w as (order by time)\n) x\nwhere hit > hit_lag or read > read_lag\norder by 1",
+          "rawSql": "select\n  time,\n  ((hit-hit_lag)::numeric / ((hit-hit_lag) + (read-read_lag)))*100 as \"Shared buffers hit ratio\"\nfrom (\n        select \n          (data->>'blks_hit')::int8 as hit, lag((data->>'blks_hit')::int8) over w as hit_lag,\n          (data->>'blks_read')::int8 as read, lag((data->>'blks_read')::int8) over w as read_lag,\n          time\n        from db_stats\n        where dbname = '$dbname' and $__timeFilter(time)\n        window w as (order by time)\n) x\nwhere hit > hit_lag or read > read_lag\norder by 1",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [


### PR DESCRIPTION
The lines below in the `Shard Buffers hit pct` panel in the `0. Health Check` dashboard are unnecessary and decrease query performance:
```
(data->>'xact_rollback')::int8 as roll, lag((data->>'xact_rollback')::int8) over w as roll_lag,
(data->>'xact_commit')::int8 as comm, lag((data->>'xact_commit')::int8) over w as comm_lag,
```
---
It seems the query was copied as is from `TX rollback pct`, and those weren't removed.