### PR TITLE
[*] set lock_timeout via connection RuntimeParams instead of per-query transaction

### DIFF
--- a/internal/sources/cmdopts.go
+++ b/internal/sources/cmdopts.go
@@ -9,5 +9,4 @@ type CmdOpts struct {
 	MaxParallelConnectionsPerDb  int      `long:"max-parallel-connections-per-db" mapstructure:"max-parallel-connections-per-db" description:"Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances" env:"PW_MAX_PARALLEL_CONNECTIONS_PER_DB" default:"4"`
 	TryCreateListedExtsIfMissing string   `long:"try-create-listed-exts-if-missing" mapstructure:"try-create-listed-exts-if-missing" description:"Try creating the listed extensions (comma sep.) on first connect for all monitored DBs when missing. Main usage - pg_stat_statements" env:"PW_TRY_CREATE_LISTED_EXTS_IF_MISSING" default:""`
 	CreateHelpers                bool     `long:"create-helpers" mapstructure:"create-helpers" description:"Create helper database objects from metric definitions" env:"PW_CREATE_HELPERS"`
-	ConnLockTimeout              string   `long:"conn-lock-timeout" mapstructure:"conn-lock-timeout" description:"PostgreSQL lock_timeout for metric query connections. Set to 0 to disable" env:"PW_CONN_LOCK_TIMEOUT" default:"100ms"`
 }

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -89,11 +89,6 @@ func (md *SourceConn) Connect(ctx context.Context, opts CmdOpts) (err error) {
 		if opts.MaxParallelConnectionsPerDb > 0 {
 			md.ConnConfig.MaxConns = int32(opts.MaxParallelConnectionsPerDb)
 		}
-		// Set lock_timeout at connection level for PostgreSQL sources to avoid
-		// wrapping every query in a transaction with SET LOCAL lock_timeout
-		if md.IsPostgresSource() && opts.ConnLockTimeout != "" && opts.ConnLockTimeout != "0" {
-			md.ConnConfig.ConnConfig.RuntimeParams["lock_timeout"] = opts.ConnLockTimeout
-		}
 		md.Conn, err = NewConnWithConfig(ctx, md.ConnConfig)
 		if err != nil {
 			return err


### PR DESCRIPTION
Reduces metric queries from 4 roundtrips (BEGIN/SET/query/COMMIT) to 1 by setting lock_timeout at connection level via pgx RuntimeParams.

- Add --conn-lock-timeout option (default: 100ms, env: PW_CONN_LOCK_TIMEOUT)
- Set lock_timeout in RuntimeParams for PostgreSQL sources on connect
- Simplify QueryMeasurements by removing transaction wrapper
- Set to "0" to disable lock_timeout

Ref: https://brandur.org/fragments/postgres-parameters