### PR TITLE
webui: fix preset sorting order and ESLint issues

### DIFF
--- a/internal/webui/src/constants/presets.ts
+++ b/internal/webui/src/constants/presets.ts
@@ -1,0 +1,18 @@
+export const PRESET_ORDER = [
+  "minimal",
+  "basic",
+  "standard",
+  "exhaustive",
+  "full",
+  "aiven",
+  "azure",
+  "gce",
+  "rds",
+  "pgbouncer",
+  "pgpool",
+  "unprivileged",
+  "recommendations",
+  "prometheus-async",
+  "exhaustive_no_python",
+  "debug",
+];

--- a/internal/webui/src/containers/SourceFormDialog/components/SourceForm/components/SourceFormStepMetrics.tsx
+++ b/internal/webui/src/containers/SourceFormDialog/components/SourceForm/components/SourceFormStepMetrics.tsx
@@ -1,3 +1,4 @@
+import { PRESET_ORDER } from "constants/presets";
 import { useEffect, useMemo } from "react";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { Button, Checkbox, FormControl, FormControlLabel, FormHelperText, IconButton, InputLabel, OutlinedInput } from "@mui/material";
@@ -12,25 +13,10 @@ type PresetOption = {
   label: string;
   description?: string;
 };
-const PRESET_PRIORITY = [
-  "minimal",
-  "basic",
-  "standard",
-  "exhaustive",
-  "full",
-  "aiven",
-  "azure",
-  "gce",
-  "rds",
-  "pgbouncer",
-  "pgpool",
-  "unprivileged",
-  "recommendations",
-  "prometheus-async",
-  "exhaustive_no_python",
-  "debug",
-];
 
+type PresetMeta = {
+  Description?: string;
+};
 
 export const SourceFormStepMetrics = () => {
   const { control, register, watch, formState: { errors }, clearErrors } = useFormContext<SourceFormValues>();
@@ -58,23 +44,16 @@ export const SourceFormStepMetrics = () => {
 
   const presets = usePresets();
   const metrics = useMetrics();
-
-
-type PresetMeta = {
-  Description?: string;
-};
-
 const presetsOptions = useMemo<PresetOption[]>(() => {
   
-
   if (!presets.data) {
     return [];
   }
 
   return Object.entries(presets.data)
     .sort(([a], [b]) => {
-      const ia = PRESET_PRIORITY.indexOf(a);
-      const ib = PRESET_PRIORITY.indexOf(b);
+      const ia = PRESET_ORDER.indexOf(a);
+      const ib = PRESET_ORDER.indexOf(b);
 
       if (ia === -1 && ib === -1) {
         return a.localeCompare(b);

--- a/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
+++ b/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
@@ -1,3 +1,4 @@
+import { PRESET_ORDER } from "constants/presets";
 import { useMemo } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import { Error } from "components/Error/Error";
@@ -10,25 +11,6 @@ import { usePresets } from "queries/Preset";
 import { usePresetsGridColumns } from "./PresetsGrid.consts";
 import { PresetGridRow } from "./PresetsGrid.types";
 import { PresetsGridToolbar } from "./components/PresetsGridToolbar/PresetsGridToolbar";
-
-const PRESET_ORDER = [
-  "minimal",
-  "basic",
-  "standard",
-  "exhaustive",
-  "full",
-  "aiven",
-  "azure",
-  "gce",
-  "rds",
-  "pgbouncer",
-  "pgpool",
-  "unprivileged",
-  "recommendations",
-  "prometheus-async",
-  "exhaustive_no_python",
-  "debug",
-];
 
 export const PresetsGrid = () => {
   const { classes } = usePageStyles();


### PR DESCRIPTION
Hi @0xgouda, thanks for the feedback!

I’ve moved the changes to a dedicated branch as suggested and updated the preset
sorting order to:

minimal
basic
standard
exhaustive
full
aiven
azure
gce
rds
pgbouncer
pgpool
unprivileged
recommendations
prometheus-async
exhaustive_no_python
debug

The same ordering is now used as the default in the Presets tab as well.
All checks are passing locally.

Please let me know if anything else is needed 🙏
