### PR TITLE
[+] add `admin.maintain_unique_sources()` to Postgres sink

### DIFF
--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -510,97 +510,12 @@ func (pgw *PostgresWriter) DeleteOldPartitions() {
 // This is used to avoid listing the same source multiple times in Grafana dropdowns.
 func (pgw *PostgresWriter) MaintainUniqueSources() {
 	logger := log.GetLogger(pgw.ctx)
-
-	sqlGetAdvisoryLock := `SELECT pg_try_advisory_lock(1571543679778230000) AS have_lock` // 1571543679778230000 is just a random bigint
-	sqlTopLevelMetrics := `SELECT table_name FROM admin.get_top_level_metric_tables()`
-	sqlDistinct := `
-	WITH RECURSIVE t(dbname) AS (
-		SELECT MIN(dbname) AS dbname FROM %s
-		UNION
-		SELECT (SELECT MIN(dbname) FROM %s WHERE dbname > t.dbname) FROM t 
-	)
-	SELECT dbname FROM t WHERE dbname NOTNULL ORDER BY 1`
-	sqlDelete := `DELETE FROM admin.all_distinct_dbname_metrics WHERE NOT dbname = ANY($1) and metric = $2`
-	sqlDeleteAll := `DELETE FROM admin.all_distinct_dbname_metrics WHERE metric = $1`
-	sqlDroppedTables := `DELETE FROM admin.all_distinct_dbname_metrics WHERE metric != ALL($1)`
-	sqlAdd := `
-		INSERT INTO admin.all_distinct_dbname_metrics 
-		SELECT u, $2 FROM (select unnest($1::text[]) as u) x
-		WHERE NOT EXISTS (select * from admin.all_distinct_dbname_metrics where dbname = u and metric = $2)
-		RETURNING *`
-
-	var lock bool
-	logger.Infof("Trying to get admin.all_distinct_dbname_metrics maintainer advisory lock...") // to only have one "maintainer" in case of a "push" setup, as can get costly
-	if err := pgw.sinkDb.QueryRow(pgw.ctx, sqlGetAdvisoryLock).Scan(&lock); err != nil {
-		logger.Error("Getting admin.all_distinct_dbname_metrics maintainer advisory lock failed:", err)
+	var rowsAffected int
+	if err := pgw.sinkDb.QueryRow(pgw.ctx, `SELECT admin.maintain_unique_sources()`).Scan(&rowsAffected); err != nil {
+		logger.Error("Failed to run admin.all_distinct_dbname_metrics maintenance:", err)
 		return
 	}
-	if !lock {
-		logger.Info("Skipping admin.all_distinct_dbname_metrics maintenance as another instance has the advisory lock...")
-		return
-	}
-
-	logger.Info("Refreshing admin.all_distinct_dbname_metrics listing table...")
-	rows, _ := pgw.sinkDb.Query(pgw.ctx, sqlTopLevelMetrics)
-	allDistinctMetricTables, err := pgx.CollectRows(rows, pgx.RowTo[string])
-	if err != nil {
-		logger.Error(err)
-		return
-	}
-
-	for i, tableName := range allDistinctMetricTables {
-		foundDbnamesMap := make(map[string]bool)
-		foundDbnamesArr := make([]string, 0)
-
-		metricName := strings.Replace(tableName, "public.", "", 1)
-		// later usage in sqlDroppedTables requires no "public." prefix
-		allDistinctMetricTables[i] = metricName
-
-		logger.Debugf("Refreshing all_distinct_dbname_metrics listing for metric: %s", metricName)
-		rows, _ := pgw.sinkDb.Query(pgw.ctx, fmt.Sprintf(sqlDistinct, tableName, tableName))
-		ret, err := pgx.CollectRows(rows, pgx.RowTo[string])
-		if err != nil {
-			logger.Errorf("Could not refresh Postgres all_distinct_dbname_metrics listing table for metric '%s': %s", metricName, err)
-			continue
-		}
-		for _, drDbname := range ret {
-			foundDbnamesMap[drDbname] = true // "set" behaviour, don't want duplicates
-		}
-
-		// delete all that are not known and add all that are not there
-		for k := range foundDbnamesMap {
-			foundDbnamesArr = append(foundDbnamesArr, k)
-		}
-		if len(foundDbnamesArr) == 0 { // delete all entries for given metric
-			logger.Debugf("Deleting Postgres all_distinct_dbname_metrics listing table entries for metric '%s':", metricName)
-
-			_, err = pgw.sinkDb.Exec(pgw.ctx, sqlDeleteAll, metricName)
-			if err != nil {
-				logger.Errorf("Could not delete Postgres all_distinct_dbname_metrics listing table entries for metric '%s': %s", metricName, err)
-			}
-			continue
-		}
-		cmdTag, err := pgw.sinkDb.Exec(pgw.ctx, sqlDelete, foundDbnamesArr, metricName)
-		if err != nil {
-			logger.Errorf("Could not refresh Postgres all_distinct_dbname_metrics listing table for metric '%s': %s", metricName, err)
-		} else if cmdTag.RowsAffected() > 0 {
-			logger.Infof("Removed %d stale entries from all_distinct_dbname_metrics listing table for metric: %s", cmdTag.RowsAffected(), metricName)
-		}
-		cmdTag, err = pgw.sinkDb.Exec(pgw.ctx, sqlAdd, foundDbnamesArr, metricName)
-		if err != nil {
-			logger.Errorf("Could not refresh Postgres all_distinct_dbname_metrics listing table for metric '%s': %s", metricName, err)
-		} else if cmdTag.RowsAffected() > 0 {
-			logger.Infof("Added %d entry to the Postgres all_distinct_dbname_metrics listing table for metric: %s", cmdTag.RowsAffected(), metricName)
-		}
-		time.Sleep(time.Minute)
-	}
-
-	cmdTag, err := pgw.sinkDb.Exec(pgw.ctx, sqlDroppedTables, allDistinctMetricTables)
-	if err != nil {
-		logger.Errorf("Could not refresh Postgres all_distinct_dbname_metrics listing table for dropped metric tables: %s", err)
-	} else if cmdTag.RowsAffected() > 0 {
-		logger.Infof("Removed %d stale entries for dropped tables from all_distinct_dbname_metrics listing table", cmdTag.RowsAffected())
-	}
+	logger.WithField("rows", rowsAffected).Info("Successfully processed admin.all_distinct_dbname_metrics")
 }
 
 func (pgw *PostgresWriter) AddDBUniqueMetricToListingTable(dbUnique, metric string) error {

--- a/internal/sinks/sql/admin_schema.sql
+++ b/internal/sinks/sql/admin_schema.sql
@@ -50,8 +50,9 @@ create table admin.config (
 
 -- to later change the value call the admin.change_timescale_chunk_interval(interval) function!
 -- as changing the row directly will only be effective for completely new tables (metrics).
-insert into admin.config select 'timescale_chunk_interval', '2 days';
-insert into admin.config select 'timescale_compress_interval', '1 day';
+insert into admin.config (key, value) values 
+  ('timescale_chunk_interval', '2 days'),
+  ('timescale_compress_interval', '1 day');
 
 create or replace function trg_config_modified() returns trigger
 as $$


### PR DESCRIPTION
The function maintains a mapping of unique sources in each metric table in `admin.all_distinct_dbname_metrics`. This is used to avoid listing the same source multiple times in Grafana dropdowns.

Returns the total number of rows affected by all operations.

Use this function in `PostgresWriter.MaintainUniqueSources()`