### PR TITLE
[+] minor improvement to `Missing Indexes` panel

### DIFF
--- a/grafana/postgres/v12/index-overview.json
+++ b/grafana/postgres/v12/index-overview.json
@@ -186,7 +186,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n    dbname AS \"Source Name\",\n    tag_data->>'object_name' AS \"Table Name\",\n    data->>'affected_query_count' AS \"Affected Queries\",\n    data->>'query_id' AS \"Heaviest Query\",\n    data->>'recommendation' AS \"Recommendation\"\nFROM recommendations \nWHERE \n  time in (\n    select max(time) \n    from recommendations \n    where $__timeFilter(time) AND dbname in ($dbname) and tag_data->>'reco_topic' = 'create_index' \n    group by dbname\n  )\n  AND dbname IN ($dbname)\n",
+          "rawSql": "SELECT\n    dbname AS \"Source Name\",\n    tag_data->>'object_name' AS \"Table Name\",\n    data->>'affected_query_count' AS \"Affected Queries\",\n    data->>'query_id' AS \"Heaviest Query\",\n    data->>'recommendation' AS \"Recommendation\"\nFROM recommendations \nWHERE \n  time in (\n    select max(time) \n    from recommendations \n    where $__timeFilter(time) AND dbname in ($dbname) and tag_data->>'reco_topic' = 'create_index' \n    group by dbname\n  )\n  AND dbname IN ($dbname) AND tag_data->>'reco_topic' = 'create_index' \nORDER BY (data->>'total_exec_time')::float8 DESC",
           "refId": "A",
           "select": [
             [

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -1420,7 +1420,8 @@ metrics:
                     'create_index'::text as tag_reco_topic,
                     qrs.query_id,
                     qrs.affected_query_count,
-                    qrs.recommendation
+                    qrs.recommendation,
+                    s.total_exec_time
                 from 
                     qrs
                 join pg_stat_statements s on qrs.query_id = s.queryid


### PR DESCRIPTION
- A minor improvement that builds on top of #1117.
- Here we just include `total_exec_time` in the select fields of `reco_add_index` to order the index recommendations in the panel from most important to least. 