### PR TITLE
Fix sink upgrade - error to warning

### DIFF
--- a/cmd/pgwatch/main.go
+++ b/cmd/pgwatch/main.go
@@ -67,6 +67,22 @@ func main() {
 
 	// check if some sub-command was executed and exit
 	if opts.CommandCompleted {
+		if err != nil {
+			var upgErr *cmdopts.ErrUpgradeNotSupported
+			if errors.As(err, &upgErr) {
+				log.GetLogger(mainCtx).Warnf(
+					"[%s] configuration storage does not support upgrade, skipping",
+					upgErr.Target,
+				)
+				exitCode.Store(cmdopts.ExitCodeOK)
+				return
+			}
+
+			log.GetLogger(mainCtx).Error(err)
+			exitCode.Store(opts.ExitCode)
+			return
+		}
+
 		exitCode.Store(opts.ExitCode)
 		return
 	}

--- a/cmd/pgwatch/version.go
+++ b/cmd/pgwatch/version.go
@@ -7,8 +7,8 @@ var (
 	commit       = "unknown"
 	version      = "unknown"
 	date         = "unknown"
-	ConfigSchema = "00824"
-	SinkSchema   = "01110"
+	configSchema = "00824"
+	sinkSchema   = "01110"
 )
 
 func printVersion() {
@@ -20,5 +20,5 @@ Version info:
   Git Commit:    %s
   Built:         %s
 
-`, version, ConfigSchema, SinkSchema, commit, date)
+`, version, configSchema, sinkSchema, commit, date)
 }

--- a/internal/cmdopts/cmdconfig_test.go
+++ b/internal/cmdopts/cmdconfig_test.go
@@ -74,7 +74,7 @@ func TestConfigInitCommand_Execute(t *testing.T) {
 func TestConfigUpgradeCommand_Execute(t *testing.T) {
 	a := assert.New(t)
 
-	t.Run("sources and metrics are empty", func(*testing.T) {
+	t.Run("no upgrade target specified", func(*testing.T) {
 		os.Args = []string{0: "config_test", "config", "upgrade"}
 		_, err := New(io.Discard)
 		a.Error(err)
@@ -84,9 +84,8 @@ func TestConfigUpgradeCommand_Execute(t *testing.T) {
 		fname := t.TempDir() + "/metrics.yaml"
 		os.Args = []string{0: "config_test", "--metrics=" + fname, "config", "upgrade"}
 		c, err := New(io.Discard)
-		a.NoError(err)
-		a.True(c.CommandCompleted)
-		a.Equal(ExitCodeOK, c.ExitCode)
+		a.Error(err)
+		a.False(c.CommandCompleted)
 	})
 
 }
@@ -309,7 +308,8 @@ func TestConfigUpgradeCommand_Errors(t *testing.T) {
 		}
 		cmd := ConfigUpgradeCommand{owner: opts}
 		err := cmd.Execute(nil)
-		a.NoError(err)
+		a.Error(err)
+
 	})
 
 	t.Run("init metrics reader fails", func(*testing.T) {

--- a/internal/cmdopts/cmdoptions.go
+++ b/internal/cmdopts/cmdoptions.go
@@ -186,11 +186,11 @@ func (c *Options) NeedsSchemaUpgrade() (upgrade bool, err error) {
 }
 
 // ValidateConfig checks if the configuration is valid.
-// Configuration database can be specified for one of the --sources or --metrics.
+// Configuration database can be specified for one of the --sources or --metrics or --sink.
 // If one is specified, the other one is set to the same value.
 func (c *Options) ValidateConfig() error {
-	if len(c.Sources.Sources)+len(c.Metrics.Metrics) == 0 {
-		return errors.New("both --sources and --metrics are empty")
+	if len(c.Sources.Sources) == 0 && len(c.Metrics.Metrics) == 0 && len(c.Sinks.Sinks) == 0 {
+		return errors.New("at least one of --sources, --metrics, or --sink must be provided")
 	}
 	switch { // if specified configuration database, use it for both sources and metrics
 	case c.Sources.Sources == "" && c.IsPgConnStr(c.Metrics.Metrics):

--- a/internal/cmdopts/errors.go
+++ b/internal/cmdopts/errors.go
@@ -1,0 +1,11 @@
+package cmdopts
+
+// ErrUpgradeNotSupported is returned when a config backend
+// does not support schema upgrades (e.g. YAML files).
+type ErrUpgradeNotSupported struct {
+	Target string // sources.yaml / metrics.yaml / sinks
+}
+
+func (e *ErrUpgradeNotSupported) Error() string {
+	return "configuration storage does not support upgrade"
+}


### PR DESCRIPTION
Allow sink-only config upgrades when sources or metrics storage do not support upgrades.

Unsupported upgrades now emit a warning instead of failing, and the sink schema upgrade proceeds as expected.
The "--version" output was also updated to include the sink schema version.
the error message turned into warning.

Fixes #1114