### PR TITLE
[*] don't remove `\n \t \r` meta chars from query text

### DIFF
--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -2201,7 +2201,7 @@ metrics:
                     b.wal_fpi,
                     b.wal_bytes,
                     b.total_plan_time,
-                    ltrim(regexp_replace(b.query, E'[ \\t\\n\\r]+', ' ', 'g')) AS tag_query
+                    ltrim(b.query) AS tag_query
                 FROM (
                     SELECT
                         *
@@ -2351,7 +2351,7 @@ metrics:
                     b.wal_bytes,
                     b.total_plan_time,
                     b.jit_generation_time,
-                    ltrim(regexp_replace(b.query, E'[ \\t\\n\\r]+', ' ', 'g')) AS tag_query
+                    ltrim(b.query) AS tag_query
                 FROM (
                     SELECT
                         *
@@ -2514,7 +2514,7 @@ metrics:
                     b.wal_bytes,
                     b.total_plan_time,
                     b.jit_generation_time,
-                    ltrim(regexp_replace(b.query, E'[ \\t\\n\\r]+', ' ', 'g')) AS tag_query
+                    ltrim(b.query) AS tag_query
                 FROM (
                     SELECT
                         *


### PR DESCRIPTION
for better visualization for the query text in `Single query details` dashboard

closes: #1141 

before:
<img width="1079" height="137" alt="image" src="https://github.com/user-attachments/assets/8f03ea78-8253-4a2b-ad9f-e62d145dd35d" />

after:
<img width="1587" height="196" alt="image" src="https://github.com/user-attachments/assets/25503063-242b-4440-ad14-5c954732605d" />
