### PR TITLE
fix: config upgrade circular dependency

### DIFF
--- a/internal/metrics/postgres.go
+++ b/internal/metrics/postgres.go
@@ -34,6 +34,23 @@ func NewPostgresMetricReaderWriterConn(ctx context.Context, conn db.PgxPoolIface
 	return dmrw, conn.Ping(ctx)
 }
 
+func NewPostgresMetricMigrator(ctx context.Context, connstr string) (Migrator, error) {
+	conn, err := db.New(ctx, connstr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := initSchema(ctx, conn); err != nil {
+		return nil, err
+	}
+	// create struct but don't check for migrations
+	dmrw := &dbMetricReaderWriter{
+		ctx:      ctx,
+		configDb: conn,
+	}
+	return dmrw, conn.Ping(ctx)
+}
+
 type dbMetricReaderWriter struct {
 	ctx      context.Context
 	configDb db.PgxIface


### PR DESCRIPTION
Fixes #1156 

Created dedicated migration-only constructors that skip the migration check:
1. Added `NewPostgresMetricMigrator()` and `NewPostgresSinkMigrator()`
2. Updated `Execute()` in `internal/cmdopts/cmdconfig.go` to use the new migrator constructors instead of full reader/writer initialization