### PR TITLE
[*] remove redundant `Source Name` from `Tables Overview` dashboard, fixes #1134

### DIFF
--- a/grafana/postgres/v12/4-tables-overview.json
+++ b/grafana/postgres/v12/4-tables-overview.json
@@ -1457,7 +1457,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n*\nFROM\n(\n  SELECT DISTINCT ON (table_full_name)\n  tag_data->>'table_full_name' as table_full_name,\n  data->>'tx_freeze_age' as tx_freeze_age,\n  (data->>'seconds_since_last_vacuum')::int8  as last_vacuum,\n  (data->>'seconds_since_last_analyze')::int8 as last_analyze\n  FROM\n    table_stats\n  WHERE\n    $__timeFilter(time)\n    AND dbname = '$dbname'\n  ORDER BY\n    1, time DESC\n)\nORDER BY 3 DESC NULLS LAST\nLIMIT $top\n",
+          "rawSql": "SELECT\n*\nFROM\n(\n  SELECT DISTINCT ON (table_full_name)\n  tag_data->>'table_full_name' as table_full_name,\n  data->>'tx_freeze_age' as tx_freeze_age,\n  (data->>'seconds_since_last_vacuum')::int8  as last_vacuum,\n  (data->>'seconds_since_last_analyze')::int8 as last_analyze\n  FROM\n    table_stats\n  WHERE\n    $__timeFilter(time)\n    AND dbname = '$dbname'\n  ORDER BY\n    1, time DESC\n)\nORDER BY 2 DESC NULLS LAST\nLIMIT $top\n",
           "refId": "A",
           "resultFormat": "table",
           "sql": {


### PR DESCRIPTION
Fixes :  #1134
This PR removes the redundant dbname / "Source Name" field from dashboards
that only accept a single dbname value to be more clarify.

The change is limited to single-db dashboards (e.g. tables-overview.json).

Global dashboards that may display multiple databases are intentionally left unchanged.
If there are other single-db dashboards should be updated, please let me know.
