### PR TITLE
[*] monitor specified groups only, fixes #1093

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -397,7 +397,7 @@ func (r *Reaper) LoadSources(ctx context.Context) (err error) {
 		return err
 	}
 	srcs = slices.DeleteFunc(srcs, func(s sources.Source) bool {
-		return !s.IsEnabled || len(r.Sources.Groups) > 0 && !s.IsDefaultGroup() && !slices.Contains(r.Sources.Groups, s.Group)
+		return !s.IsEnabled || len(r.Sources.Groups) > 0 && !slices.Contains(r.Sources.Groups, s.Group)
 	})
 	if newSrcs, err = srcs.ResolveDatabases(); err != nil {
 		r.logger.WithError(err).Error("could not resolve databases from sources")

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -74,27 +74,28 @@ func TestReaper_LoadSources(t *testing.T) {
 	})
 
 	t.Run("Test group limited sources", func(t *testing.T) {
-		source1 := sources.Source{Name: "Source 1", IsEnabled: true, Kind: sources.SourcePostgres, Group: ""} // Empty group should not filter
+		source1 := sources.Source{Name: "Source 1", IsEnabled: true, Kind: sources.SourcePostgres, Group: ""}
 		source2 := sources.Source{Name: "Source 2", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group1"}
-		source3 := sources.Source{Name: "Source 3", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group2"}
-		source4 := sources.Source{Name: "Source 4", IsEnabled: true, Kind: sources.SourcePostgres, Group: "default"} // Default group should not filter
+		source3 := sources.Source{Name: "Source 3", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group1"}
+		source4 := sources.Source{Name: "Source 4", IsEnabled: true, Kind: sources.SourcePostgres, Group: "group2"}
+		source5 := sources.Source{Name: "Source 5", IsEnabled: true, Kind: sources.SourcePostgres, Group: "default"}
 		newReader := &testutil.MockSourcesReaderWriter{
 			GetSourcesFunc: func() (sources.Sources, error) {
-				return sources.Sources{source1, source2, source3, source4}, nil
+				return sources.Sources{source1, source2, source3, source4, source5}, nil
 			},
 		}
 
 		r := NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: newReader, Sources: sources.CmdOpts{Groups: []string{"group1", "group2"}}})
 		assert.NoError(t, r.LoadSources(ctx))
-		assert.Equal(t, 4, len(r.monitoredSources), "Expected four monitored sources after load")
+		assert.Equal(t, 3, len(r.monitoredSources), "Expected three monitored sources after load")
 
 		r = NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: newReader, Sources: sources.CmdOpts{Groups: []string{"group1"}}})
 		assert.NoError(t, r.LoadSources(ctx))
-		assert.Equal(t, 3, len(r.monitoredSources), "Expected three monitored sources after group filtering")
+		assert.Equal(t, 2, len(r.monitoredSources), "Expected two monitored source after group filtering")
 
 		r = NewReaper(ctx, &cmdopts.Options{SourcesReaderWriter: newReader})
 		assert.NoError(t, r.LoadSources(ctx))
-		assert.Equal(t, 4, len(r.monitoredSources), "Expected four monitored sources after resetting groups")
+		assert.Equal(t, 5, len(r.monitoredSources), "Expected five monitored sources after resetting groups")
 	})
 
 	t.Run("Test source config changes trigger restart", func(t *testing.T) {

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -61,10 +61,6 @@ type (
 	Sources []Source
 )
 
-func (s Source) IsDefaultGroup() bool {
-	return s.Group == "" || s.Group == "default"
-}
-
 func (srcs Sources) Validate() (Sources, error) {
 	names := map[string]any{}
 	for _, src := range srcs {

--- a/internal/sources/types_test.go
+++ b/internal/sources/types_test.go
@@ -31,26 +31,6 @@ func TestKind_IsValid(t *testing.T) {
 	}
 }
 
-func TestSource_IsDefaultGroup(t *testing.T) {
-	sources := sources.Sources{
-		{
-			Name:  "test_source",
-			Group: "default",
-		},
-		{
-			Name:  "test_source3",
-			Group: "",
-		},
-		{
-			Name:  "test_source2",
-			Group: "custom_group",
-		},
-	}
-	assert.True(t, sources[0].IsDefaultGroup())
-	assert.True(t, sources[1].IsDefaultGroup())
-	assert.False(t, sources[2].IsDefaultGroup())
-}
-
 func TestSource_Equal(t *testing.T) {
 	var correctInterval float64 = 60
 	var incorrectInterval float64 = 10


### PR DESCRIPTION
don't consider default group or whatever

So now if we don't have any group specified we monitor all sources. If we do have then we monitor only sources with the specified group[s].

Closes #1093