### PR TITLE
[+] add `metric list` command for exporting metric definitions

### DIFF
--- a/internal/cmdopts/cmdmetric_test.go
+++ b/internal/cmdopts/cmdmetric_test.go
@@ -15,8 +15,8 @@ func TestMetricPrintInit_Execute(t *testing.T) {
 	w := &strings.Builder{}
 	os.Args = []string{0: "config_test", "metric", "print-init", "test1"}
 	_, err = New(w)
-	assert.Empty(t, w.String())
-	assert.NoError(t, err, "should not error when no metrics found")
+	assert.Error(t, err, "should error when metric not found")
+	assert.Contains(t, err.Error(), "not found")
 
 	w.Reset()
 	os.Args = []string{0: "config_test", "metric", "print-init", "cpu_load"}
@@ -45,8 +45,8 @@ func TestMetricPrintSQL_Execute(t *testing.T) {
 	w := &strings.Builder{}
 	os.Args = []string{0: "config_test", "metric", "print-sql", "test1"}
 	_, err = New(w)
-	assert.Empty(t, w.String())
-	assert.NoError(t, err, "should not error when no metrics found")
+	assert.Error(t, err, "should error when metric not found")
+	assert.Contains(t, err.Error(), "not found")
 
 	w.Reset()
 	os.Args = []string{0: "config_test", "metric", "print-sql", "cpu_load"}
@@ -65,6 +65,57 @@ func TestMetricPrintSQL_Execute(t *testing.T) {
 	assert.Error(t, err, "should error when no metric definitions found")
 
 	os.Args = []string{0: "config_test", "--metrics=postgresql://foo@bar/fail", "metric", "print-sql", "foo"}
+	_, err = New(w)
+	assert.Error(t, err, "should error when no config database found")
+}
+
+func TestMetricList_Execute(t *testing.T) {
+	var err error
+
+	// Test: List all metrics and presets (no argument)
+	w := &strings.Builder{}
+	os.Args = []string{0: "config_test", "metric", "list"}
+	_, err = New(w)
+	assert.NoError(t, err, "should not error when listing all metrics")
+	assert.Contains(t, w.String(), "metrics:")
+	assert.Contains(t, w.String(), "presets:")
+	assert.Contains(t, w.String(), "cpu_load")
+	assert.Contains(t, w.String(), "standard")
+
+	// Test: List specific metric
+	w.Reset()
+	os.Args = []string{0: "config_test", "metric", "list", "cpu_load"}
+	_, err = New(w)
+	assert.NoError(t, err, "should not error when listing specific metric")
+	assert.Contains(t, w.String(), "cpu_load")
+	assert.Contains(t, w.String(), "metrics:")
+	// Should not contain other metrics
+	assert.NotContains(t, w.String(), "presets:")
+
+	// Test: List specific preset
+	w.Reset()
+	os.Args = []string{0: "config_test", "metric", "list", "standard"}
+	_, err = New(w)
+	assert.NoError(t, err, "should not error when listing preset")
+	assert.Contains(t, w.String(), "presets:")
+	assert.Contains(t, w.String(), "standard")
+	assert.Contains(t, w.String(), "metrics:")
+	// Should contain metrics from the preset
+	assert.Contains(t, w.String(), "cpu_load")
+
+	// Test: List non-existent metric/preset
+	w.Reset()
+	os.Args = []string{0: "config_test", "metric", "list", "nonexistent"}
+	_, err = New(w)
+	assert.Error(t, err, "should error when metric/preset not found")
+	assert.Contains(t, err.Error(), "not found")
+
+	// Test: Error handling - invalid metrics path
+	os.Args = []string{0: "config_test", "--metrics=foo", "metric", "list"}
+	_, err = New(w)
+	assert.Error(t, err, "should error when no metric definitions found")
+
+	os.Args = []string{0: "config_test", "--metrics=postgresql://foo@bar/fail", "metric", "list"}
 	_, err = New(w)
 	assert.Error(t, err, "should error when no config database found")
 }

--- a/internal/metrics/types_test.go
+++ b/internal/metrics/types_test.go
@@ -64,3 +64,141 @@ func TestMeasurements(t *testing.T) {
 	assert.NotEqual(t, m, m1, "deep copy should be different")
 	assert.True(t, time.Now().UnixNano()-m1.GetEpoch() < int64(time.Second), "epoch should be close to now")
 }
+
+func TestFilterByNames(t *testing.T) {
+	// Setup test data
+	metrics := &Metrics{
+		MetricDefs: MetricDefs{
+			"cpu_load": Metric{
+				Description: "CPU load metric",
+				InitSQL:     "CREATE FUNCTION cpu_load()",
+			},
+			"db_size": Metric{
+				Description: "Database size metric",
+			},
+			"db_stats": Metric{
+				Description: "Database stats metric",
+			},
+			"replication": Metric{
+				Description: "Replication metric",
+			},
+		},
+		PresetDefs: PresetDefs{
+			"minimal": Preset{
+				Description: "Minimal preset",
+				Metrics: map[string]float64{
+					"cpu_load": 60,
+					"db_size":  300,
+				},
+			},
+			"standard": Preset{
+				Description: "Standard preset",
+				Metrics: map[string]float64{
+					"cpu_load":    60,
+					"db_size":     300,
+					"db_stats":    60,
+					"replication": 120,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		names         []string
+		wantMetrics   []string
+		wantPresets   []string
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name:        "empty names returns all",
+			names:       []string{},
+			wantMetrics: []string{"cpu_load", "db_size", "db_stats", "replication"},
+			wantPresets: []string{"minimal", "standard"},
+			wantErr:     false,
+		},
+		{
+			name:        "single metric",
+			names:       []string{"cpu_load"},
+			wantMetrics: []string{"cpu_load"},
+			wantPresets: []string{},
+			wantErr:     false,
+		},
+		{
+			name:        "multiple metrics",
+			names:       []string{"cpu_load", "db_size"},
+			wantMetrics: []string{"cpu_load", "db_size"},
+			wantPresets: []string{},
+			wantErr:     false,
+		},
+		{
+			name:        "single preset includes all its metrics",
+			names:       []string{"minimal"},
+			wantMetrics: []string{"cpu_load", "db_size"},
+			wantPresets: []string{"minimal"},
+			wantErr:     false,
+		},
+		{
+			name:        "multiple presets",
+			names:       []string{"minimal", "standard"},
+			wantMetrics: []string{"cpu_load", "db_size", "db_stats", "replication"},
+			wantPresets: []string{"minimal", "standard"},
+			wantErr:     false,
+		},
+		{
+			name:        "mix of metrics and presets",
+			names:       []string{"minimal", "replication"},
+			wantMetrics: []string{"cpu_load", "db_size", "replication"},
+			wantPresets: []string{"minimal"},
+			wantErr:     false,
+		},
+		{
+			name:        "non-existent metric",
+			names:       []string{"nonexistent"},
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
+			name:        "mix of existing and non-existing",
+			names:       []string{"cpu_load", "nonexistent"},
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
+			name:        "non-existent preset",
+			names:       []string{"nonexistent_preset"},
+			wantErr:     true,
+			errContains: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := metrics.FilterByNames(tt.names)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+
+			// Check metrics
+			assert.Equal(t, len(tt.wantMetrics), len(result.MetricDefs), "metric count mismatch")
+			for _, metricName := range tt.wantMetrics {
+				assert.Contains(t, result.MetricDefs, metricName, "expected metric not found: "+metricName)
+			}
+
+			// Check presets
+			assert.Equal(t, len(tt.wantPresets), len(result.PresetDefs), "preset count mismatch")
+			for _, presetName := range tt.wantPresets {
+				assert.Contains(t, result.PresetDefs, presetName, "expected preset not found: "+presetName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Supports listing all metrics/presets or filtering by name(s). Outputs YAML format suitable for creating custom `metrics.yaml` files. Returns errors for non-existent metric or preset names.