### PR TITLE
Remove Source Name field from tables in Table Statistics in Table ove…

### DIFF
--- a/grafana/postgres/v12/4-tables-overview.json
+++ b/grafana/postgres/v12/4-tables-overview.json
@@ -47,7 +47,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -90,7 +90,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -208,7 +208,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -250,7 +250,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -360,7 +360,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -402,7 +402,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -512,7 +512,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -554,7 +554,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -664,7 +664,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -706,7 +706,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -816,7 +816,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -858,7 +858,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -968,7 +968,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -1010,7 +1010,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -1120,7 +1120,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -1161,7 +1161,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 240
               }
             ]
           },
@@ -1331,7 +1331,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 440
+                "value": 550
               }
             ]
           },


### PR DESCRIPTION
Fixes: #1134 
Removed the source name field from tables in tables statistics (Largest Tables by Total Size, Largest Tables by Data Size, Tables with Highest Growth, ..., Tables with oldest non-frozen xid age)
Changes applied to: **4-tables-overview.json** file
Steps:

1.  Removed Source Name from json object
2.  Modified rawSql query by removing the selection of the dbname column and adjusting order by and group by values

<img width="1893" height="928" alt="image" src="https://github.com/user-attachments/assets/05f11e9e-fc53-41a3-a0a1-55c6c6d1c41d" />
