### PR TITLE
Dashboards/index bloat

### DIFF
--- a/grafana/postgres/v12/4-tables-overview.json
+++ b/grafana/postgres/v12/4-tables-overview.json
@@ -47,7 +47,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -77,6 +77,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -208,7 +212,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -237,6 +241,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -360,7 +368,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -389,6 +397,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -512,7 +524,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -541,6 +553,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -664,7 +680,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -693,6 +709,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -816,7 +836,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -845,6 +865,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -968,7 +992,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -997,6 +1021,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -1120,7 +1148,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -1148,6 +1176,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",
@@ -1318,6 +1350,10 @@
               {
                 "id": "displayName",
                 "value": "Table Name"
+              },
+              {
+                "id": "custom.inspect",
+                "value": true
               },
               {
                 "id": "links",


### PR DESCRIPTION
Fixes: #1166 

This PR adds an Index Bloat Overview section to the Tables dashboard.
- Introduces a new row for index bloat metrics
- Adds a table panel showing top 10 bloated indexes by bloat ratio in `tables-overview-prometheus`