### PR TITLE
[*] drop redundant and unused admin functions

### DIFF
--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -606,7 +606,12 @@ var migrations func() migrator.Option = func() migrator.Option {
 		&migrator.Migration{
 			Name: "01180 Apply admin functions migrations for v5",
 			Func: func(ctx context.Context, tx pgx.Tx) error {
-				_, err := tx.Exec(ctx, `DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time`)
+				_, err := tx.Exec(ctx, `
+					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;
+					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_time;
+					DROP FUNCTION IF EXISTS admin.get_old_time_partitions(integer, text);
+					DROP FUNCTION IF EXISTS admin.drop_old_time_partitions(integer, boolean, text);
+				`)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Update the `01180` migration to drop:
1. `admin.ensure_partition_metric_time()`
2. `admin.get_old_time_partitions(integer, text)`
3. `admin.drop_old_time_partitions(integer, boolean, text)`

---

If a user already downloaded v5.0.0-beta and ran the migration before, there is no problem and it won't cause any bugs, they are just not used anywhere so we drop them.