### PR TITLE
ci: add Trivy scan to Docker image build

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Cache scope for build cache'
     required: false
     default: 'default'
+  load:
+    description: 'Load built image into Docker daemon (true/false)'
+    required: false
+    default: 'false'
 
 outputs:
   image-id:
@@ -100,6 +104,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         platforms: ${{ inputs.platforms }}
         push: ${{ inputs.push == 'true' }}
+        load: ${{ inputs.load == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: ${{ inputs.build-args }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,17 @@ jobs:
           GIT_HASH=${{ steps.meta.outputs.GIT_HASH }}
           GIT_TIME=${{ steps.meta.outputs.GIT_TIME }}
           VERSION=${{ steps.meta.outputs.VERSION }}   
+        load: 'true'
+
+    - name: Run vulnerability scanner
+      uses: aquasecurity/trivy-action@0.33.1
+      with:
+        image-ref: 'cybertecpostgresql/pgwatch:${{ steps.meta.outputs.VERSION }}'
+        format: 'table'
+        exit-code: '1'
+        ignore-unfixed: true
+        pkg-types: 'os,library'
+        severity: 'CRITICAL,HIGH'   
 
   build-docs:
     if: true # false to skip job during debug


### PR DESCRIPTION
Fixes #1202 

Updated 
`build.yml` : Added a new step to run `aquasecurity/trivy-action` after the image build.
`action.yml` : Added the missing load input definition and passed it to `docker/build-push-action`, allowing the built image to be accessible for scanning.

<img width="1004" height="304" alt="Screenshot From 2026-02-14 16-53-10" src="https://github.com/user-attachments/assets/19d242ca-5667-4b6b-888a-740e691d6a5f" />




