### PR TITLE
[*] fix typos in docs and source comments

### DIFF
--- a/docs/howto/config_db_bootstrap.md
+++ b/docs/howto/config_db_bootstrap.md
@@ -59,7 +59,7 @@ pgwatch --sink=postgresql://pgwatch:pgwatchadmin@localhost/measurements config i
 ## Usage
 
 You can now configure pgwatch to use the `pgwatch` database as the configuration database for storing monitored sources,
-metric deinitions and presets.
+metric definitions and presets.
 
 ```terminal
 $ pgwatch --sources=postgresql://pgwatch:pgwatchadmin@localhost/pgwatch --sink=postgresql://pgwatch@10.0.0.42/measurements

--- a/docs/howto/migrate_v2_to_v3.md
+++ b/docs/howto/migrate_v2_to_v3.md
@@ -73,7 +73,7 @@ from pgwatch2.monitored_db;
     You may skip this step if you have not created custom metrics or presets.
     All built-in metrics and presets are already included in pgwatch3.
 
-Exucute the following queries to migrate the metrics and presets:
+Execute the following queries to migrate the metrics and presets:
 
 ```sql
 insert into pgwatch.preset

--- a/docs/tutorial/docker_installation.md
+++ b/docs/tutorial/docker_installation.md
@@ -220,7 +220,7 @@ Source file `sources.yaml` in the same directory:
 
 ```yaml
 - name: demo
-  conn_str: postgresql://pgwatch:pgwatchadmin@postgres/pgwatch'
+  conn_str: postgresql://pgwatch:pgwatchadmin@postgres/pgwatch
   preset_metrics: exhaustive
   is_enabled: true
   group: default

--- a/internal/log/log_broker_hook.go
+++ b/internal/log/log_broker_hook.go
@@ -15,7 +15,7 @@ type MessageType string
 // MessageChanType represents the format of the message channel
 type MessageChanType chan MessageType
 
-// BrokerHook is the implementation of the logrus hook for publicating logs to subscribers
+// BrokerHook is the implementation of the logrus hook for publishing logs to subscribers
 type BrokerHook struct {
 	highLoadTimeout time.Duration     // wait this amount of time before skip log entry
 	subscribers     []MessageChanType //


### PR DESCRIPTION
## Summary

- Fix `publicating` → `publishing` in `internal/log/log_broker_hook.go` comment
- Fix `deinitions` → `definitions` in `docs/howto/config_db_bootstrap.md`
- Fix `Exucute` → `Execute` in `docs/howto/migrate_v2_to_v3.md`
- Remove stray single quote from connection string example in `docs/tutorial/docker_installation.md`

## Details

Found a few small typos across the codebase and documentation while reading through the project. Each fix is a single-word correction with no behavioral changes.

## Test plan

- [x] `go build ./internal/log/` compiles cleanly
- [x] Documentation changes are text-only corrections