### PR TITLE
[-] resolve race conditions in YAML file operations, fixes #1198

### DIFF
--- a/internal/metrics/yaml.go
+++ b/internal/metrics/yaml.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -25,9 +26,18 @@ func NewYAMLMetricReaderWriter(ctx context.Context, path string) (ReaderWriter, 
 type fileMetricReader struct {
 	ctx  context.Context
 	path string
+	sync.Mutex
 }
 
+// WriteMetrics writes metrics to file with locking
 func (fmr *fileMetricReader) WriteMetrics(metricDefs *Metrics) error {
+	fmr.Lock()
+	defer fmr.Unlock()
+	return fmr.writeMetrics(metricDefs)
+}
+
+// writeMetrics writes metrics to file without locking (internal use only)
+func (fmr *fileMetricReader) writeMetrics(metricDefs *Metrics) error {
 	yamlData, _ := yaml.Marshal(metricDefs)
 	return os.WriteFile(fmr.path, yamlData, 0644)
 }
@@ -35,7 +45,15 @@ func (fmr *fileMetricReader) WriteMetrics(metricDefs *Metrics) error {
 //go:embed metrics.yaml
 var defaultMetricsYAML []byte
 
+// GetMetrics reads metrics from file or returns default metrics if path is empty with locking
 func (fmr *fileMetricReader) GetMetrics() (metrics *Metrics, err error) {
+	fmr.Lock()
+	defer fmr.Unlock()
+	return fmr.getMetrics()
+}
+
+// getMetrics reads metrics from file or returns default metrics if path is empty without locking (internal use only)
+func (fmr *fileMetricReader) getMetrics() (metrics *Metrics, err error) {
 	metrics = &Metrics{MetricDefs{}, PresetDefs{}}
 	if fmr.path == "" {
 		err = yaml.Unmarshal(defaultMetricsYAML, metrics)
@@ -57,19 +75,20 @@ func (fmr *fileMetricReader) GetMetrics() (metrics *Metrics, err error) {
 				return nil
 			}
 			var m *Metrics
-			if m, err = fmr.getMetrics(path); err == nil {
+			if m, err = fmr.loadMetricsFromFile(path); err == nil {
 				maps.Copy(metrics.PresetDefs, m.PresetDefs)
 				maps.Copy(metrics.MetricDefs, m.MetricDefs)
 			}
 			return err
 		})
 	case mode.IsRegular():
-		metrics, err = fmr.getMetrics(fmr.path)
+		metrics, err = fmr.loadMetricsFromFile(fmr.path)
 	}
 	return
 }
 
-func (fmr *fileMetricReader) getMetrics(metricsFilePath string) (metrics *Metrics, err error) {
+// loadMetricsFromFile reads metrics from a single YAML file
+func (fmr *fileMetricReader) loadMetricsFromFile(metricsFilePath string) (metrics *Metrics, err error) {
 	var yamlFile []byte
 	if yamlFile, err = os.ReadFile(metricsFilePath); err != nil {
 		return
@@ -79,26 +98,35 @@ func (fmr *fileMetricReader) getMetrics(metricsFilePath string) (metrics *Metric
 	return
 }
 
+// DeleteMetric deletes a metric by name and writes the updated metrics back to file
 func (fmr *fileMetricReader) DeleteMetric(metricName string) error {
-	metrics, err := fmr.GetMetrics()
+	fmr.Lock()
+	defer fmr.Unlock()
+	metrics, err := fmr.getMetrics()
 	if err != nil {
 		return err
 	}
 	delete(metrics.MetricDefs, metricName)
-	return fmr.WriteMetrics(metrics)
+	return fmr.writeMetrics(metrics)
 }
 
+// UpdateMetric updates an existing metric or creates it if it doesn't exist, then writes the updated metrics back to file
 func (fmr *fileMetricReader) UpdateMetric(metricName string, metric Metric) error {
-	metrics, err := fmr.GetMetrics()
+	fmr.Lock()
+	defer fmr.Unlock()
+	metrics, err := fmr.getMetrics()
 	if err != nil {
 		return err
 	}
 	metrics.MetricDefs[metricName] = metric
-	return fmr.WriteMetrics(metrics)
+	return fmr.writeMetrics(metrics)
 }
 
+// CreateMetric creates a new metric if it doesn't already exist, then writes the updated metrics back to file
 func (fmr *fileMetricReader) CreateMetric(metricName string, metric Metric) error {
-	metrics, err := fmr.GetMetrics()
+	fmr.Lock()
+	defer fmr.Unlock()
+	metrics, err := fmr.getMetrics()
 	if err != nil {
 		return err
 	}
@@ -107,29 +135,38 @@ func (fmr *fileMetricReader) CreateMetric(metricName string, metric Metric) erro
 		return ErrMetricExists
 	}
 	metrics.MetricDefs[metricName] = metric
-	return fmr.WriteMetrics(metrics)
+	return fmr.writeMetrics(metrics)
 }
 
+// DeletePreset deletes a preset by name and writes the updated metrics back to file
 func (fmr *fileMetricReader) DeletePreset(presetName string) error {
-	metrics, err := fmr.GetMetrics()
+	fmr.Lock()
+	defer fmr.Unlock()
+	metrics, err := fmr.getMetrics()
 	if err != nil {
 		return err
 	}
 	delete(metrics.PresetDefs, presetName)
-	return fmr.WriteMetrics(metrics)
+	return fmr.writeMetrics(metrics)
 }
 
+// UpdatePreset updates an existing preset or creates it if it doesn't exist, then writes the updated metrics back to file
 func (fmr *fileMetricReader) UpdatePreset(presetName string, preset Preset) error {
-	metrics, err := fmr.GetMetrics()
+	fmr.Lock()
+	defer fmr.Unlock()
+	metrics, err := fmr.getMetrics()
 	if err != nil {
 		return err
 	}
 	metrics.PresetDefs[presetName] = preset
-	return fmr.WriteMetrics(metrics)
+	return fmr.writeMetrics(metrics)
 }
 
+// CreatePreset creates a new preset if it doesn't already exist, then writes the updated metrics back to file
 func (fmr *fileMetricReader) CreatePreset(presetName string, preset Preset) error {
-	metrics, err := fmr.GetMetrics()
+	fmr.Lock()
+	defer fmr.Unlock()
+	metrics, err := fmr.getMetrics()
 	if err != nil {
 		return err
 	}
@@ -138,5 +175,5 @@ func (fmr *fileMetricReader) CreatePreset(presetName string, preset Preset) erro
 		return ErrPresetExists
 	}
 	metrics.PresetDefs[presetName] = preset
-	return fmr.WriteMetrics(metrics)
+	return fmr.writeMetrics(metrics)
 }


### PR DESCRIPTION
Fixes race conditions in YAML-based metrics and sources I/O by adding an embedded `sync.Mutex` to serialize read–modify–write cycles so concurrent updates are not lost. Public methods now lock and call unlocked internal helpers (`getMetrics/getSources`, `writeMetrics/writeSources`), and new concurrent tests confirm the fix.