### PR TITLE
[-] return HTTP 405 for non-POST methods in login handler

### DIFF
--- a/internal/webserver/jwt.go
+++ b/internal/webserver/jwt.go
@@ -49,7 +49,7 @@ func (s *WebUIServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 	default:
 		w.Header().Set("Allow", "POST")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, "only POST method is allowed", http.StatusMethodNotAllowed)
 		return
 	}
 }

--- a/internal/webserver/jwt_test.go
+++ b/internal/webserver/jwt_test.go
@@ -59,9 +59,7 @@ func TestHandleLogin_GET(t *testing.T) {
 	w := httptest.NewRecorder()
 	ts.handleLogin(w, r)
 	resp := w.Result()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	body, _ := io.ReadAll(resp.Body)
-	assert.Equal(t, "only POST methods is allowed.", string(body))
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 }
 
 func TestGenerateAndValidateJWT(t *testing.T) {


### PR DESCRIPTION
Added default case for unsupported methods.