### PR TITLE
[-] fix `webui` panels needs refresh, fixes #1243

### DIFF
--- a/internal/webui/src/QueryClient.tsx
+++ b/internal/webui/src/QueryClient.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider as ClientProvider, MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { isUnauthorized } from "api";
 import axios from "axios";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { logout } from "queries/Auth";
 import { useAlert } from "utils/AlertContext";
@@ -14,19 +14,13 @@ export const QueryClientProvider = ({ children }: Props) => {
   const { callAlert } = useAlert();
   const navigate = useNavigate();
 
-  const callAlertRef = useRef(callAlert);
-
-  useEffect(() => {
-    callAlertRef.current = callAlert;
-  }, [callAlert]);
-
   const [queryClient] = useState(() => {
     const client = new QueryClient({
       queryCache: new QueryCache({
         onError: (error) => {
           if (axios.isAxiosError(error)) {
             if (isUnauthorized(error)) {
-              callAlertRef.current("error", `${error.response?.data}`);
+              callAlert("error", `${error.response?.data}`);
               logout(navigate);
             }
           }
@@ -35,13 +29,14 @@ export const QueryClientProvider = ({ children }: Props) => {
       mutationCache: new MutationCache({
         onError: (error) => {
           if (axios.isAxiosError(error)) {
-            callAlertRef.current("error", `${error.response?.data}`);
+            callAlert("error", `${error.response?.data}`);
             if (isUnauthorized(error)) {
               logout(navigate);
             }
           }
         },
         onSuccess: (_data, _variables, _context, mutation) => {
+          callAlert("success", "Success");
           if (mutation.options.mutationKey) {
             client.invalidateQueries({ queryKey: mutation.options.mutationKey });
           }
@@ -50,7 +45,6 @@ export const QueryClientProvider = ({ children }: Props) => {
     })
     return client;
   });
-
 
   return (
     <ClientProvider client={queryClient}>

--- a/internal/webui/src/pages/SourcesPage/components/SourcesGrid/components/EnabledSourceSwitch.tsx
+++ b/internal/webui/src/pages/SourcesPage/components/SourcesGrid/components/EnabledSourceSwitch.tsx
@@ -22,10 +22,6 @@ export const EnabledSourceSwitch = ({ source }: EnabledSourceSwitchProps) => {
     });
   };
   useEffect(() => {
-    setChecked(source.IsEnabled);
-  }, [source.IsEnabled]);
-
-  useEffect(() => {
     if (status === "error") {
       setChecked((prev) => !prev);
     }

--- a/internal/webui/src/utils/AlertContext.tsx
+++ b/internal/webui/src/utils/AlertContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import { AlertColor, SnackbarCloseReason } from "@mui/material";
 
 export type AlertContextType = {
@@ -20,11 +20,11 @@ export const AlertProvider = ({ children }: AlertProviderProps) => {
   const [severity, setSeverity] = useState<AlertColor>("success");
   const [message, setMessage] = useState("");
 
-  const callAlert = (alertSeverity: AlertColor, alertMessage: string) => {
+  const callAlert = useCallback((alertSeverity: AlertColor, alertMessage: string) => {
     setSeverity(alertSeverity);
     setMessage(alertMessage);
     setOpen(true);
-  };
+  }, []);
 
   const closeAlert = (_event: Event | React.SyntheticEvent<any, Event>, reason: SnackbarCloseReason) => {
     if (reason && (reason === "clickaway" || reason === "escapeKeyDown")) {


### PR DESCRIPTION
Fixes #1243 

Now when when editing the `enabled` state is reflected instantly without needing to refresh.

Edit: Now adding/deleting sources/metrics/presets doesn't need a refresh.