### PR TITLE
[*] set explicit permissions for Stale GHA workflow 

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   stale:
     if: false # false to skip job during debug
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v10


### PR DESCRIPTION
Potential fix for [https://github.com/cybertec-postgresql/pgwatch/security/code-scanning/19](https://github.com/cybertec-postgresql/pgwatch/security/code-scanning/19)

To fix the problem, we should explicitly declare the minimal `GITHUB_TOKEN` permissions needed by this workflow. Since `actions/stale` needs to mark issues/PRs as stale, comment, and possibly close them, it needs write access to `issues` and `pull-requests`, and typically only read access to `contents`. We can set these at the job level so they only apply to this workflow’s `stale` job.

The best fix without changing functionality is to add a `permissions` block under `jobs: stale:` (same indentation level as `runs-on`). This block should specify:
- `contents: read` (no need to write to the repository contents),
- `issues: write` (to label/comment/close issues),
- `pull-requests: write` (to label/comment/close PRs).

No imports or additional definitions are needed; this is purely a YAML configuration change in `.github/workflows/stale.yml`.

Concretely, in `.github/workflows/stale.yml`, between lines 12 and 13 (after `if: false # false to skip job during debug` and before `runs-on: ubuntu-latest`), add the `permissions` block with the above three entries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
