### PR TITLE
docs: add response examples and field tables to REST API reference

### DIFF
--- a/docs/reference/rest.md
+++ b/docs/reference/rest.md
@@ -11,14 +11,14 @@ $ curl -X POST http://localhost:8080/login \
   -H "Content-Type: application/json" \
   -d '{"user": "your_username", "password": "your_password"}'
 
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemVkIjp0cnVlLCJleHAiOjE3NTI3MDY0OTYsInVzZXJuYW1lIjoieW91cl91c2VybmFtZSJ9.sPpNgpqtjZJqNfgfmypdR3rvlPQxxMtsg2v2WLPVbUA
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
-Use the returned token in the Authorization header for subsequent requests:
+Use the returned token in subsequent requests:
 
 ```bash
 # Set token as environment variable (copy the token from login response)
-export TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemVkIjp0cnVlLCJleHAiOjE3NTI3MDY0OTYsInVzZXJuYW1lIjoieW91cl91c2VybmFtZSJ9.sPpNgpqtjZJqNfgfmypdR3rvlPQxxMtsg2v2WLPVbUA"
+export TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 
 # Or capture token automatically in one command
 TOKEN=$(curl -s -X POST http://localhost:8080/login \
@@ -36,10 +36,14 @@ $ curl -H "Token: $TOKEN" http://localhost:8080/source
 Check if the service is running (no authentication required).
 
 ```bash
-curl -X GET http://localhost:8080/liveness
+$ curl -X GET http://localhost:8080/liveness
 ```
 
-**Response:** `{"status": "ok"}` if service is alive
+**Response:** `200 OK`
+
+```json
+{"status": "ok"}
+```
 
 ### Readiness probe
 
@@ -47,10 +51,13 @@ Check if the service is ready to serve requests (no authentication required).
 
 ```bash
 $ curl -X GET http://localhost:8080/readiness
- 
 ```
 
-**Response:** `{"status": "ok"}` if service is ready
+**Response:** `200 OK`
+
+```json
+{"status": "ok"}
+```
 
 ## API Patterns
 
@@ -108,10 +115,47 @@ Get all monitoring sources.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X GET http://localhost:8080/source
-  
 ```
 
-**Response:** JSON array of source objects
+**Response:** `200 OK` — JSON array of source objects
+
+```json
+[
+  {
+    "Name": "my-postgres",
+    "Group": "default",
+    "ConnStr": "postgresql://user:pass@localhost:5432/dbname",
+    "Kind": "postgres",
+    "IncludePattern": "",
+    "ExcludePattern": "",
+    "PresetMetrics": "exhaustive",
+    "PresetMetricsStandby": "",
+    "IsEnabled": true,
+    "CustomTags": {},
+    "OnlyIfMaster": false,
+    "Metrics": null,
+    "MetricsStandby": null
+  }
+]
+```
+
+### Source object fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | string | Unique identifier for the source |
+| `Group` | string | Logical grouping for the source |
+| `ConnStr` | string | PostgreSQL connection string |
+| `Kind` | string | Source type: `postgres`, `postgres-continuous-discovery`, `pgbouncer`, `pgpool`, or `patroni` |
+| `IncludePattern` | string | Regex to include databases (continuous discovery only) |
+| `ExcludePattern` | string | Regex to exclude databases (continuous discovery only) |
+| `PresetMetrics` | string | Name of a preset to use for primary metrics |
+| `PresetMetricsStandby` | string | Name of a preset to use for standby metrics |
+| `IsEnabled` | bool | Whether monitoring is active |
+| `CustomTags` | object | Key-value pairs added to all measurements from this source |
+| `OnlyIfMaster` | bool | Only monitor if the instance is a primary |
+| `Metrics` | object | Custom metric-to-interval mapping (alternative to preset) |
+| `MetricsStandby` | object | Custom metric-to-interval mapping for standby servers |
 
 ### Create source
 
@@ -131,20 +175,34 @@ $ curl -X POST http://localhost:8080/source \
   }'
 ```
 
+**Response:** `201 Created` on success, `409 Conflict` if a source with that name already exists
+
 ### Get specific source
 
 Retrieve a specific source by name.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X GET http://localhost:8080/source/my-postgres
-  
 ```
 
-**Response:** JSON object with source details
+**Response:** `200 OK` — JSON object with source details, `404 Not Found` if the source does not exist
+
+```json
+{
+  "Name": "my-postgres",
+  "Group": "default",
+  "ConnStr": "postgresql://user:pass@localhost:5432/dbname",
+  "Kind": "postgres",
+  "PresetMetrics": "exhaustive",
+  "IsEnabled": true,
+  "CustomTags": {},
+  "OnlyIfMaster": false
+}
+```
 
 ### Update specific source
 
-Update an existing source using PUT method.
+Update an existing source using PUT method. The `Name` in the request body must match the URL parameter.
 
 ```bash
 $ curl -X PUT http://localhost:8080/source/my-postgres \
@@ -160,18 +218,21 @@ $ curl -X PUT http://localhost:8080/source/my-postgres \
   }'
 ```
 
+**Response:** `200 OK` on success, `400 Bad Request` if the name in URL and body do not match
+
 ### Delete specific source
 
 Remove a monitoring source.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X DELETE http://localhost:8080/source/my-postgres
-  
 ```
+
+**Response:** `200 OK` on success
 
 ### Test connection
 
-Test connectivity to a PostgreSQL instance. This endpoint allows you to verify that the connection string is valid and the database is reachable from the pgwatch environment.
+Test connectivity to a PostgreSQL instance.
 
 ```bash
 $ curl -X POST http://localhost:8080/test-connect \
@@ -180,18 +241,48 @@ $ curl -X POST http://localhost:8080/test-connect \
   -d 'postgresql://user:pass@localhost:5432/dbname'
 ```
 
+**Response:** `200 OK` if the connection is successful, error message otherwise
+
 ## Metrics API
 
 ### List all metrics
 
-Get all available metrics definitions.
+Get all available metric definitions.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X GET http://localhost:8080/metric
-  
 ```
 
-**Response:** JSON array of metric objects
+**Response:** `200 OK` — JSON object mapping metric names to definitions
+
+```json
+{
+  "db_stats": {
+    "SQLs": {
+      "11": "SELECT ... FROM pg_stat_database ...",
+      "16": "SELECT ... FROM pg_stat_database ..."
+    },
+    "InitSQL": "",
+    "NodeStatus": "",
+    "Gauges": ["numbackends", "xact_commit"],
+    "IsInstanceLevel": false,
+    "StorageName": "",
+    "Description": "Database statistics from pg_stat_database"
+  }
+}
+```
+
+### Metric object fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SQLs` | object | Map of PostgreSQL major version (int) to SQL query string |
+| `InitSQL` | string | SQL to run once before the first metric collection |
+| `NodeStatus` | string | `"primary"` or `"standby"` to restrict which nodes run this metric |
+| `Gauges` | array | Column names that represent gauge values (vs. monotonic counters) |
+| `IsInstanceLevel` | bool | If true, metric is collected once per instance, not per database |
+| `StorageName` | string | Override the metric name used in the storage sink |
+| `Description` | string | Human-readable description of the metric |
 
 ### Create metric
 
@@ -214,6 +305,8 @@ $ curl -X POST http://localhost:8080/metric \
     }
   }'
 ```
+
+**Response:** `201 Created` on success, `409 Conflict` if the metric already exists
 
 **Bulk creation example:**
 
@@ -239,10 +332,18 @@ Retrieve a specific metric definition by name.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X GET http://localhost:8080/metric/custom_metric
-  
 ```
 
-**Response:** JSON object with metric definition
+**Response:** `200 OK` — JSON object with metric definition, `404 Not Found` if not found
+
+```json
+{
+  "SQLs": {
+    "11": "SELECT count(*) as active_connections FROM pg_stat_activity"
+  },
+  "Description": "Number of active connections"
+}
+```
 
 ### Update specific metric
 
@@ -260,14 +361,17 @@ $ curl -X PUT http://localhost:8080/metric/custom_metric \
   }'
 ```
 
+**Response:** `200 OK` on success
+
 ### Delete specific metric
 
 Remove a metric definition.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X DELETE http://localhost:8080/metric/custom_metric
- 
 ```
+
+**Response:** `200 OK` on success
 
 ## Presets API
 
@@ -277,10 +381,38 @@ Get all available metric presets.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X GET http://localhost:8080/preset
-  
 ```
 
-**Response:** JSON array of preset objects
+**Response:** `200 OK` — JSON object mapping preset names to definitions
+
+```json
+{
+  "basic": {
+    "Description": "Basic set of metrics for lightweight monitoring",
+    "Metrics": {
+      "db_stats": 60,
+      "cpu_load": 60
+    }
+  },
+  "exhaustive": {
+    "Description": "All available metrics for detailed monitoring",
+    "Metrics": {
+      "db_stats": 60,
+      "table_stats": 300,
+      "index_stats": 300,
+      "cpu_load": 60,
+      "wal": 60
+    }
+  }
+}
+```
+
+### Preset object fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Description` | string | Human-readable description of the preset |
+| `Metrics` | object | Map of metric name to collection interval in seconds |
 
 ### Create preset
 
@@ -306,16 +438,28 @@ $ curl -X POST http://localhost:8080/preset \
   }'
 ```
 
+**Response:** `201 Created` on success, `409 Conflict` if the preset already exists
+
 ### Get specific preset
 
 Retrieve a specific preset by name.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X GET http://localhost:8080/preset/custom_preset
- 
 ```
 
-**Response:** JSON object with preset definition
+**Response:** `200 OK` — JSON object with preset definition, `404 Not Found` if not found
+
+```json
+{
+  "Description": "Custom monitoring preset",
+  "Metrics": {
+    "db_stats": 60,
+    "table_stats": 300,
+    "custom_metric": 120
+  }
+}
+```
 
 ### Update specific preset
 
@@ -335,14 +479,33 @@ $ curl -X PUT http://localhost:8080/preset/custom_preset \
   }'
 ```
 
+**Response:** `200 OK` on success
+
 ### Delete specific preset
 
 Remove a preset definition.
 
 ```bash
 $ curl -H "Token: $TOKEN" -X DELETE http://localhost:8080/preset/custom_preset
- 
 ```
+
+**Response:** `200 OK` on success
+
+## Log Streaming API
+
+### WebSocket log stream
+
+Stream live server logs via WebSocket connection. Useful for real-time monitoring and debugging.
+
+```bash
+$ wscat -c ws://localhost:8080/log -H "Token: $TOKEN"
+```
+
+This endpoint upgrades the HTTP connection to a WebSocket and streams log entries as they are generated by the pgwatch server.
+
+!!! Note
+    This endpoint requires a WebSocket client. Standard HTTP clients like curl
+    cannot consume WebSocket streams.
 
 ## Options Requests
 
@@ -350,17 +513,19 @@ All resource endpoints support OPTIONS requests to discover allowed methods:
 
 ```bash
 $ curl -H "Token: $TOKEN" -X OPTIONS http://localhost:8080/source/my-postgres
- 
 ```
 
 **Response:** `Allow` header with supported methods (e.g., `GET, PUT, DELETE, OPTIONS`)
 
 ## HTTP Status Codes
 
-- `200 OK` - Request successful
-- `201 Created` - Resource created successfully
-- `400 Bad Request` - Invalid request parameters
-- `401 Unauthorized` - Authentication required or invalid
-- `404 Not Found` - Resource not found
-- `405 Method Not Allowed` - HTTP method not supported for endpoint
-- `500 Internal Server Error` - Server error
+| Code | Meaning |
+|------|---------|
+| `200 OK` | Request successful |
+| `201 Created` | Resource created successfully |
+| `400 Bad Request` | Invalid request parameters or mismatched name in URL/body |
+| `401 Unauthorized` | Authentication required or token invalid/expired |
+| `404 Not Found` | Resource not found |
+| `405 Method Not Allowed` | HTTP method not supported for this endpoint |
+| `409 Conflict` | Resource already exists (duplicate name on creation) |
+| `500 Internal Server Error` | Server error |


### PR DESCRIPTION
## Summary

The REST API reference (`docs/reference/rest.md`) documents all endpoints
but was missing example response bodies and field descriptions. This made
it harder for new users and API consumers to understand the expected
response shapes without reading the source code.

Changes:

- Add example JSON response bodies for all GET endpoints (sources,
  metrics, presets, health checks)
- Add field description tables for Source, Metric, and Preset objects
  derived from the Go struct definitions
- Document per-endpoint HTTP status codes (201 Created, 404 Not Found,
  409 Conflict, etc.)
- Add missing `/log` WebSocket endpoint documentation
- Convert the HTTP status codes section to a table for readability

## Test plan

- [x] Verified all example response fields match the Go struct
  definitions in `internal/sources/types.go` and
  `internal/metrics/types.go`
- [x] Verified all documented endpoints match the routes registered in
  `internal/webserver/webserver.go`
- [ ] Visual review of rendered markdown

