### PR TITLE
[-] fix flag name typo in docs

### DIFF
--- a/docs/reference/cli_env.md
+++ b/docs/reference/cli_env.md
@@ -98,7 +98,7 @@ It reads the configuration from the specified sources and metrics, then begins c
     ENV: `$PW_PARTITION_INTERVAL`
 
     Example:
-    `--partition-inteval="3 weeks 4 days"`,
+    `--partition-interval="3 weeks 4 days"`,
 
 - `--retention=`
 


### PR DESCRIPTION
**Title**
Fix typo in --partition-interval flag.

**Description**
While reading the documentation , I found a typo in the CLI options reference. The --partition-interval flag was misspelled in the example section.

**Before**
`--partition-inteval="3 weeks 4 days"`

**After**
`--partition-interval="3 weeks 4 days"`

**Change**
`"inteval"` => `"interval"`