### PR TITLE
[*] improve `single query details` pg dashboard

### DIFF
--- a/grafana/postgres/v12/single-query-details.json
+++ b/grafana/postgres/v12/single-query-details.json
@@ -432,7 +432,7 @@
             },
             "showPoints": "never",
             "showValues": false,
-            "spanNulls": true,
+            "spanNulls": 3600000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -592,7 +592,7 @@
             },
             "showPoints": "never",
             "showValues": false,
-            "spanNulls": true,
+            "spanNulls": 3600000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -753,7 +753,7 @@
             },
             "showPoints": "never",
             "showValues": false,
-            "spanNulls": true,
+            "spanNulls": 3600000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1079,7 +1079,7 @@
             },
             "showPoints": "never",
             "showValues": false,
-            "spanNulls": false,
+            "spanNulls": 3600000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1408,7 +1408,7 @@
             },
             "showPoints": "never",
             "showValues": false,
-            "spanNulls": false,
+            "spanNulls": 3600000,
             "stacking": {
               "group": "A",
               "mode": "none"


### PR DESCRIPTION
## Description

based on @0xgouda [request](https://github.com/cybertec-postgresql/pgwatch/pull/1235#:~:text=ok%2C%20can%20you%20also%20make%20the%20Single%20Query%20Details%20pg%20dashboard%20match%20the%20new%20ones%20in%20the%20prom%20dashboards%3F) this PR modify queries in `single query dashboard` in pg to match the updates in correspond prom dashboard and partially solves https://github.com/cybertec-postgresql/pgwatch/issues/1152 in this dashboard 

fixes partially: #1152 

<img width="1600" height="787" alt="image" src="https://github.com/user-attachments/assets/6e3edc90-fc7a-482d-892c-904cdf9a3eb3" />

<img width="1590" height="647" alt="image" src="https://github.com/user-attachments/assets/490290b3-d5e0-4764-b2e1-554d57646cdf" />


## AI & Automation Policy

- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:

No agents were used in this PR i only used Gemini the free tier to help me with the queries but i have reviewed it carefully and tested it well

## Checklist

- [x] Code compiles and existing tests pass locally.
- [x] New or updated tests are included where applicable.
- [x] Documentation is updated where applicable.
