### PR TITLE
[*] fix typos in `cmdopts/cmdconfig_test.go`

### DIFF
--- a/internal/cmdopts/cmdconfig_test.go
+++ b/internal/cmdopts/cmdconfig_test.go
@@ -62,7 +62,7 @@ func TestConfigInitCommand_Execute(t *testing.T) {
 		a.Equal(ExitCodeConfigError, opts.ExitCode)
 	})
 
-	t.Run("metrics is proper postgres connectin string", func(*testing.T) {
+	t.Run("metrics is proper postgres connection string", func(*testing.T) {
 		os.Args = []string{0: "config_test", "--metrics=postgresql://foo@bar/baz", "config", "init"}
 		opts, err := New(io.Discard)
 		a.Error(err)
@@ -312,7 +312,7 @@ func TestConfigUpgradeCommand_Errors(t *testing.T) {
 		cmd := ConfigUpgradeCommand{owner: opts}
 		err := cmd.Execute(nil)
 		if err != nil {
-			a.Contains(err.Error(), "cannot updrage storage")
+			a.Contains(err.Error(), "cannot upgrade storage")
 		}
 		a.Equal(ExitCodeOK, opts.ExitCode)
 	})
@@ -356,7 +356,7 @@ func TestConfigUpgradeCommand_Execute_Coverage(t *testing.T) {
 		err := cmd.Execute(nil)
 		// Execute will return errors for unsupported storage types
 		if err != nil {
-			a.Contains(err.Error(), "cannot updrage storage")
+			a.Contains(err.Error(), "cannot upgrade storage")
 			a.Contains(err.Error(), "unsupported operation")
 		}
 		a.Equal(ExitCodeOK, opts.ExitCode)
@@ -396,7 +396,7 @@ func TestConfigUpgradeCommand_Execute_Coverage(t *testing.T) {
 		err := cmd.Execute(nil)
 		// Non-postgres URIs return unsupported error
 		if err != nil {
-			a.Contains(err.Error(), "cannot updrage storage")
+			a.Contains(err.Error(), "cannot upgrade storage")
 			a.Contains(err.Error(), "unsupported operation")
 		}
 		a.Equal(ExitCodeOK, opts.ExitCode)
@@ -441,7 +441,7 @@ func TestConfigUpgradeCommand_Execute_Coverage(t *testing.T) {
 		cmd := ConfigUpgradeCommand{owner: opts}
 		err := cmd.Execute(nil)
 		if err != nil {
-			a.Contains(err.Error(), "cannot updrage storage")
+			a.Contains(err.Error(), "cannot upgrade storage")
 		}
 		a.Equal(ExitCodeOK, opts.ExitCode)
 	})
@@ -455,7 +455,7 @@ func TestConfigUpgradeCommand_Execute_Coverage(t *testing.T) {
 		cmd := ConfigUpgradeCommand{owner: opts}
 		err := cmd.Execute(nil)
 		if err != nil {
-			a.Contains(err.Error(), "cannot updrage storage")
+			a.Contains(err.Error(), "cannot upgrade storage")
 		}
 		a.Equal(ExitCodeOK, opts.ExitCode)
 	})


### PR DESCRIPTION
## Description

<!-- Describe your changes and the motivation behind them. Link any related issues. -->

when looking at changes in #1274 I saw these typos, I checked `cmdopts/cmdconfig.go` error strings to make sure that the strings are identical.

## AI & Automation Policy

<!-- See AI_POLICY.md for full terms. All boxes must be checked before this PR can be merged. -->

- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:

<!-- e.g. "Drafted with the assistance of GitHub Copilot", "Issue revealed by Gemini" -->

## Checklist

- [x] Code compiles and existing tests pass locally.
- [x] New or updated tests are included where applicable.
- [x] Documentation is updated where applicable.
