### PR TITLE
fix(webui): fix flex columns ignoring resize, fixes #1323

### DIFF
--- a/internal/webui/src/hooks/useGridState.ts
+++ b/internal/webui/src/hooks/useGridState.ts
@@ -37,10 +37,7 @@ export const useGridState = (
         ...defaultVisibility,
         ...(savedState.columnVisibility || {})
       },
-      columnSizing: {
-        ...defaultSizing,
-        ...(savedState.columnSizing || {})
-      }
+      columnSizing: savedState.columnSizing || {}
     };
   });
 
@@ -71,24 +68,26 @@ export const useGridState = (
   }, [saveToStorage]);
 
   const resetColumnSizes = useCallback(() => {
-    const defaultSizing = columns?.reduce((acc, col) => ({
-      ...acc,
-      [col.field]: col.width || 150
-    }), {});
-
-    setGridState(prev => {
-      const newState = { ...prev, columnSizing: defaultSizing };
+    // reset to empty, restores original flex/width definition
+      setGridState(prev => {
+      const newState = { ...prev, columnSizing: {} };
       saveToStorage(newState);
       return newState;
     });
-  }, [columns, saveToStorage]);
+  }, [saveToStorage]);
 
   // Memoize columns with applied widths so objects are stable between renders
-  const columnsWithSizing = useMemo(() => columns?.map(col => ({
-    ...col,
-    width: gridState.columnSizing[col.field] || col.width || 150
-  })), [columns, gridState.columnSizing]);
+  const columnsWithSizing = useMemo(() => columns?.map(col => {
+      const userWidth = gridState.columnSizing[col.field];
 
+      if (userWidth !== undefined) {
+        const { flex, minWidth, ...colWithoutFlex } = col as any;
+        return { ...colWithoutFlex, width: userWidth };
+      }
+      return col;
+    }),
+    [columns, gridState.columnSizing]
+  );
   return {
     columnVisibility: gridState.columnVisibility,
     columnSizing: gridState.columnSizing,


### PR DESCRIPTION
Fixes #1323 

I made changes: 
- `columnSizing` initializes as {}, only user-set widths are stored
- `columnsWithSizing` only overrides a column when the user has resized it, so when applying user width, strip `flex` and `minWidth` so the pixel value is respected in both directions


https://github.com/user-attachments/assets/87449b99-2f19-455c-84fa-5bdc911f5c39




## AI & Automation Policy

- [X] I am the human author and take full personal responsibility for every change in this PR.
- [X] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.
Drafted with the assistance Claude Sonnet 4.6

## Checklist

- [X] Code compiles and existing tests pass locally.
- [X] New or updated tests are included where applicable.
- [X] Documentation is updated where applicable.
