### PR TITLE
[-] fix `--web-base-path` deployments, closes #1328

### DIFF
--- a/internal/webui/vite.config.ts
+++ b/internal/webui/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(({ command }) => ({
       include: '**/*.svg',
     }),
   ],
+  base: './',
   server: {
     port: 4000,
     proxy: {


### PR DESCRIPTION
## Description

  Fix the embedded web UI so it loads correctly when `--web-base-path` is set.

Fixes #1328

  The frontend build was generating root-relative asset URLs like `/assets/
  index-*.js`. When pgwatch is served under a subpath such as `/pgwatch/`, the
  browser requests `/assets/...` instead of `/pgwatch/assets/...`, which causes
  the main bundle to 404 and leaves the page blank.

  This change sets the Vite build base to a relative path so generated assets
  resolve correctly under both root and subpath deployments.



## AI & Automation Policy

<!-- See AI_POLICY.md for full terms. All boxes must be checked before this PR can be merged. -->

- [ ✔️] I am the human author and take full personal responsibility for every change in this PR.
- [ ] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:

<!-- e.g. "Drafted with the assistance of GitHub Copilot", "Issue revealed by Gemini" -->

## Checklist

- [ ✔️] Code compiles and existing tests pass locally.
- [ ] New or updated tests are included where applicable.
- [ ] Documentation is updated where applicable.
