### PR TITLE
feat(webui): add reset column sizes button to all grid toolbars

### DIFF
--- a/internal/webui/src/pages/MetricsPage/components/MetricsGrid/MetricsGrid.tsx
+++ b/internal/webui/src/pages/MetricsPage/components/MetricsGrid/MetricsGrid.tsx
@@ -21,7 +21,8 @@ export const MetricsGrid = () => {
     columnVisibility, 
     columnsWithSizing, 
     onColumnVisibilityChange, 
-    onColumnWidthChange
+    onColumnWidthChange,
+    resetColumnSizes
   } = useGridState('METRICS_GRID', columns);
 
   const rows: MetricGridRow[] | [] = useMemo(() => {
@@ -59,7 +60,7 @@ export const MetricsGrid = () => {
           rows={rows}
           pageSizeOptions={[]}
           slots={{ 
-            toolbar: () => <MetricsGridToolbar />
+            toolbar: () => <MetricsGridToolbar onResetColumns={resetColumnSizes} />
           }}
           columnVisibilityModel={columnVisibility}
           onColumnVisibilityModelChange={onColumnVisibilityChange}

--- a/internal/webui/src/pages/MetricsPage/components/MetricsGrid/components/MetricsGridToolbar/MetricsGridToolbar.tsx
+++ b/internal/webui/src/pages/MetricsPage/components/MetricsGrid/components/MetricsGridToolbar/MetricsGridToolbar.tsx
@@ -1,8 +1,12 @@
 import { GridToolbar } from "components/GridToolbar/GridToolbar";
 import { useMetricFormContext } from "contexts/MetricForm/MetricForm.context";
 
-export const MetricsGridToolbar = () => {
+export const MetricsGridToolbar = ({ onResetColumns }: { onResetColumns: () => void }) => {
   const { handleOpen, setData } = useMetricFormContext();
+
+  type Props = {
+    onResetColumns: () => void;
+  };
 
   const onNewClick = () => {
     setData(undefined);
@@ -10,6 +14,6 @@ export const MetricsGridToolbar = () => {
   };
 
   return (
-    <GridToolbar onNewClick={onNewClick} />
+    <GridToolbar onNewClick={onNewClick} onResetColumns={onResetColumns} />
   );
 };

--- a/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
+++ b/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
@@ -21,7 +21,8 @@ export const PresetsGrid = () => {
     columnVisibility, 
     columnsWithSizing, 
     onColumnVisibilityChange, 
-    onColumnWidthChange
+    onColumnWidthChange,
+    resetColumnSizes
   } = useGridState('PRESETS_GRID', columns);
 
   const rows: PresetGridRow[] | [] = useMemo(() => {
@@ -59,7 +60,7 @@ export const PresetsGrid = () => {
           rows={rows}
           pageSizeOptions={[]}
           slots={{ 
-            toolbar: () => <PresetsGridToolbar />
+            toolbar: () => <PresetsGridToolbar onResetColumns={resetColumnSizes} />
           }}
           columnVisibilityModel={columnVisibility}
           onColumnVisibilityModelChange={onColumnVisibilityChange}

--- a/internal/webui/src/pages/PresetsPage/components/PresetsGrid/components/PresetsGridToolbar/PresetsGridToolbar.tsx
+++ b/internal/webui/src/pages/PresetsPage/components/PresetsGrid/components/PresetsGridToolbar/PresetsGridToolbar.tsx
@@ -1,7 +1,11 @@
 import { GridToolbar } from "components/GridToolbar/GridToolbar";
 import { usePresetFormContext } from "contexts/PresetForm/PresetForm.context";
 
-export const PresetsGridToolbar = () => {
+type Props = {
+  onResetColumns: () => void;
+};
+
+export const PresetsGridToolbar = ({ onResetColumns }: Props) => {
   const { handleOpen, setData } = usePresetFormContext();
 
   const onNewClick = () => {
@@ -10,6 +14,6 @@ export const PresetsGridToolbar = () => {
   };
 
   return (
-    <GridToolbar onNewClick={onNewClick} />
+    <GridToolbar onNewClick={onNewClick} onResetColumns={onResetColumns} />
   );
 };

--- a/internal/webui/src/pages/SourcesPage/components/SourcesGrid/SourcesGrid.tsx
+++ b/internal/webui/src/pages/SourcesPage/components/SourcesGrid/SourcesGrid.tsx
@@ -19,7 +19,8 @@ export const SourcesGrid = () => {
     columnVisibility, 
     columnsWithSizing, 
     onColumnVisibilityChange, 
-    onColumnWidthChange
+    onColumnWidthChange,
+    resetColumnSizes
   } = useGridState('SOURCES_GRID', columns, {
     Kind: false,
     IncludePattern: false,
@@ -52,7 +53,7 @@ export const SourcesGrid = () => {
           rows={data ?? []}
           pageSizeOptions={[]}
           slots={{ 
-            toolbar: () => <SourcesGridToolbar />
+            toolbar: () => <SourcesGridToolbar onResetColumns={resetColumnSizes} />
           }}
           columnVisibilityModel={columnVisibility}
           onColumnVisibilityModelChange={onColumnVisibilityChange}

--- a/internal/webui/src/pages/SourcesPage/components/SourcesGrid/components/SourcesGridToolbar.tsx
+++ b/internal/webui/src/pages/SourcesPage/components/SourcesGrid/components/SourcesGridToolbar.tsx
@@ -2,7 +2,11 @@ import { GridToolbar } from "components/GridToolbar/GridToolbar";
 import { useSourceFormContext } from "contexts/SourceForm/SourceForm.context";
 import { SourceFormActions } from "contexts/SourceForm/SourceForm.types";
 
-export const SourcesGridToolbar = () => {
+type Props = {
+  onResetColumns: () => void;
+};
+
+export const SourcesGridToolbar = ({ onResetColumns }: Props) => {
   const { handleOpen, setData, setAction } = useSourceFormContext();
 
   const onNewClick = () => {
@@ -12,6 +16,6 @@ export const SourcesGridToolbar = () => {
   };
 
   return (
-    <GridToolbar onNewClick={onNewClick} />
+    <GridToolbar onNewClick={onNewClick} onResetColumns={onResetColumns} />
   );
 };


### PR DESCRIPTION
## Description

Fixes #1308

`useGridState` already exposes resetColumnSizes() but it was never
connected to the UI.

This PR adds a "Reset column sizes" button to the toolbar of all three
grid pages: `Sources`, `Metrics`, and `Presets`.

<img width="1918" height="830" alt="image" src="https://github.com/user-attachments/assets/a623085a-dfa8-4f86-9a62-19cb905575a3" />


## AI & Automation Policy

- [X] I am the human author and take full personal responsibility for every change in this PR.
- [X] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.
Drafted with the assistance of Claude Sonned 4.6

## Checklist

- [X] Code compiles and existing tests pass locally.
- [X] New or updated tests are included where applicable.
- [X] Documentation is updated where applicable.
