### PR TITLE
Improve log severity parsing and extend locale support

### DIFF
--- a/internal/reaper/logparser.go
+++ b/internal/reaper/logparser.go
@@ -21,8 +21,9 @@ import (
 var pgSeverities = [...]string{"DEBUG", "INFO", "NOTICE", "WARNING", "ERROR", "LOG", "FATAL", "PANIC"}
 var pgSeveritiesLocale = map[string]map[string]string{
 	"C.": {"DEBUG": "DEBUG", "LOG": "LOG", "INFO": "INFO", "NOTICE": "NOTICE", "WARNING": "WARNING", "ERROR": "ERROR", "FATAL": "FATAL", "PANIC": "PANIC"},
+	"C":  {"DEBUG": "DEBUG", "LOG": "LOG", "INFO": "INFO", "NOTICE": "NOTICE", "WARNING": "WARNING", "ERROR": "ERROR", "FATAL": "FATAL", "PANIC": "PANIC"},
 	"de": {"DEBUG": "DEBUG", "LOG": "LOG", "INFO": "INFO", "HINWEIS": "NOTICE", "WARNUNG": "WARNING", "FEHLER": "ERROR", "FATAL": "FATAL", "PANIK": "PANIC"},
-	"fr": {"DEBUG": "DEBUG", "LOG": "LOG", "INFO": "INFO", "NOTICE": "NOTICE", "ATTENTION": "WARNING", "ERREUR": "ERROR", "FATAL": "FATAL", "PANIK": "PANIC"},
+	"fr": {"DEBUG": "DEBUG", "LOG": "LOG", "INFO": "INFO", "NOTICE": "NOTICE", "ATTENTION": "WARNING", "ERREUR": "ERROR", "FATAL": "FATAL", "PANIK": "PANIC", "PANIQUE": "PANIC"},
 	"it": {"DEBUG": "DEBUG", "LOG": "LOG", "INFO": "INFO", "NOTIFICA": "NOTICE", "ATTENZIONE": "WARNING", "ERRORE": "ERROR", "FATALE": "FATAL", "PANICO": "PANIC"},
 	"ko": {"디버그": "DEBUG", "로그": "LOG", "정보": "INFO", "알림": "NOTICE", "경고": "WARNING", "오류": "ERROR", "치명적오류": "FATAL", "손상": "PANIC"},
 	"pl": {"DEBUG": "DEBUG", "DZIENNIK": "LOG", "INFORMACJA": "INFO", "UWAGA": "NOTICE", "OSTRZEŻENIE": "WARNING", "BŁĄD": "ERROR", "KATASTROFALNY": "FATAL", "PANIKA": "PANIC"},
@@ -161,13 +162,14 @@ func checkHasLocalPrivileges(logsDirPath string) error {
 }
 
 func severityToEnglish(serverLang, errorSeverity string) string {
+	normalizedSeverity := strings.ToUpper(errorSeverity)
 	if serverLang == "en" {
-		return errorSeverity
+		return normalizedSeverity
 	}
 	severityMap := pgSeveritiesLocale[serverLang]
-	severityEn, ok := severityMap[errorSeverity]
+	severityEn, ok := severityMap[normalizedSeverity]
 	if !ok {
-		return errorSeverity
+		return normalizedSeverity
 	}
 	return severityEn
 }

--- a/internal/reaper/logparser_test.go
+++ b/internal/reaper/logparser_test.go
@@ -270,13 +270,16 @@ func TestSeverityToEnglish(t *testing.T) {
 		expected      string
 	}{
 		{"en", "ERROR", "ERROR"},
+		{"en", "error", "ERROR"},
 		{"de", "FEHLER", "ERROR"},
 		{"fr", "ERREUR", "ERROR"},
+		{"fr", "PANIQUE", "PANIC"},
+		{"C", "WARNING", "WARNING"},
 		{"de", "WARNUNG", "WARNING"},
 		{"ru", "ОШИБКА", "ERROR"},
 		{"zh", "错误", "ERROR"},
-		{"unknown", "ERROR", "ERROR"},                  // Unknown language, return as-is
-		{"de", "UNKNOWN_SEVERITY", "UNKNOWN_SEVERITY"}, // Unknown severity in known language
+		{"unknown", "ERROR", "ERROR"},                  // Unknown language, return uppercase as-is
+		{"de", "unknown_severity", "UNKNOWN_SEVERITY"}, // Unknown severity in known language
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Logs may not always follow strict formatting (e.g., lowercase or localized values).
I tried to ensure more consistent parsing and more accurate event counting by these changes. 

What changes:
- Normalize severity values to uppercase, so this handles cases like error, Warning correctly
- Add support for lc_messages = 'C'
- add missing French mapping (PANIQUE: PANIC)
- Improve fallback behavior for unknown values

I added more tests to cover these scenarios

## AI & Automation Policy

<!-- See AI_POLICY.md for full terms. All boxes must be checked before this PR can be merged. -->

- [X] I am the human author and take full personal responsibility for every change in this PR.
- [X] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:
Drafted with Codex

## Checklist

- [X] Code compiles and existing tests pass locally.
- [X] New or updated tests are included where applicable.
- [X] Documentation is updated where applicable.
