### PR TITLE
[+] add custom `TimescaleDB` Dockerfile with plpython3u support

### DIFF
--- a/docker/Dockerfile.timescaledb-plpython3u
+++ b/docker/Dockerfile.timescaledb-plpython3u
@@ -1,0 +1,4 @@
+FROM timescale/timescaledb:latest-pg18
+
+# Install plpython3u
+RUN set -ex && apk add ---virtual .plpython3-deps --no-cache py3-psutil --repository http://nl.alpinelinux.org/alpine/edge/testing postgresql-plpython3

--- a/docker/compose.timescaledb.yml
+++ b/docker/compose.timescaledb.yml
@@ -1,7 +1,10 @@
 services:
   postgres:
     user: postgres
-    image: &pgimage timescale/timescaledb:latest-pg18
+    build:
+      context: .
+      dockerfile: Dockerfile.timescaledb-plpython3u
+    # image: &pgimage timescale/timescaledb:latest-pg18
     container_name: postgres
     command:
       - "-cshared_preload_libraries=pg_stat_statements,timescaledb"
@@ -27,7 +30,10 @@ services:
 
   postgres-standby:
     user: postgres
-    image: *pgimage
+    build:
+      context: .
+      dockerfile: Dockerfile.timescaledb-plpython3u
+    # image: *pgimage
     container_name: postgres-standby
     environment:
       POSTGRES_PASSWORD: standbypass


### PR DESCRIPTION
- Creates a new `Dockerfile.timescaledb-plpython3u`
- Updates `compose.timescaledb.yml` to build from it instead of using the pre-built `timescale/timescaledb` image that doesn't have plpython3u