### PR TITLE
[+] implement parallel source discovery

### DIFF
--- a/internal/cmdopts/cmdsource.go
+++ b/internal/cmdopts/cmdsource.go
@@ -99,7 +99,7 @@ func (cmd *SourceResolveCommand) Execute(args []string) error {
 			}
 		}
 	}
-	conns, err := foundSources.ResolveDatabases()
+	conns, err := foundSources.ResolveDatabases(nil)
 	if err != nil {
 		return err
 	}

--- a/internal/reaper/database.go
+++ b/internal/reaper/database.go
@@ -438,7 +438,7 @@ func (r *Reaper) GetInstanceUpMeasurement(ctx context.Context, md *sources.Sourc
 	return metrics.Measurements{
 		metrics.Measurement{
 			metrics.EpochColumnName: time.Now().UnixNano(),
-			"instance_up": func() int {
+			specialMetricInstanceUp: func() int {
 				if md.Conn.Ping(ctx) == nil {
 					return 1
 				}

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -407,8 +407,19 @@ func (r *Reaper) LoadSources(ctx context.Context) (err error) {
 	srcs = slices.DeleteFunc(srcs, func(s sources.Source) bool {
 		return !s.IsEnabled || len(r.Sources.Groups) > 0 && !slices.Contains(r.Sources.Groups, s.Group)
 	})
-	if newSrcs, err = srcs.ResolveDatabases(); err != nil {
+	newSrcs, err = srcs.ResolveDatabases()
+	if err != nil {
 		r.logger.WithError(err).Error("could not resolve databases from sources")
+		for _, s := range srcs {
+			if s.Kind != sources.SourcePostgresContinuous && s.Kind != sources.SourcePatroni {
+				continue
+			}
+			if !slices.ContainsFunc(newSrcs, func(sc *sources.SourceConn) bool {
+				return sc.Name == s.Name || strings.HasPrefix(sc.Name, s.Name+"_")
+			}) {
+				r.WriteInstanceDown(sources.NewSourceConn(s))
+			}
+		}
 	}
 
 	for i, newMD := range newSrcs {

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -101,7 +101,7 @@ func (r *Reaper) Reap(ctx context.Context) {
 			ctx = log.WithLogger(ctx, srcL)
 
 			if monitoredSource.Connect(ctx, r.Sources) != nil {
-				r.WriteInstanceDown(monitoredSource)
+				r.WriteInstanceDown(monitoredSource.Name)
 				srcL.Warning("could not init connection, retrying on next iteration")
 				continue
 			}
@@ -405,6 +405,7 @@ func (r *Reaper) LoadSources(ctx context.Context) (err error) {
 		return err
 	}
 	srcs = slices.DeleteFunc(srcs, func(s sources.Source) bool {
+		// filter out disabled sources and sources with group not in the list of groups to monitor
 		return !s.IsEnabled || len(r.Sources.Groups) > 0 && !slices.Contains(r.Sources.Groups, s.Group)
 	})
 	newSrcs, err = srcs.ResolveDatabases()
@@ -417,7 +418,7 @@ func (r *Reaper) LoadSources(ctx context.Context) (err error) {
 			if !slices.ContainsFunc(newSrcs, func(sc *sources.SourceConn) bool {
 				return sc.Name == s.Name || strings.HasPrefix(sc.Name, s.Name+"_")
 			}) {
-				r.WriteInstanceDown(sources.NewSourceConn(s))
+				r.WriteInstanceDown(s.Name)
 			}
 		}
 	}
@@ -443,9 +444,9 @@ func (r *Reaper) LoadSources(ctx context.Context) (err error) {
 }
 
 // WriteInstanceDown writes instance_up = 0 metric to sinks for the given source
-func (r *Reaper) WriteInstanceDown(md *sources.SourceConn) {
+func (r *Reaper) WriteInstanceDown(name string) {
 	r.measurementCh <- metrics.MeasurementEnvelope{
-		DBName:     md.Name,
+		DBName:     name,
 		MetricName: specialMetricInstanceUp,
 		Data: metrics.Measurements{metrics.Measurement{
 			metrics.EpochColumnName: time.Now().UnixNano(),

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -408,19 +408,10 @@ func (r *Reaper) LoadSources(ctx context.Context) (err error) {
 		// filter out disabled sources and sources with group not in the list of groups to monitor
 		return !s.IsEnabled || len(r.Sources.Groups) > 0 && !slices.Contains(r.Sources.Groups, s.Group)
 	})
-	newSrcs, err = srcs.ResolveDatabases()
-	if err != nil {
+
+	if newSrcs, err = srcs.ResolveDatabases(r.WriteInstanceDown); err != nil {
+		// discover dtabases for continuous monitoring sources
 		r.logger.WithError(err).Error("could not resolve databases from sources")
-		for _, s := range srcs {
-			if s.Kind != sources.SourcePostgresContinuous && s.Kind != sources.SourcePatroni {
-				continue
-			}
-			if !slices.ContainsFunc(newSrcs, func(sc *sources.SourceConn) bool {
-				return sc.Name == s.Name || strings.HasPrefix(sc.Name, s.Name+"_")
-			}) {
-				r.WriteInstanceDown(s.Name)
-			}
-		}
 	}
 
 	for i, newMD := range newSrcs {

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -593,5 +593,5 @@ func TestWriteMeasurements(t *testing.T) {
 		SinksWriter: err,
 	})
 	go r.WriteMeasurements(ctx)
-	r.WriteInstanceDown(&sources.SourceConn{})
+	r.WriteInstanceDown("foo")
 }

--- a/internal/sources/resolver.go
+++ b/internal/sources/resolver.go
@@ -28,7 +28,7 @@ import (
 
 // ResolveDatabases() updates list of monitored objects from continuous monitoring sources, e.g. patroni.
 // Each source is resolved concurrently so that a slow or unreachable source does not block the others.
-func (srcs Sources) ResolveDatabases() (_ SourceConns, err error) {
+func (srcs Sources) ResolveDatabases(onError func(string)) (_ SourceConns, err error) {
 	type result struct {
 		dbs SourceConns
 		err error
@@ -45,6 +45,9 @@ func (srcs Sources) ResolveDatabases() (_ SourceConns, err error) {
 	resolvedDbs := make(SourceConns, 0, len(srcs))
 	for i, res := range results {
 		if res.err != nil {
+			if onError != nil {
+				onError(srcs[i].Name)
+			}
 			logger.WithField("source", srcs[i].Name).WithError(res.err).Error("could not resolve databases from source")
 			err = errors.Join(err, res.err)
 		}

--- a/internal/sources/resolver.go
+++ b/internal/sources/resolver.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -25,16 +26,29 @@ import (
 	"go.uber.org/zap"
 )
 
-// ResolveDatabases() updates list of monitored objects from continuous monitoring sources, e.g. patroni
+// ResolveDatabases() updates list of monitored objects from continuous monitoring sources, e.g. patroni.
+// Each source is resolved concurrently so that a slow or unreachable source does not block the others.
 func (srcs Sources) ResolveDatabases() (_ SourceConns, err error) {
+	type result struct {
+		dbs SourceConns
+		err error
+	}
+	results := make([]result, len(srcs))
+	var wg sync.WaitGroup
+	for i, s := range srcs {
+		wg.Go(func() {
+			dbs, e := s.ResolveDatabases()
+			results[i] = result{dbs, e}
+		})
+	}
+	wg.Wait()
 	resolvedDbs := make(SourceConns, 0, len(srcs))
-	for _, s := range srcs {
-		if !s.IsEnabled {
-			continue
+	for i, res := range results {
+		if res.err != nil {
+			logger.WithField("source", srcs[i].Name).WithError(res.err).Error("could not resolve databases from source")
+			err = errors.Join(err, res.err)
 		}
-		dbs, e := s.ResolveDatabases()
-		err = errors.Join(err, e)
-		resolvedDbs = append(resolvedDbs, dbs...)
+		resolvedDbs = append(resolvedDbs, res.dbs...)
 	}
 	return resolvedDbs, err
 }


### PR DESCRIPTION
Improves dead-source handling with parallel resolution and `instance_up=0` on discovery failure.

`Sources.ResolveDatabases()` previously resolved each source sequentially. A single slow or unresponsive source (e.g. a continuous-discovery endpoint behind a firewall) would block discovery of all subsequent sources for the full connection timeout duration.

Sources are now resolved concurrently using `sync.WaitGroup.Go()`. Results are collected into a pre-allocated indexed slice to preserve deterministic ordering. Per-source error logging with source name is included in the resolver itself.

When a `SourcePostgresContinuous` or `SourcePatroni` source fails to resolve any databases, `LoadSources()` now emits `instance_up=0` to the configured sinks. This makes the failure visible in dashboards and alerting, consistent with how unreachable directly-monitored sources are handled.