### PR TITLE
[+] add `wal_fpi_bytes` field to `wal_stats` metric, fixes #1399

### DIFF
--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -4137,6 +4137,27 @@ metrics:
                     wal_sync_time
                 from
                     pg_stat_wal, io
+            19: |-
+                with io as (
+                  select 
+                    sum(writes) as wal_write, 
+                    sum(fsyncs) as wal_sync,
+                    sum(round(write_time::numeric, 3)::int8) as wal_write_time,
+                    sum(round(fsync_time::numeric, 3)::int8) as wal_sync_time
+                  from pg_stat_io where "object" = 'wal')
+                select /* pgwatch_generated */
+                    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                    wal_records,
+                    wal_fpi,
+                    (wal_bytes / 1024)::int8 as wal_bytes_kb,
+                    wal_fpi_bytes,
+                    wal_buffers_full,
+                    wal_write,
+                    wal_sync,
+                    wal_write_time,
+                    wal_sync_time
+                from
+                    pg_stat_wal, io
     datfrozenxid:
         description: >
             This metric collects information about the database frozen transaction ID.


### PR DESCRIPTION
## Description

After reading [https://postgr.es/c/f9a09aa29](https://postgr.es/c/f9a09aa29) I added `wal_fpi_bytes` to `wal_stats`  metric
Fixes #1399
 
I've added `wal_fpi_bytes` to the `wal_stats` metric by adding a new SQL query block for version 19 (duplicating the version 18 query and adding the new column).

Also, from reading the commit, I noticed that `wal_fpi_bytes` is also available on `pg_stat_get_backend_wal()`, but `pgwatch` doesn't currently have backend-specific WAL stats metric, I didn't create a new metric for it.

I am opening this as a draft to make sure I correctly understood what's needed.

## AI & Automation Policy

<!-- See AI_POLICY.md for full terms. All boxes must be checked before this PR can be merged. -->

- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:

<!-- e.g. "Drafted with the assistance of GitHub Copilot", "Issue revealed by Gemini" -->

## Checklist

- [X] Code compiles and existing tests pass locally.
- [ ] New or updated tests are included where applicable.
- [ ] Documentation is updated where applicable.
