### PR TITLE
[+] add `autovacuum_scores` metric

### DIFF
--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -44,6 +44,31 @@ metrics:
             - is_failing_int
             - seconds_since_last_failure
         is_instance_level: true
+    autovacuum_scores:
+        description: >
+            This metric retrieves vacuum scores for each table in the current database from the PostgreSQL pg_stat_autovacuum_scores view, it also shows whether autovacuum would vacuum or analyze the table.
+        sqls: 
+            19: |
+                select /* pgwatch_generated */
+                  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+                  schemaname::text as tag_schema,
+                  relname::text as tag_table_name,
+                  quote_ident(schemaname)||'.'||quote_ident(relname) as tag_table_full_name,
+                  score,
+                  xid_score,
+                  mxid_score,
+                  vacuum_score,
+                  vacuum_insert_score,
+                  analyze_score,
+                  case when do_vacuum then 1 else 0 end as do_vacuum_int,
+                  case when do_analyze then 1 else 0 end as do_analyze_int,
+                  case when for_wraparound then 1 else 0 end as for_wraparound_int
+                from
+                  pg_stat_autovacuum_scores 
+                where
+                  schemaname not like any (array[E'pg\\_%', 'information_schema', E'\\_timescaledb%']) 
+        gauges:
+            - '*'
     backends:
         description: >
             This metric gathers detailed information from the PostgreSQL pg_stat_activity view, providing an overview of the database's current session
@@ -4285,6 +4310,7 @@ presets:
         metrics:
             archiver: 60
             archiver_pending_count: 120
+            autovacuum_scores: 60
             backends: 60
             bgwriter: 60
             checkpointer: 60
@@ -4317,6 +4343,7 @@ presets:
         metrics:
             archiver: 60
             archiver_pending_count: 120
+            autovacuum_scores: 60
             backends: 60
             bgwriter: 60
             checkpointer: 60
@@ -4441,6 +4468,7 @@ presets:
     standard:
         description: basic level + table, index, stat_statements stats
         metrics:
+            autovacuum_scores: 60
             cpu_load: 60
             db_size: 300
             db_stats: 60
@@ -4487,6 +4515,7 @@ presets:
         metrics:
             archiver: 30
             archiver_pending_count: 30
+            autovacuum_scores: 30
             backends: 30
             backup_age_pgbackrest: 30
             backup_age_walg: 30

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -46,7 +46,8 @@ metrics:
         is_instance_level: true
     autovacuum_scores:
         description: >
-            This metric retrieves vacuum scores for each table in the current database from the PostgreSQL pg_stat_autovacuum_scores view, it also shows whether autovacuum would vacuum or analyze the table.
+            This metric retrieves vacuum scores for each table in the current database from the PostgreSQL pg_stat_autovacuum_scores view,
+            it also shows whether autovacuum would vacuum or analyze the table.
         sqls: 
             19: |
                 select /* pgwatch_generated */
@@ -60,13 +61,15 @@ metrics:
                   vacuum_score,
                   vacuum_insert_score,
                   analyze_score,
-                  case when do_vacuum then 1 else 0 end as do_vacuum_int,
-                  case when do_analyze then 1 else 0 end as do_analyze_int,
-                  case when for_wraparound then 1 else 0 end as for_wraparound_int
+                  do_vacuum::int as do_vacuum_int,
+                  do_analyze::int as do_analyze_int,
+                  for_wraparound::int as for_wraparound_int
                 from
-                  pg_stat_autovacuum_scores 
+                  pg_stat_autovacuum_scores
                 where
-                  schemaname not like any (array[E'pg\\_%', 'information_schema', E'\\_timescaledb%']) 
+                  schemaname not like all (array[E'pg\\_%', 'information_schema', E'\\_timescaledb%'])
+                order by score desc nulls last
+                limit 300
         gauges:
             - '*'
     backends:

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -4218,6 +4218,7 @@ presets:
         description: aiven database metrics
         metrics:
             archiver: 60
+            autovacuum_scores: 120            
             backends: 60
             bgwriter: 60
             checkpointer: 60
@@ -4278,6 +4279,7 @@ presets:
         description: similar to 'exhaustive' with stuff that's not accessible on Azure Database for PostgreSQL removed
         metrics:
             archiver: 60
+            autovacuum_scores: 120
             backends: 60
             bgwriter: 60
             checkpointer: 60
@@ -4313,7 +4315,7 @@ presets:
         metrics:
             archiver: 60
             archiver_pending_count: 120
-            autovacuum_scores: 60
+            autovacuum_scores: 120
             backends: 60
             bgwriter: 60
             checkpointer: 60
@@ -4346,7 +4348,7 @@ presets:
         metrics:
             archiver: 60
             archiver_pending_count: 120
-            autovacuum_scores: 60
+            autovacuum_scores: 120
             backends: 60
             bgwriter: 60
             checkpointer: 60
@@ -4394,6 +4396,7 @@ presets:
         description: similar to 'exhaustive' with stuff not accessible on GCE managed PostgreSQL engine removed
         metrics:
             archiver: 60
+            autovacuum_scores: 120
             backends: 60
             bgwriter: 60
             checkpointer: 60
@@ -4445,6 +4448,7 @@ presets:
         description: similar to 'exhaustive' with stuff that's not accessible on AWS RDS removed
         metrics:
             archiver: 60
+            autovacuum_scores: 120
             archiver_pending_count: 120
             backends: 60
             bgwriter: 60
@@ -4471,7 +4475,7 @@ presets:
     standard:
         description: basic level + table, index, stat_statements stats
         metrics:
-            autovacuum_scores: 60
+            autovacuum_scores: 120
             cpu_load: 60
             db_size: 300
             db_stats: 60
@@ -4486,6 +4490,7 @@ presets:
         description: like exhaustive, but no PL/Python helpers
         metrics:
             archiver: 60
+            autovacuum_scores: 120
             archiver_pending_count: 120
             backends: 60
             bgwriter: 60


### PR DESCRIPTION
## Description

Added metric for `pg_stat_autovacuum_scores` to report per-table autovacuum details based on the new `pg_stat_autovacuum_scores` view produced by postgresql 19 


Fixes #1398

- SQL query to fetch the scores retrieved from pg_stat_autovacuum_scores` view
- Converted boolean fields (`do_vacuum`, `do_analyze`, `for_wraparound`) to integers 1/0 to match other metrics
- Applied tag naming (`tag_schema`, `tag_table_name`, `tag_table_full_name`).
- Registered the new metric in the presets (`exhaustive`, `full`, `standard`, `debug`).
I honestly do not sure about proper presets to add to, but I suggested the above based on the provided description on each preset.
## AI & Automation Policy

<!-- See AI_POLICY.md for full terms. All boxes must be checked before this PR can be merged. -->

- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:

<!-- e.g. "Drafted with the assistance of GitHub Copilot", "Issue revealed by Gemini" -->

## Checklist

- [x] Code compiles and existing tests pass locally.
- [ ] New or updated tests are included where applicable.
- [ ] Documentation is updated where applicable.
