### PR TITLE
Add metric for pg_dsm_registry_allocations

### DIFF
--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -638,6 +638,21 @@ metrics:
             - checksum_last_failure_s
             - parallel_workers_to_launch
             - parallel_workers_launched
+    dsm_registry_allocations:
+        description: >
+            This metric provides information about entries in the dynamic shared memory (DSM) registry, it retrieves the name, type (segment, area, or hash), and size of each entry.
+        sqls:
+            19: |
+                select /* pgwatch_generated */
+                  (extract (epoch from now()) * 1e9)::int8 as epoch_ns,
+                  name::text as tag_name,
+                  type::text as tag_type,
+                  coalesce(size, 0)::int8 as size_bytes
+                from 
+                  pg_dsm_registry_allocations;
+        gauges:
+            - size_bytes
+        is_instance_level: true    
     index_hashes:
         description: >
             Retrieves the hash of index definitions in the PostgreSQL database, providing a way to track changes in index definitions over time.
@@ -4293,6 +4308,7 @@ presets:
             datfrozenxid: 300
             db_size: 300
             db_stats: 60
+            dsm_registry_allocations: 60
             index_stats: 900
             instance_up: 60
             locks: 60
@@ -4325,6 +4341,7 @@ presets:
             datfrozenxid: 300
             db_size: 300
             db_stats: 60
+            dsm_registry_allocations: 60
             index_stats: 900
             instance_up: 60
             kpi: 120
@@ -4463,6 +4480,7 @@ presets:
             datfrozenxid: 300
             db_size: 300
             db_stats: 60
+            dsm_registry_allocations: 60
             index_stats: 900
             instance_up: 60
             locks: 60
@@ -4503,6 +4521,7 @@ presets:
             db_size: 30
             db_size_approx: 30
             db_stats: 30
+            dsm_registry_allocations: 30
             index_hashes: 30
             index_stats: 30
             instance_up: 30


### PR DESCRIPTION
## Description

Added metric for `dsm_registry_allocations` to report dynamic shared memory allocations using the new `pg_dsm_registry_allocations` view provided in PostgreSQL 19.

Fixes #1400
- SQL query to fetch the allocations retrieved from `pg_dsm_registry_allocations` view
- Used coalesce(size, 0) to handle edge cases, as I read that partially-initialized entries will report a NULL size
- Applied tag naming (tag_name, tag_type)
- Registered the new metric in the presets (exhaustive, full, debug, exhaustive_no_python)
- I set `is_instance_level: true`  based on my understanding that DSM is a cluster-wide resource, but please let me know if this needs correction
## AI & Automation Policy

<!-- See AI_POLICY.md for full terms. All boxes must be checked before this PR can be merged. -->

- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:

<!-- e.g. "Drafted with the assistance of GitHub Copilot", "Issue revealed by Gemini" -->

## Checklist

- [x] Code compiles and existing tests pass locally.
- [ ] New or updated tests are included where applicable.
- [ ] Documentation is updated where applicable.
