### PR TITLE
[-] fix Grafana postgres datasource provisioning for Grafana 12+

### DIFF
--- a/grafana/postgres_datasource.yml
+++ b/grafana/postgres_datasource.yml
@@ -6,13 +6,14 @@ datasources:
   type: postgres
   url: postgres:5432
   access: proxy
-  password: pgwatchadmin
   user: pgwatch
-  database: pgwatch_metrics
+  secureJsonData:
+    password: pgwatchadmin
   basicAuth: false
   isDefault: true
   jsonData:
-     sslmode: disable
-     postgresVersion: 1500 
+    database: pgwatch_metrics
+    sslmode: disable
+    postgresVersion: 1500
   version: 1
   editable: true


### PR DESCRIPTION
Grafana 12 dropped support for top-level `database` and `password` fields in datasource provisioning files. Move `database` into `jsonData` and `password` into `secureJsonData` as now required.

Fixes the error:
"You do not currently have a default database configured for this data source."
