### PR TITLE
[*] migrate to time-only partitioning in pg sink

### DIFF
--- a/cmd/pgwatch/doc.go
+++ b/cmd/pgwatch/doc.go
@@ -54,6 +54,9 @@
 //	                                     may be ignored by some sinks
 //	                                     (default: 950ms)
 //	                                     [$PW_BATCHING_DELAY]
+//  --partition-interval=                Time range for PostgreSQL sink time partitions. 
+// 										 Must be a valid PostgreSQL interval. 
+// 										 (default: 1 day) [$PW_PARTITION_INTERVAL]
 //	--retention=                         Delete metrics older than this. 
 //	                                     Must be a valid PostgreSQL interval. 
 //	                                     (default: 14 days) [$PW_RETENTION]

--- a/cmd/pgwatch/version.go
+++ b/cmd/pgwatch/version.go
@@ -8,7 +8,7 @@ var (
 	version      = "unknown"
 	date         = "unknown"
 	configSchema = "00824"
-	sinkSchema   = "01180"
+	sinkSchema   = "01409"
 )
 
 func printVersion() {

--- a/docs/reference/cli_env.md
+++ b/docs/reference/cli_env.md
@@ -94,7 +94,7 @@ It reads the configuration from the specified sources and metrics, then begins c
 
 - `--partition-interval=`
 
-    Time range for PostgreSQL sink table partitions. Must be a valid PostgreSQL interval. (default: 1 week)  
+    Time range for PostgreSQL sink table partitions. Must be a valid PostgreSQL interval. (default: 1 day)  
     ENV: `$PW_PARTITION_INTERVAL`
 
     Example:

--- a/internal/sinks/cmdopts.go
+++ b/internal/sinks/cmdopts.go
@@ -6,7 +6,7 @@ import "time"
 type CmdOpts struct {
 	Sinks                 []string      `long:"sink" mapstructure:"sink" description:"URI where metrics will be stored, can be used multiple times" env:"PW_SINK"`
 	BatchingDelay         time.Duration `long:"batching-delay" mapstructure:"batching-delay" description:"Sink-specific batching flush delay; may be ignored by some sinks" default:"950ms" env:"PW_BATCHING_DELAY"`
-	PartitionInterval     string        `long:"partition-interval" mapstructure:"partition-interval" description:"Time range for PostgreSQL sink time partitions. Must be a valid PostgreSQL interval." default:"1 week" env:"PW_PARTITION_INTERVAL"`
+	PartitionInterval     string        `long:"partition-interval" mapstructure:"partition-interval" description:"Time range for PostgreSQL sink time partitions. Must be a valid PostgreSQL interval." default:"1 day" env:"PW_PARTITION_INTERVAL"`
 	RetentionInterval     string        `long:"retention" mapstructure:"retention" description:"Delete metrics older than this. Must be a valid PostgreSQL interval." default:"14 days" env:"PW_RETENTION"`
 	MaintenanceInterval   string        `long:"maintenance-interval" mapstructure:"maintenance-interval" description:"Run pgwatch maintenance tasks on sinks with this interval e.g., deleting old metrics; Set to zero to disable. Must be a valid PostgreSQL interval." default:"12 hours" env:"PW_MAINTENANCE_INTERVAL"`
 	RealDbnameField       string        `long:"real-dbname-field" mapstructure:"real-dbname-field" description:"Tag key for real database name" env:"PW_REAL_DBNAME_FIELD" default:"real_dbname"`

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -61,16 +61,16 @@ var (
 // However, one is able to use any Postgres-compatible database as a storage backend,
 // e.g. PGEE, Citus, Greenplum, CockroachDB, etc.
 type PostgresWriter struct {
-	ctx                      context.Context
-	sinkDb                   db.PgxPoolIface
-	metricSchema             DbStorageSchemaType
-	opts                     *CmdOpts
-	retentionInterval        time.Duration
-	maintenanceInterval      time.Duration
-	input                    chan metrics.MeasurementEnvelope
-	lastError                chan error
-	forceRecreatePartitions  bool                                        // to signal override PG metrics storage cache
-	partitionMapMetric 		 map[string]ExistingPartitionInfo // metric = min/max bounds
+	ctx                     context.Context
+	sinkDb                  db.PgxPoolIface
+	metricSchema            DbStorageSchemaType
+	opts                    *CmdOpts
+	retentionInterval       time.Duration
+	maintenanceInterval     time.Duration
+	input                   chan metrics.MeasurementEnvelope
+	lastError               chan error
+	forceRecreatePartitions bool                             // to signal override PG metrics storage cache
+	partitionMapMetric      map[string]ExistingPartitionInfo // metric = min/max bounds
 }
 
 // make sure *dbMetricReaderWriter implements the Migrator interface
@@ -90,13 +90,13 @@ func NewWriterFromPostgresConn(ctx context.Context, conn db.PgxPoolIface, opts *
 	l := log.GetLogger(ctx).WithField("sink", "postgres").WithField("db", conn.Config().ConnConfig.Database)
 	ctx = log.WithLogger(ctx, l)
 	pgw = &PostgresWriter{
-		ctx:                      ctx,
-		opts:                     opts,
-		input:                    make(chan metrics.MeasurementEnvelope, cacheLimit),
-		lastError:                make(chan error),
-		sinkDb:                   conn,
-		forceRecreatePartitions:  false,
-		partitionMapMetric: 	  make(map[string]ExistingPartitionInfo),
+		ctx:                     ctx,
+		opts:                    opts,
+		input:                   make(chan metrics.MeasurementEnvelope, cacheLimit),
+		lastError:               make(chan error),
+		sinkDb:                  conn,
+		forceRecreatePartitions: false,
+		partitionMapMetric:      make(map[string]ExistingPartitionInfo),
 	}
 	l.Info("initialising measurements database...")
 	if err = pgw.init(); err != nil {
@@ -453,7 +453,7 @@ func (pgw *PostgresWriter) EnsureMetricTimescale(pgPartBounds map[string]Existin
 	return
 }
 
-func (pgw *PostgresWriter) EnsureMetricTimePartsExist(metricPartBounds map[string]ExistingPartitionInfo) (error) {
+func (pgw *PostgresWriter) EnsureMetricTimePartsExist(metricPartBounds map[string]ExistingPartitionInfo) error {
 	var err error
 	var rows pgx.Rows
 	sqlEnsure := `select * from admin.ensure_partition_metric_time($1, $2, $3)`
@@ -636,17 +636,17 @@ var migrations func() migrator.Option = func() migrator.Option {
 					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
 						// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
 						var isTableMigrated bool
-						if err = conn.QueryRow(ctx, `SELECT true pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r'`, metricTable).Scan(&isTableMigrated); isTableMigrated || err != nil {
+						if err = conn.QueryRow(ctx, `SELECT true FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r'`, metricTable).Scan(&isTableMigrated); isTableMigrated || err != nil {
 							return err
 						}
 
-						if _, err = tx.Exec(ctx, `ALTER TABLE ` + metricTable + ` RENAME TO ` + metricTableRenamed); err != nil {
+						if _, err = tx.Exec(ctx, `ALTER TABLE `+metricTable+` RENAME TO `+metricTableRenamed); err != nil {
 							return err
 						}
 
 						var minTime *time.Time
 						var daysToPrecreate *int32
-						if err := tx.QueryRow(ctx, `SELECT MIN(time), CEIL(EXTRACT(EPOCH FROM (MAX(time) - MIN(time))::interval) / 86400) + 1 FROM ` + metricTableRenamed).Scan(&minTime, &daysToPrecreate); err != nil {
+						if err := tx.QueryRow(ctx, `SELECT MIN(time), CEIL(EXTRACT(EPOCH FROM (MAX(time) - MIN(time))::interval) / 86400) + 1 FROM `+metricTableRenamed).Scan(&minTime, &daysToPrecreate); err != nil {
 							return err
 						}
 
@@ -660,7 +660,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 								return err
 							}
 						}
-						
+
 						return nil
 					})
 					if err != nil {
@@ -679,13 +679,13 @@ var migrations func() migrator.Option = func() migrator.Option {
 
 					for _, partInfo := range partitionsInfo {
 						err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
-							if _, err = tx.Exec(ctx, `INSERT INTO ` + metricTable + ` SELECT * FROM ` + partInfo.Rel); err != nil {
+							if _, err = tx.Exec(ctx, `INSERT INTO `+metricTable+` SELECT * FROM `+partInfo.Rel); err != nil {
 								return err
 							}
-							if _, err = tx.Exec(ctx, `ALTER TABLE ` + partInfo.ParentRel + ` DETACH PARTITION ` + partInfo.Rel); err != nil {
+							if _, err = tx.Exec(ctx, `ALTER TABLE `+partInfo.ParentRel+` DETACH PARTITION `+partInfo.Rel); err != nil {
 								return err
 							}
-							if _, err = tx.Exec(ctx, `DROP TABLE IF EXISTS ` + partInfo.Rel); err != nil {
+							if _, err = tx.Exec(ctx, `DROP TABLE IF EXISTS `+partInfo.Rel); err != nil {
 								return err
 							}
 							return nil
@@ -695,7 +695,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 						}
 					}
 
-					if _, err := conn.Exec(ctx, `DROP TABLE IF EXISTS ` + metricTableRenamed); err != nil {
+					if _, err := conn.Exec(ctx, `DROP TABLE IF EXISTS `+metricTableRenamed); err != nil {
 						return err
 					}
 				}

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -642,7 +642,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 							return err
 						}
 
-						if _, err = tx.Exec(ctx, `ALTER TABLE `+metricTable+` RENAME TO `+metricTableRenamed); err != nil {
+						if _, err := tx.Exec(ctx, `ALTER TABLE `+metricTable+` RENAME TO `+metricTableRenamed); err != nil {
 							return err
 						}
 
@@ -654,11 +654,11 @@ var migrations func() migrator.Option = func() migrator.Option {
 
 						if minTime == nil {
 							// no data in the table, just create a new empty partitioned table
-							if _, err = tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, NOW()::timestamptz, '1 day'::interval, 0)`, metricTable); err != nil {
+							if _, err := tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, NOW()::timestamptz, '1 day'::interval, 0)`, metricTable); err != nil {
 								return err
 							}
 						} else {
-							if _, err = tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`, metricTable, minTime, daysToPrecreate); err != nil {
+							if _, err := tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`, metricTable, minTime, daysToPrecreate); err != nil {
 								return err
 							}
 						}
@@ -681,13 +681,13 @@ var migrations func() migrator.Option = func() migrator.Option {
 
 					for _, partInfo := range partitionsInfo {
 						err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
-							if _, err = tx.Exec(ctx, `INSERT INTO `+metricTable+` SELECT * FROM `+partInfo.Rel); err != nil {
+							if _, err := tx.Exec(ctx, `INSERT INTO `+metricTable+` SELECT * FROM `+partInfo.Rel); err != nil {
 								return err
 							}
-							if _, err = tx.Exec(ctx, `ALTER TABLE `+partInfo.ParentRel+` DETACH PARTITION `+partInfo.Rel); err != nil {
+							if _, err := tx.Exec(ctx, `ALTER TABLE `+partInfo.ParentRel+` DETACH PARTITION `+partInfo.Rel); err != nil {
 								return err
 							}
-							if _, err = tx.Exec(ctx, `DROP TABLE IF EXISTS `+partInfo.Rel); err != nil {
+							if _, err := tx.Exec(ctx, `DROP TABLE IF EXISTS `+partInfo.Rel); err != nil {
 								return err
 							}
 							return nil

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -602,9 +602,19 @@ var migrations func() migrator.Option = func() migrator.Option {
 		&migrator.Migration{
 			Name: "01409 Switch to time-only partitioning",
 			Func: func(ctx context.Context, tx pgx.Tx) error {
-				_, err := tx.Exec(ctx, `
+				_, err := tx.Exec(ctx, `SELECT admin.drop_all_metric_tables()`)
+				if err != nil {
+					return err
+				}
+
+				_, err = tx.Exec(ctx, `
 					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;
 				`)
+				if err != nil {
+					return err
+				}
+
+				_, err = tx.Exec(ctx, sqlMetricAdminFunctions)
 				if err != nil {
 					return err
 				}

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -605,6 +605,8 @@ var migrations func() migrator.Option = func() migrator.Option {
 				// %s placeholders are filled with regclass-derived identifiers, which are already
 				// safely quoted by PostgreSQL, so fmt.Sprintf interpolation is safe here.
 				const (
+					sqlDropOldEnsurePartitionDbnameTime = `DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;`
+
 					sqlListMetricTables = `SELECT objoid::regclass 
 						FROM pg_description WHERE description = 'pgwatch-generated-metric-lvl'`
 
@@ -631,19 +633,9 @@ var migrations func() migrator.Option = func() migrator.Option {
 
 					sqlDropTableIfExists = `DROP TABLE IF EXISTS %s`
 				)
-				err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
-					if _, err := tx.Exec(ctx, `DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time`); err != nil {
-						return err
-					}
-					if _, err := tx.Exec(ctx, sqlMetricAdminFunctions); err != nil {
-						return err
-					}
-					if _, err := tx.Exec(ctx, sqlMetricEnsurePartitionPostgres); err != nil {
-						return err
-					}
-					return nil
-				})
-				if err != nil {
+				if _, err := conn.Exec(ctx, sqlDropOldEnsurePartitionDbnameTime+
+					sqlMetricAdminFunctions+
+					sqlMetricEnsurePartitionPostgres); err != nil {
 					return err
 				}
 

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -70,8 +70,7 @@ type PostgresWriter struct {
 	input                    chan metrics.MeasurementEnvelope
 	lastError                chan error
 	forceRecreatePartitions  bool                                        // to signal override PG metrics storage cache
-	partitionMapMetric       map[string]ExistingPartitionInfo            // metric = min/max bounds
-	partitionMapMetricDbname map[string]map[string]ExistingPartitionInfo // metric[dbname = min/max bounds]
+	partitionMapMetric 		 map[string]ExistingPartitionInfo // metric = min/max bounds
 }
 
 // make sure *dbMetricReaderWriter implements the Migrator interface
@@ -97,8 +96,7 @@ func NewWriterFromPostgresConn(ctx context.Context, conn db.PgxPoolIface, opts *
 		lastError:                make(chan error),
 		sinkDb:                   conn,
 		forceRecreatePartitions:  false,
-		partitionMapMetric:       make(map[string]ExistingPartitionInfo),
-		partitionMapMetricDbname: make(map[string]map[string]ExistingPartitionInfo),
+		partitionMapMetric: 	  make(map[string]ExistingPartitionInfo),
 	}
 	l.Info("initialising measurements database...")
 	if err = pgw.init(); err != nil {
@@ -364,8 +362,7 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 		return
 	}
 	logger := log.GetLogger(pgw.ctx)
-	pgPartBounds := make(map[string]ExistingPartitionInfo)                  // metric=min/max
-	pgPartBoundsDbName := make(map[string]map[string]ExistingPartitionInfo) // metric=[dbname=min/max]
+	pgPartBounds := make(map[string]ExistingPartitionInfo) // metric=min/max
 	var err error
 
 	slices.SortFunc(msgs, func(a, b metrics.MeasurementEnvelope) int {
@@ -380,41 +377,21 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 	for _, msg := range msgs {
 		for _, dataRow := range msg.Data {
 			epochTime := time.Unix(0, metrics.Measurement(dataRow).GetEpoch())
-			switch pgw.metricSchema {
-			case DbStorageSchemaTimescale:
-				// set min/max timestamps to check/create partitions
-				bounds, ok := pgPartBounds[msg.MetricName]
-				if !ok || (ok && epochTime.Before(bounds.StartTime)) {
-					bounds.StartTime = epochTime
-					pgPartBounds[msg.MetricName] = bounds
-				}
-				if !ok || (ok && epochTime.After(bounds.EndTime)) {
-					bounds.EndTime = epochTime
-					pgPartBounds[msg.MetricName] = bounds
-				}
-			case DbStorageSchemaPostgres:
-				_, ok := pgPartBoundsDbName[msg.MetricName]
-				if !ok {
-					pgPartBoundsDbName[msg.MetricName] = make(map[string]ExistingPartitionInfo)
-				}
-				bounds, ok := pgPartBoundsDbName[msg.MetricName][msg.DBName]
-				if !ok || (ok && epochTime.Before(bounds.StartTime)) {
-					bounds.StartTime = epochTime
-					pgPartBoundsDbName[msg.MetricName][msg.DBName] = bounds
-				}
-				if !ok || (ok && epochTime.After(bounds.EndTime)) {
-					bounds.EndTime = epochTime
-					pgPartBoundsDbName[msg.MetricName][msg.DBName] = bounds
-				}
-			default:
-				logger.Fatal("unknown storage schema...")
+			bounds, ok := pgPartBounds[msg.MetricName]
+			if !ok || (ok && epochTime.Before(bounds.StartTime)) {
+				bounds.StartTime = epochTime
+				pgPartBounds[msg.MetricName] = bounds
+			}
+			if !ok || (ok && epochTime.After(bounds.EndTime)) {
+				bounds.EndTime = epochTime
+				pgPartBounds[msg.MetricName] = bounds
 			}
 		}
 	}
 
 	switch pgw.metricSchema {
 	case DbStorageSchemaPostgres:
-		err = pgw.EnsureMetricDbnameTime(pgPartBoundsDbName)
+		err = pgw.EnsureMetricTimePartsExist(pgPartBounds)
 	case DbStorageSchemaTimescale:
 		err = pgw.EnsureMetricTimescale(pgPartBounds)
 	default:
@@ -470,38 +447,23 @@ func (pgw *PostgresWriter) EnsureMetricTimescale(pgPartBounds map[string]Existin
 	return
 }
 
-func (pgw *PostgresWriter) EnsureMetricDbnameTime(metricDbnamePartBounds map[string]map[string]ExistingPartitionInfo) (err error) {
+func (pgw *PostgresWriter) EnsureMetricTimePartsExist(metricPartBounds map[string]ExistingPartitionInfo) (error) {
+	var err error
 	var rows pgx.Rows
-	sqlEnsure := `select * from admin.ensure_partition_metric_dbname_time($1, $2, $3, $4)`
-	for metric, dbnameTimestampMap := range metricDbnamePartBounds {
-		_, ok := pgw.partitionMapMetricDbname[metric]
-		if !ok {
-			pgw.partitionMapMetricDbname[metric] = make(map[string]ExistingPartitionInfo)
+	sqlEnsure := `select * from admin.ensure_partition_metric_time($1, $2, $3)`
+	for metric, pb := range metricPartBounds {
+		if pb.StartTime.IsZero() || pb.EndTime.IsZero() {
+			return fmt.Errorf("zero StartTime/EndTime in partitioning request: [%s:%v]", metric, pb)
 		}
-
-		for dbname, pb := range dbnameTimestampMap {
-			if pb.StartTime.IsZero() || pb.EndTime.IsZero() {
-				return fmt.Errorf("zero StartTime/EndTime in partitioning request: [%s:%v]", metric, pb)
+		partInfo, ok := pgw.partitionMapMetric[metric]
+		if !ok || pb.EndTime.After(partInfo.EndTime) || pb.EndTime.Equal(partInfo.EndTime) || pgw.forceRecreatePartitions {
+			if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, pb.EndTime, pgw.opts.PartitionInterval); err != nil {
+				return err
 			}
-			partInfo, ok := pgw.partitionMapMetricDbname[metric][dbname]
-			if !ok || (ok && (pb.StartTime.Before(partInfo.StartTime))) || pgw.forceRecreatePartitions {
-				if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, dbname, pb.StartTime, pgw.opts.PartitionInterval); err != nil {
-					return
-				}
-				if partInfo, err = pgx.CollectOneRow(rows, pgx.RowToStructByPos[ExistingPartitionInfo]); err != nil {
-					return err
-				}
-				pgw.partitionMapMetricDbname[metric][dbname] = partInfo
+			if partInfo, err = pgx.CollectOneRow(rows, pgx.RowToStructByPos[ExistingPartitionInfo]); err != nil {
+				return err
 			}
-			if pb.EndTime.After(partInfo.EndTime) || pb.EndTime.Equal(partInfo.EndTime) || pgw.forceRecreatePartitions {
-				if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, dbname, pb.EndTime, pgw.opts.PartitionInterval); err != nil {
-					return
-				}
-				if partInfo, err = pgx.CollectOneRow(rows, pgx.RowToStructByPos[ExistingPartitionInfo]); err != nil {
-					return err
-				}
-				pgw.partitionMapMetricDbname[metric][dbname] = partInfo
-			}
+			pgw.partitionMapMetric[metric] = partInfo
 		}
 	}
 	return nil

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -636,7 +636,9 @@ var migrations func() migrator.Option = func() migrator.Option {
 					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
 						// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
 						var isTableMigrated bool
-						if err = conn.QueryRow(ctx, `SELECT true FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r'`, metricTable).Scan(&isTableMigrated); isTableMigrated || err != nil {
+						if err := tx.QueryRow(ctx, `SELECT EXISTS (
+						SELECT 1 FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r')`,
+							metricTable).Scan(&isTableMigrated); isTableMigrated || err != nil {
 							return err
 						}
 

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -564,7 +564,7 @@ func (pgw *PostgresWriter) NeedsMigration() (bool, error) {
 }
 
 // MigrationsCount is the total number of migrations in admin.migration table
-const MigrationsCount = 1
+const MigrationsCount = 3
 
 // migrations holds function returning all upgrade migrations needed
 var migrations func() migrator.Option = func() migrator.Option {

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -593,6 +593,21 @@ var migrations func() migrator.Option = func() migrator.Option {
 			},
 		},
 
+		&migrator.Migration{
+			Name: "01409 Apply postgres sink partitioning scheme migrations",
+			Func: func(ctx context.Context, tx pgx.Tx) error {
+				_, err := tx.Exec(ctx, `
+					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;
+				`)
+				if err != nil {
+					return err
+				}
+
+				_, err = tx.Exec(ctx, sqlMetricEnsurePartitionPostgres)
+				return err
+			},
+		},
+
 		// adding new migration here, update "admin"."migration" in "admin_schema.sql"!
 
 		// &migrator.Migration{

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -599,28 +599,108 @@ var migrations func() migrator.Option = func() migrator.Option {
 			},
 		},
 
-		&migrator.Migration{
+		&migrator.MigrationNoTx{
 			Name: "01409 Switch to time-only partitioning",
-			Func: func(ctx context.Context, tx pgx.Tx) error {
-				_, err := tx.Exec(ctx, `SELECT admin.drop_all_metric_tables()`)
+			Func: func(ctx context.Context, conn migrator.PgxIface) error {
+				err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
+					if _, err := tx.Exec(ctx, `DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time`); err != nil {
+						return err
+					}
+					if _, err := tx.Exec(ctx, sqlMetricAdminFunctions); err != nil {
+						return err
+					}
+					if _, err := tx.Exec(ctx, sqlMetricEnsurePartitionPostgres); err != nil {
+						return err
+					}
+					return nil
+				})
 				if err != nil {
 					return err
 				}
 
-				_, err = tx.Exec(ctx, `
-					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;
-				`)
+				rows, _ := conn.Query(ctx, `SELECT objoid::regclass FROM pg_description WHERE description = 'pgwatch-generated-metric-lvl'`)
+				metricTables, err := pgx.CollectRows(rows, pgx.RowTo[string])
 				if err != nil {
 					return err
 				}
 
-				_, err = tx.Exec(ctx, sqlMetricAdminFunctions)
-				if err != nil {
-					return err
+				for _, metricTable := range metricTables {
+					// skip *_before_v6_migration tables to avoid double migration
+					// this could happen if the migration is re-run after a failed attempt
+					suffix := "_before_v6_migration"
+					if strings.HasSuffix(metricTable, suffix) {
+						continue
+					}
+					metricTableRenamed := metricTable + suffix
+
+					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
+						// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
+						var isTableMigrated bool
+						if err = conn.QueryRow(ctx, `SELECT true pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r'`, metricTable).Scan(&isTableMigrated); isTableMigrated || err != nil {
+							return err
+						}
+
+						if _, err = tx.Exec(ctx, `ALTER TABLE ` + metricTable + ` RENAME TO ` + metricTableRenamed); err != nil {
+							return err
+						}
+
+						var minTime *time.Time
+						var daysToPrecreate *int32
+						if err := tx.QueryRow(ctx, `SELECT MIN(time), CEIL(EXTRACT(EPOCH FROM (MAX(time) - MIN(time))::interval) / 86400) + 1 FROM ` + metricTableRenamed).Scan(&minTime, &daysToPrecreate); err != nil {
+							return err
+						}
+
+						if minTime == nil {
+							// no data in the table, just create a new empty partitioned table
+							if _, err = tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, NOW()::timestamptz, '1 day'::interval, 0)`, metricTable); err != nil {
+								return err
+							}
+						} else {
+							if _, err = tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`, metricTable, minTime, daysToPrecreate); err != nil {
+								return err
+							}
+						}
+						
+						return nil
+					})
+					if err != nil {
+						return err
+					}
+
+					type partitionInfo struct {
+						Rel       string
+						ParentRel string
+					}
+					rows, _ := conn.Query(ctx, `SELECT relid::regclass, parentrelid::regclass FROM pg_partition_tree($1::regclass) WHERE relid::text like 'subpartitions%' ORDER BY isleaf DESC, relid::text`, metricTableRenamed)
+					partitionsInfo, err := pgx.CollectRows(rows, pgx.RowToStructByPos[partitionInfo])
+					if err != nil {
+						return err
+					}
+
+					for _, partInfo := range partitionsInfo {
+						err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
+							if _, err = tx.Exec(ctx, `INSERT INTO ` + metricTable + ` SELECT * FROM ` + partInfo.Rel); err != nil {
+								return err
+							}
+							if _, err = tx.Exec(ctx, `ALTER TABLE ` + partInfo.ParentRel + ` DETACH PARTITION ` + partInfo.Rel); err != nil {
+								return err
+							}
+							if _, err = tx.Exec(ctx, `DROP TABLE IF EXISTS ` + partInfo.Rel); err != nil {
+								return err
+							}
+							return nil
+						})
+						if err != nil {
+							return err
+						}
+					}
+
+					if _, err := conn.Exec(ctx, `DROP TABLE IF EXISTS ` + metricTableRenamed); err != nil {
+						return err
+					}
 				}
 
-				_, err = tx.Exec(ctx, sqlMetricEnsurePartitionPostgres)
-				return err
+				return nil
 			},
 		},
 

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -594,7 +594,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 		},
 
 		&migrator.Migration{
-			Name: "01409 Apply postgres sink partitioning scheme migrations",
+			Name: "01409 Switch to time-only partitioning",
 			Func: func(ctx context.Context, tx pgx.Tx) error {
 				_, err := tx.Exec(ctx, `
 					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -633,38 +633,32 @@ var migrations func() migrator.Option = func() migrator.Option {
 					}
 					metricTableRenamed := metricTable + suffix
 
-					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
+					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) (ferr error) {
 						// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
 						var isTableMigrated bool
-						if err := tx.QueryRow(ctx, `SELECT EXISTS (
+						if ferr = tx.QueryRow(ctx, `SELECT EXISTS (
 						SELECT 1 FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r')`,
-							metricTable).Scan(&isTableMigrated); isTableMigrated || err != nil {
-							return err
+							metricTable).Scan(&isTableMigrated); isTableMigrated || ferr != nil {
+							return
 						}
 
-						if _, err := tx.Exec(ctx, `ALTER TABLE `+metricTable+` RENAME TO `+metricTableRenamed); err != nil {
-							return err
+						if _, ferr = tx.Exec(ctx, `ALTER TABLE `+metricTable+` RENAME TO `+metricTableRenamed); ferr != nil {
+							return
 						}
 
-						var minTime *time.Time
-						var daysToPrecreate *int32
-						if err := tx.QueryRow(ctx, `SELECT MIN(time), CEIL(EXTRACT(EPOCH FROM (MAX(time) - MIN(time))::interval) / 86400) + 1 FROM `+metricTableRenamed).Scan(&minTime, &daysToPrecreate); err != nil {
-							return err
+						// for an empty table MIN(time) is NULL, so COALESCE falls back to server-side
+						// NOW() and daysToPrecreate becomes 0, creating a single empty partition
+						var minTime time.Time
+						var daysToPrecreate int32
+						if ferr = tx.QueryRow(ctx, `SELECT 
+						COALESCE(MIN(time), NOW()),
+						COALESCE(CEIL(EXTRACT(EPOCH FROM (MAX(time) - MIN(time))::interval) / 86400) + 1, 0)
+						FROM `+metricTableRenamed).Scan(&minTime, &daysToPrecreate); ferr == nil {
+							_, ferr = tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`, metricTable, minTime, daysToPrecreate)
 						}
-
-						if minTime == nil {
-							// no data in the table, just create a new empty partitioned table
-							if _, err := tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, NOW()::timestamptz, '1 day'::interval, 0)`, metricTable); err != nil {
-								return err
-							}
-						} else {
-							if _, err := tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`, metricTable, minTime, daysToPrecreate); err != nil {
-								return err
-							}
-						}
-
-						return nil
+						return
 					})
+
 					if err != nil {
 						return err
 					}

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -674,19 +674,12 @@ var migrations func() migrator.Option = func() migrator.Option {
 					}
 
 					for _, partInfo := range partitionsInfo {
-						err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
-							if _, err := tx.Exec(ctx, `INSERT INTO `+metricTable+` (time, dbname, data, tag_data) SELECT time, dbname, data, tag_data FROM `+partInfo.Rel); err != nil {
-								return err
-							}
-							if _, err := tx.Exec(ctx, `ALTER TABLE `+partInfo.ParentRel+` DETACH PARTITION `+partInfo.Rel); err != nil {
-								return err
-							}
-							if _, err := tx.Exec(ctx, `DROP TABLE IF EXISTS `+partInfo.Rel); err != nil {
-								return err
-							}
-							return nil
-						})
-						if err != nil {
+						// multiple statements in a single Exec run in an implicit transaction
+						if _, err := conn.Exec(ctx,
+							`INSERT INTO `+metricTable+` (time, dbname, data, tag_data) SELECT time, dbname, data, tag_data FROM `+partInfo.Rel+`;
+							ALTER TABLE `+partInfo.ParentRel+` DETACH PARTITION `+partInfo.Rel+`;
+							DROP TABLE `+partInfo.Rel+`;`,
+						); err != nil {
 							return err
 						}
 					}

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -599,6 +599,21 @@ var migrations func() migrator.Option = func() migrator.Option {
 			},
 		},
 
+		&migrator.Migration{
+			Name: "01409 Apply postgres sink partitioning scheme migrations",
+			Func: func(ctx context.Context, tx pgx.Tx) error {
+				_, err := tx.Exec(ctx, `
+					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;
+				`)
+				if err != nil {
+					return err
+				}
+
+				_, err = tx.Exec(ctx, sqlMetricEnsurePartitionPostgres)
+				return err
+			},
+		},
+
 		// adding new migration here, update "admin"."migration" in "admin_schema.sql"!
 
 		// &migrator.Migration{

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -681,7 +681,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 
 					for _, partInfo := range partitionsInfo {
 						err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
-							if _, err := tx.Exec(ctx, `INSERT INTO `+metricTable+` SELECT * FROM `+partInfo.Rel); err != nil {
+							if _, err := tx.Exec(ctx, `INSERT INTO `+metricTable+` (time, dbname, data, tag_data) SELECT time, dbname, data, tag_data FROM `+partInfo.Rel); err != nil {
 								return err
 							}
 							if _, err := tx.Exec(ctx, `ALTER TABLE `+partInfo.ParentRel+` DETACH PARTITION `+partInfo.Rel); err != nil {

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -624,10 +624,10 @@ var migrations func() migrator.Option = func() migrator.Option {
 					return err
 				}
 
+				// skip *_before_v6_migration tables to avoid double migration
+				// this could happen if the migration is re-run after a failed attempt
+				const suffix = "_before_v6_migration"
 				for _, metricTable := range metricTables {
-					// skip *_before_v6_migration tables to avoid double migration
-					// this could happen if the migration is re-run after a failed attempt
-					suffix := "_before_v6_migration"
 					if strings.HasSuffix(metricTable, suffix) {
 						continue
 					}

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -70,8 +70,7 @@ type PostgresWriter struct {
 	input                    chan metrics.MeasurementEnvelope
 	lastError                chan error
 	forceRecreatePartitions  bool                                        // to signal override PG metrics storage cache
-	partitionMapMetric       map[string]ExistingPartitionInfo            // metric = min/max bounds
-	partitionMapMetricDbname map[string]map[string]ExistingPartitionInfo // metric[dbname = min/max bounds]
+	partitionMapMetric 		 map[string]ExistingPartitionInfo // metric = min/max bounds
 }
 
 // make sure *dbMetricReaderWriter implements the Migrator interface
@@ -97,8 +96,7 @@ func NewWriterFromPostgresConn(ctx context.Context, conn db.PgxPoolIface, opts *
 		lastError:                make(chan error),
 		sinkDb:                   conn,
 		forceRecreatePartitions:  false,
-		partitionMapMetric:       make(map[string]ExistingPartitionInfo),
-		partitionMapMetricDbname: make(map[string]map[string]ExistingPartitionInfo),
+		partitionMapMetric: 	  make(map[string]ExistingPartitionInfo),
 	}
 	l.Info("initialising measurements database...")
 	if err = pgw.init(); err != nil {
@@ -366,8 +364,7 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 		return
 	}
 	logger := log.GetLogger(pgw.ctx)
-	pgPartBounds := make(map[string]ExistingPartitionInfo)                  // metric=min/max
-	pgPartBoundsDbName := make(map[string]map[string]ExistingPartitionInfo) // metric=[dbname=min/max]
+	pgPartBounds := make(map[string]ExistingPartitionInfo) // metric=min/max
 	var err error
 
 	slices.SortFunc(msgs, func(a, b metrics.MeasurementEnvelope) int {
@@ -382,41 +379,21 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 	for _, msg := range msgs {
 		for _, dataRow := range msg.Data {
 			epochTime := time.Unix(0, metrics.Measurement(dataRow).GetEpoch())
-			switch pgw.metricSchema {
-			case DbStorageSchemaTimescale:
-				// set min/max timestamps to check/create partitions
-				bounds, ok := pgPartBounds[msg.MetricName]
-				if !ok || (ok && epochTime.Before(bounds.StartTime)) {
-					bounds.StartTime = epochTime
-					pgPartBounds[msg.MetricName] = bounds
-				}
-				if !ok || (ok && epochTime.After(bounds.EndTime)) {
-					bounds.EndTime = epochTime
-					pgPartBounds[msg.MetricName] = bounds
-				}
-			case DbStorageSchemaPostgres:
-				_, ok := pgPartBoundsDbName[msg.MetricName]
-				if !ok {
-					pgPartBoundsDbName[msg.MetricName] = make(map[string]ExistingPartitionInfo)
-				}
-				bounds, ok := pgPartBoundsDbName[msg.MetricName][msg.DBName]
-				if !ok || (ok && epochTime.Before(bounds.StartTime)) {
-					bounds.StartTime = epochTime
-					pgPartBoundsDbName[msg.MetricName][msg.DBName] = bounds
-				}
-				if !ok || (ok && epochTime.After(bounds.EndTime)) {
-					bounds.EndTime = epochTime
-					pgPartBoundsDbName[msg.MetricName][msg.DBName] = bounds
-				}
-			default:
-				logger.Fatal("unknown storage schema...")
+			bounds, ok := pgPartBounds[msg.MetricName]
+			if !ok || (ok && epochTime.Before(bounds.StartTime)) {
+				bounds.StartTime = epochTime
+				pgPartBounds[msg.MetricName] = bounds
+			}
+			if !ok || (ok && epochTime.After(bounds.EndTime)) {
+				bounds.EndTime = epochTime
+				pgPartBounds[msg.MetricName] = bounds
 			}
 		}
 	}
 
 	switch pgw.metricSchema {
 	case DbStorageSchemaPostgres:
-		err = pgw.EnsureMetricDbnameTime(pgPartBoundsDbName)
+		err = pgw.EnsureMetricTimePartsExist(pgPartBounds)
 	case DbStorageSchemaTimescale:
 		err = pgw.EnsureMetricTimescale(pgPartBounds)
 	default:
@@ -476,38 +453,23 @@ func (pgw *PostgresWriter) EnsureMetricTimescale(pgPartBounds map[string]Existin
 	return
 }
 
-func (pgw *PostgresWriter) EnsureMetricDbnameTime(metricDbnamePartBounds map[string]map[string]ExistingPartitionInfo) (err error) {
+func (pgw *PostgresWriter) EnsureMetricTimePartsExist(metricPartBounds map[string]ExistingPartitionInfo) (error) {
+	var err error
 	var rows pgx.Rows
-	sqlEnsure := `select * from admin.ensure_partition_metric_dbname_time($1, $2, $3, $4)`
-	for metric, dbnameTimestampMap := range metricDbnamePartBounds {
-		_, ok := pgw.partitionMapMetricDbname[metric]
-		if !ok {
-			pgw.partitionMapMetricDbname[metric] = make(map[string]ExistingPartitionInfo)
+	sqlEnsure := `select * from admin.ensure_partition_metric_time($1, $2, $3)`
+	for metric, pb := range metricPartBounds {
+		if pb.StartTime.IsZero() || pb.EndTime.IsZero() {
+			return fmt.Errorf("zero StartTime/EndTime in partitioning request: [%s:%v]", metric, pb)
 		}
-
-		for dbname, pb := range dbnameTimestampMap {
-			if pb.StartTime.IsZero() || pb.EndTime.IsZero() {
-				return fmt.Errorf("zero StartTime/EndTime in partitioning request: [%s:%v]", metric, pb)
+		partInfo, ok := pgw.partitionMapMetric[metric]
+		if !ok || pb.EndTime.After(partInfo.EndTime) || pb.EndTime.Equal(partInfo.EndTime) || pgw.forceRecreatePartitions {
+			if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, pb.EndTime, pgw.opts.PartitionInterval); err != nil {
+				return err
 			}
-			partInfo, ok := pgw.partitionMapMetricDbname[metric][dbname]
-			if !ok || (ok && (pb.StartTime.Before(partInfo.StartTime))) || pgw.forceRecreatePartitions {
-				if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, dbname, pb.StartTime, pgw.opts.PartitionInterval); err != nil {
-					return
-				}
-				if partInfo, err = pgx.CollectOneRow(rows, pgx.RowToStructByPos[ExistingPartitionInfo]); err != nil {
-					return err
-				}
-				pgw.partitionMapMetricDbname[metric][dbname] = partInfo
+			if partInfo, err = pgx.CollectOneRow(rows, pgx.RowToStructByPos[ExistingPartitionInfo]); err != nil {
+				return err
 			}
-			if pb.EndTime.After(partInfo.EndTime) || pb.EndTime.Equal(partInfo.EndTime) || pgw.forceRecreatePartitions {
-				if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, dbname, pb.EndTime, pgw.opts.PartitionInterval); err != nil {
-					return
-				}
-				if partInfo, err = pgx.CollectOneRow(rows, pgx.RowToStructByPos[ExistingPartitionInfo]); err != nil {
-					return err
-				}
-				pgw.partitionMapMetricDbname[metric][dbname] = partInfo
-			}
+			pgw.partitionMapMetric[metric] = partInfo
 		}
 	}
 	return nil

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -600,7 +600,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 		},
 
 		&migrator.Migration{
-			Name: "01409 Apply postgres sink partitioning scheme migrations",
+			Name: "01409 Switch to time-only partitioning",
 			Func: func(ctx context.Context, tx pgx.Tx) error {
 				_, err := tx.Exec(ctx, `
 					DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -602,6 +602,35 @@ var migrations func() migrator.Option = func() migrator.Option {
 		&migrator.MigrationNoTx{
 			Name: "01409 Switch to time-only partitioning",
 			Func: func(ctx context.Context, conn migrator.PgxIface) error {
+				// %s placeholders are filled with regclass-derived identifiers, which are already
+				// safely quoted by PostgreSQL, so fmt.Sprintf interpolation is safe here.
+				const (
+					sqlListMetricTables = `SELECT objoid::regclass 
+						FROM pg_description WHERE description = 'pgwatch-generated-metric-lvl'`
+
+					sqlIsTableMigrated = `SELECT EXISTS (
+						SELECT 1 FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r')`
+
+					sqlRenameMetricTable = `ALTER TABLE %s RENAME TO %s`
+
+					sqlMetricTableBounds = `SELECT COALESCE(MIN(time), NOW()),
+						COALESCE(CEIL(EXTRACT(EPOCH FROM (MAX(time) - MIN(time))::interval) / 86400) + 1, 0)
+						FROM %s`
+
+					sqlEnsurePartitionMetricTime = `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`
+
+					sqlListSubpartitions = `SELECT relid::regclass, parentrelid::regclass 
+						FROM pg_partition_tree($1::regclass) WHERE relid::text LIKE 'subpartitions%' 
+						ORDER BY isleaf DESC, relid::text`
+
+					// moves rows into the new partitioned parent, detaches and drops the old subpartition;
+					// multiple statements in a single Exec run in an implicit transaction
+					sqlMoveSubpartition = `INSERT INTO %[1]s (time, dbname, data, tag_data) SELECT time, dbname, data, tag_data FROM %[2]s;
+						ALTER TABLE %[3]s DETACH PARTITION %[2]s;
+						DROP TABLE %[2]s;`
+
+					sqlDropTableIfExists = `DROP TABLE IF EXISTS %s`
+				)
 				err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
 					if _, err := tx.Exec(ctx, `DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time`); err != nil {
 						return err
@@ -618,7 +647,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 					return err
 				}
 
-				rows, _ := conn.Query(ctx, `SELECT objoid::regclass FROM pg_description WHERE description = 'pgwatch-generated-metric-lvl'`)
+				rows, _ := conn.Query(ctx, sqlListMetricTables)
 				metricTables, err := pgx.CollectRows(rows, pgx.RowTo[string])
 				if err != nil {
 					return err
@@ -636,13 +665,11 @@ var migrations func() migrator.Option = func() migrator.Option {
 					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) (ferr error) {
 						// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
 						var isTableMigrated bool
-						if ferr = tx.QueryRow(ctx, `SELECT EXISTS (
-						SELECT 1 FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r')`,
-							metricTable).Scan(&isTableMigrated); isTableMigrated || ferr != nil {
+						if ferr = tx.QueryRow(ctx, sqlIsTableMigrated, metricTable).Scan(&isTableMigrated); isTableMigrated || ferr != nil {
 							return
 						}
 
-						if _, ferr = tx.Exec(ctx, `ALTER TABLE `+metricTable+` RENAME TO `+metricTableRenamed); ferr != nil {
+						if _, ferr = tx.Exec(ctx, fmt.Sprintf(sqlRenameMetricTable, metricTable, metricTableRenamed)); ferr != nil {
 							return
 						}
 
@@ -650,11 +677,8 @@ var migrations func() migrator.Option = func() migrator.Option {
 						// NOW() and daysToPrecreate becomes 0, creating a single empty partition
 						var minTime time.Time
 						var daysToPrecreate int32
-						if ferr = tx.QueryRow(ctx, `SELECT 
-						COALESCE(MIN(time), NOW()),
-						COALESCE(CEIL(EXTRACT(EPOCH FROM (MAX(time) - MIN(time))::interval) / 86400) + 1, 0)
-						FROM `+metricTableRenamed).Scan(&minTime, &daysToPrecreate); ferr == nil {
-							_, ferr = tx.Exec(ctx, `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`, metricTable, minTime, daysToPrecreate)
+						if ferr = tx.QueryRow(ctx, fmt.Sprintf(sqlMetricTableBounds, metricTableRenamed)).Scan(&minTime, &daysToPrecreate); ferr == nil {
+							_, ferr = tx.Exec(ctx, sqlEnsurePartitionMetricTime, metricTable, minTime, daysToPrecreate)
 						}
 						return
 					})
@@ -667,24 +691,19 @@ var migrations func() migrator.Option = func() migrator.Option {
 						Rel       string
 						ParentRel string
 					}
-					rows, _ := conn.Query(ctx, `SELECT relid::regclass, parentrelid::regclass FROM pg_partition_tree($1::regclass) WHERE relid::text like 'subpartitions%' ORDER BY isleaf DESC, relid::text`, metricTableRenamed)
+					rows, _ := conn.Query(ctx, sqlListSubpartitions, metricTableRenamed)
 					partitionsInfo, err := pgx.CollectRows(rows, pgx.RowToStructByPos[partitionInfo])
 					if err != nil {
 						return err
 					}
 
 					for _, partInfo := range partitionsInfo {
-						// multiple statements in a single Exec run in an implicit transaction
-						if _, err := conn.Exec(ctx,
-							`INSERT INTO `+metricTable+` (time, dbname, data, tag_data) SELECT time, dbname, data, tag_data FROM `+partInfo.Rel+`;
-							ALTER TABLE `+partInfo.ParentRel+` DETACH PARTITION `+partInfo.Rel+`;
-							DROP TABLE `+partInfo.Rel+`;`,
-						); err != nil {
+						if _, err := conn.Exec(ctx, fmt.Sprintf(sqlMoveSubpartition, metricTable, partInfo.Rel, partInfo.ParentRel)); err != nil {
 							return err
 						}
 					}
 
-					if _, err := conn.Exec(ctx, `DROP TABLE IF EXISTS `+metricTableRenamed); err != nil {
+					if _, err := conn.Exec(ctx, fmt.Sprintf(sqlDropTableIfExists, metricTableRenamed)); err != nil {
 						return err
 					}
 				}

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -602,13 +602,13 @@ var migrations func() migrator.Option = func() migrator.Option {
 		&migrator.MigrationNoTx{
 			Name: "01409 Switch to time-only partitioning",
 			Func: func(ctx context.Context, conn migrator.PgxIface) error {
-				// %s placeholders are filled with regclass-derived identifiers, which are already
-				// safely quoted by PostgreSQL, so fmt.Sprintf interpolation is safe here.
 				const (
 					sqlDropOldEnsurePartitionDbnameTime = `DROP FUNCTION IF EXISTS admin.ensure_partition_metric_dbname_time;`
 
-					sqlListMetricTables = `SELECT objoid::regclass 
-						FROM pg_description WHERE description = 'pgwatch-generated-metric-lvl'`
+					sqlListMetricTables = `SELECT c.relname
+						FROM pg_description d
+						JOIN pg_class c ON c.oid = d.objoid
+						WHERE d.description = 'pgwatch-generated-metric-lvl'`
 
 					sqlIsTableMigrated = `SELECT EXISTS (
 						SELECT 1 FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r')`
@@ -622,7 +622,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 					sqlEnsurePartitionMetricTime = `SELECT admin.ensure_partition_metric_time($1::text, $2::timestamptz, '1 day'::interval, $3)`
 
 					sqlListSubpartitions = `SELECT relid::regclass, parentrelid::regclass 
-						FROM pg_partition_tree($1::regclass) WHERE relid::text LIKE 'subpartitions%' 
+						FROM pg_partition_tree(to_regclass($1)) WHERE relid::text LIKE 'subpartitions%' 
 						ORDER BY isleaf DESC, relid::text`
 
 					// moves rows into the new partitioned parent, detaches and drops the old subpartition;
@@ -648,16 +648,19 @@ var migrations func() migrator.Option = func() migrator.Option {
 				// skip *_before_v6_migration tables to avoid double migration
 				// this could happen if the migration is re-run after a failed attempt
 				const suffix = "_before_v6_migration"
-				for _, metricTable := range metricTables {
-					if strings.HasSuffix(metricTable, suffix) {
+				for _, metricTableRawName := range metricTables {
+					if strings.HasSuffix(metricTableRawName, suffix) {
 						continue
 					}
-					metricTableRenamed := metricTable + suffix
+
+					metricTableRawRename := metricTableRawName + suffix
+					metricTableRenamed := pgx.Identifier{metricTableRawRename}.Sanitize()
+					metricTable := pgx.Identifier{metricTableRawName}.Sanitize()
 
 					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) (ferr error) {
 						// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
 						var isTableMigrated bool
-						if ferr = tx.QueryRow(ctx, sqlIsTableMigrated, metricTable).Scan(&isTableMigrated); isTableMigrated || ferr != nil {
+						if ferr = tx.QueryRow(ctx, sqlIsTableMigrated, metricTableRawName).Scan(&isTableMigrated); isTableMigrated || ferr != nil {
 							return
 						}
 
@@ -670,7 +673,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 						var minTime time.Time
 						var daysToPrecreate int32
 						if ferr = tx.QueryRow(ctx, fmt.Sprintf(sqlMetricTableBounds, metricTableRenamed)).Scan(&minTime, &daysToPrecreate); ferr == nil {
-							_, ferr = tx.Exec(ctx, sqlEnsurePartitionMetricTime, metricTable, minTime, daysToPrecreate)
+							_, ferr = tx.Exec(ctx, sqlEnsurePartitionMetricTime, metricTableRawName, minTime, daysToPrecreate)
 						}
 						return
 					})
@@ -683,7 +686,7 @@ var migrations func() migrator.Option = func() migrator.Option {
 						Rel       string
 						ParentRel string
 					}
-					rows, _ := conn.Query(ctx, sqlListSubpartitions, metricTableRenamed)
+					rows, _ := conn.Query(ctx, sqlListSubpartitions, metricTableRawRename)
 					partitionsInfo, err := pgx.CollectRows(rows, pgx.RowToStructByPos[partitionInfo])
 					if err != nil {
 						return err

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -657,13 +657,15 @@ var migrations func() migrator.Option = func() migrator.Option {
 					metricTableRenamed := pgx.Identifier{metricTableRawRename}.Sanitize()
 					metricTable := pgx.Identifier{metricTableRawName}.Sanitize()
 
-					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) (ferr error) {
-						// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
-						var isTableMigrated bool
-						if ferr = tx.QueryRow(ctx, sqlIsTableMigrated, metricTableRawName).Scan(&isTableMigrated); isTableMigrated || ferr != nil {
-							return
-						}
+					// check if the table is already migrated to avoid errors on re-run after a failed migration attempt
+					var isTableMigrated bool
+					if err = conn.QueryRow(ctx, sqlIsTableMigrated, metricTableRawName).Scan(&isTableMigrated); err != nil {
+						return err
+					} else if isTableMigrated {
+						continue
+					}
 
+					err = pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) (ferr error) {
 						if _, ferr = tx.Exec(ctx, fmt.Sprintf(sqlRenameMetricTable, metricTable, metricTableRenamed)); ferr != nil {
 							return
 						}

--- a/internal/sinks/postgres_migration_test.go
+++ b/internal/sinks/postgres_migration_test.go
@@ -1,0 +1,215 @@
+package sinks
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/cybertec-postgresql/pgwatch/v5/internal/testutil"
+	migrator "github.com/cybertec-postgresql/pgx-migrator"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigrationsCountInvariant is a fast, dependency-free unit test that guards against the
+// "stale MigrationsCount" class of bug. It asserts that MigrationsCount matches:
+//   - the number of migrations actually registered in migrations(), and
+//   - the number of rows seeded into admin.migration in admin_schema.sql.
+//
+// Whenever a migration is added, all three must be bumped together, so this test fails loudly
+// if any of them drifts out of sync.
+func TestMigrationsCountInvariant(t *testing.T) {
+	a := assert.New(t)
+
+	// 1. Count migrations actually registered in migrations().
+	m, err := migrator.New(migrations())
+	require.NoError(t, err)
+	registered := m.Count()
+	a.Equal(MigrationsCount, registered,
+		"MigrationsCount (%d) must equal the number of migrations registered in migrations() (%d)",
+		MigrationsCount, registered)
+
+	// 2. Count rows seeded into admin.migration in admin_schema.sql. The seed looks like:
+	//     INSERT INTO admin.migration (id, version) VALUES
+	//         (0, '...'),
+	//         (1, '...'),
+	//         (2, '...');
+	seeded := len(regexp.MustCompile(`(?m)^\s*\(\d+,\s*'`).FindAllString(sqlMetricAdminSchema, -1))
+	a.Equal(MigrationsCount, seeded,
+		"MigrationsCount (%d) must equal the number of rows seeded into admin.migration in admin_schema.sql (%d)",
+		MigrationsCount, seeded)
+}
+
+// simulatePreV6Migration rolls the seeded admin.migration table back to a pre-01409 state so
+// that the migrator considers the "01409 Switch to time-only partitioning" migration pending.
+// A fresh NewPostgresSinkMigrator bootstrap seeds all migrations as applied (the current install
+// path); here we emulate an older database that must still be upgraded.
+//
+// The migrator determines pending migrations purely from the row count in admin.migration, so we
+// delete the last-applied migration row, leaving MigrationsCount-1 rows behind.
+func simulatePreV6Migration(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	_, err := conn.Exec(ctx, `DELETE FROM admin.migration WHERE id = (SELECT max(id) FROM admin.migration)`)
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, conn.QueryRow(ctx, `SELECT count(*) FROM admin.migration`).Scan(&count))
+	require.Equal(t, MigrationsCount-1, count, "exactly one migration should be pending after rollback")
+}
+
+// oldSchemaMetricTable creates a metric table using the pre-v6 (dbname -> time) two-level
+// partitioning layout that the "01409 Switch to time-only partitioning" migration converts from:
+//
+//	public.<metric>                      PARTITION BY LIST (dbname)      -- top level
+//	  subpartitions.<metric>_<dbname>    PARTITION BY RANGE (time)       -- dbname level
+//	    subpartitions.<metric>_<...>_<w> leaf partition                  -- time level
+//
+// It seeds a couple of rows so the test can assert data survives the migration.
+func oldSchemaMetricTable(t *testing.T, conn *pgx.Conn, metric string) {
+	t.Helper()
+	_, err := conn.Exec(ctx, `
+		CREATE TABLE public.`+metric+` (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY LIST (dbname);
+		COMMENT ON TABLE public.`+metric+` IS 'pgwatch-generated-metric-lvl';
+
+		CREATE TABLE subpartitions.`+metric+`_db1 PARTITION OF public.`+metric+`
+			FOR VALUES IN ('db1') PARTITION BY RANGE (time);
+
+		CREATE TABLE subpartitions.`+metric+`_db1_2024w01 PARTITION OF subpartitions.`+metric+`_db1
+			FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
+		COMMENT ON TABLE subpartitions.`+metric+`_db1_2024w01 IS 'pgwatch-generated-metric-time-lvl';
+
+		INSERT INTO public.`+metric+` (time, dbname, data) VALUES
+			('2024-01-03 10:00:00+00', 'db1', '{"x": 1}'::jsonb),
+			('2024-01-04 11:00:00+00', 'db1', '{"x": 2}'::jsonb);
+	`)
+	require.NoError(t, err)
+}
+
+// isRangePartitioned reports whether the given relation is now top-level RANGE partitioned.
+func isRangePartitioned(t *testing.T, conn *pgx.Conn, metric string) bool {
+	t.Helper()
+	var ok bool
+	err := conn.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_partitioned_table WHERE partrelid = to_regclass($1) AND partstrat = 'r')`,
+		metric).Scan(&ok)
+	require.NoError(t, err)
+	return ok
+}
+
+// rowCount returns the number of rows currently stored in the (partitioned) metric table.
+func rowCount(t *testing.T, conn *pgx.Conn, metric string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, conn.QueryRow(ctx, `SELECT count(*) FROM public.`+metric).Scan(&n))
+	return n
+}
+
+// TestMigration01409_TimeOnlyPartitioning is an end-to-end test against a real PostgreSQL
+// container. It builds the old (dbname -> time) partitioned layout, runs the sink migrations,
+// and asserts that the table is converted to time-only RANGE partitioning while preserving data.
+// It also runs the migration a second time to verify idempotency / re-run safety.
+func TestMigration01409_TimeOnlyPartitioning(t *testing.T) {
+	if os.Getenv("PGWATCH_TEST_SKIP_MIGRATION") != "" {
+		t.Skip("migration integration test skipped via PGWATCH_TEST_SKIP_MIGRATION")
+	}
+	r := require.New(t)
+	a := assert.New(t)
+
+	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
+	r.NoError(err)
+	defer pgTearDown()
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	r.NoError(err)
+
+	// Bootstrap the admin schema (creates admin.*, subpartitions, metrics_template, etc.).
+	// A fresh bootstrap seeds admin.migration with ALL migrations already applied, so we
+	// delete the 01409 row to simulate an older database that predates this migration.
+	mig, err := NewPostgresSinkMigrator(ctx, connStr)
+	r.NoError(err)
+
+	conn, err := pgx.Connect(ctx, connStr)
+	r.NoError(err)
+	defer conn.Close(ctx)
+
+	simulatePreV6Migration(t, conn)
+
+	const metric = "old_style_metric"
+	oldSchemaMetricTable(t, conn, metric)
+
+	// Sanity check: before migration the table is LIST (dbname) partitioned, not RANGE.
+	a.False(isRangePartitioned(t, conn, metric), "table should start as LIST(dbname) partitioned")
+	a.Equal(2, rowCount(t, conn, metric), "seeded rows should be present before migration")
+
+	// Run the migrations (this executes 01110, 01180 and the 01409 conversion).
+	r.NoError(mig.Migrate())
+
+	// After migration the top-level table must be RANGE(time) partitioned and keep its data.
+	a.True(isRangePartitioned(t, conn, metric), "table should be converted to RANGE(time) partitioning")
+	a.Equal(2, rowCount(t, conn, metric), "data must be preserved across the migration")
+
+	// The temporary *_before_v6_migration table must have been cleaned up.
+	var leftover bool
+	r.NoError(conn.QueryRow(ctx,
+		`SELECT to_regclass($1) IS NOT NULL`, metric+"_before_v6_migration").Scan(&leftover))
+	a.False(leftover, "the *_before_v6_migration scratch table should be dropped")
+
+	// Idempotency: running the migrations again must not error and must not lose data.
+	needs, err := mig.NeedsMigration()
+	r.NoError(err)
+	a.False(needs, "no migrations should be pending immediately after a successful migrate")
+
+	r.NoError(mig.Migrate(), "re-running Migrate() must be a no-op and not error")
+	a.True(isRangePartitioned(t, conn, metric))
+	a.Equal(2, rowCount(t, conn, metric), "data must remain intact after a second migrate")
+}
+
+// TestMigration01409_EmptyTable verifies the migration handles a metric table with no rows:
+// MIN(time) is NULL server-side, so it should create a single empty time partition without error.
+func TestMigration01409_EmptyTable(t *testing.T) {
+	if os.Getenv("PGWATCH_TEST_SKIP_MIGRATION") != "" {
+		t.Skip("migration integration test skipped via PGWATCH_TEST_SKIP_MIGRATION")
+	}
+	r := require.New(t)
+	a := assert.New(t)
+
+	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
+	r.NoError(err)
+	defer pgTearDown()
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	r.NoError(err)
+
+	mig, err := NewPostgresSinkMigrator(ctx, connStr)
+	r.NoError(err)
+
+	conn, err := pgx.Connect(ctx, connStr)
+	r.NoError(err)
+	defer conn.Close(ctx)
+
+	simulatePreV6Migration(t, conn)
+
+	const metric = "empty_old_metric"
+	_, err = conn.Exec(ctx, `
+		CREATE TABLE public.`+metric+` (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY LIST (dbname);
+		COMMENT ON TABLE public.`+metric+` IS 'pgwatch-generated-metric-lvl';
+		CREATE TABLE subpartitions.`+metric+`_db1 PARTITION OF public.`+metric+`
+			FOR VALUES IN ('db1') PARTITION BY RANGE (time);
+		CREATE TABLE subpartitions.`+metric+`_db1_2024w01 PARTITION OF subpartitions.`+metric+`_db1
+			FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
+		COMMENT ON TABLE subpartitions.`+metric+`_db1_2024w01 IS 'pgwatch-generated-metric-time-lvl';
+	`)
+	r.NoError(err)
+
+	r.NoError(mig.Migrate())
+
+	a.True(isRangePartitioned(t, conn, metric), "empty table should still be converted to RANGE(time)")
+	a.Equal(0, rowCount(t, conn, metric))
+
+	// at least one (empty) time partition should have been created
+	var leaves int
+	r.NoError(conn.QueryRow(ctx,
+		`SELECT count(*) FROM pg_partition_tree($1) WHERE isleaf`, metric).Scan(&leaves))
+	a.GreaterOrEqual(leaves, 1, "a single empty time partition should exist")
+}

--- a/internal/sinks/postgres_schema_test.go
+++ b/internal/sinks/postgres_schema_test.go
@@ -91,7 +91,7 @@ func TestPostgresWriterNeedsMigrationNoMigrationNeeded(t *testing.T) {
 	conn.ExpectQuery(`SELECT to_regclass`).
 		WithArgs("admin.migration").
 		WillReturnRows(pgxmock.NewRows([]string{"to_regclass"}).AddRow(true))
-	conn.ExpectQuery(`SELECT count`).WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(2))
+	conn.ExpectQuery(`SELECT count`).WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(3))
 
 	pgw := &PostgresWriter{ctx: ctx, sinkDb: conn}
 	needs, err := pgw.NeedsMigration()

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -966,9 +966,9 @@ func Test_Maintain(t *testing.T) {
 	})
 }
 
-// TestEnsureMetricTimePartsExist_SpecialSourceNames verifies that metric names with special characters
+// TestEnsureMetricTimePartsExist_SpecialMetricNames verifies that metric names with special characters
 // (dots, uppercase, hyphens, underscores) are accepted by the partition functions.
-func TestEnsureMetricTimePartsExist_SpecialSourceNames(t *testing.T) {
+func TestEnsureMetricTimePartsExist_SpecialMetricNames(t *testing.T) {
 	r := require.New(t)
 	a := assert.New(t)
 
@@ -1017,7 +1017,7 @@ func TestEnsureMetricTimePartsExist_SpecialSourceNames(t *testing.T) {
 	err = conn.QueryRow(ctx, `SELECT COUNT(*) FROM pg_partition_tree('"metric.new"') WHERE level = 1`).Scan(&partitionCount)
 	r.NoError(err)
 	// 4 time partitions (1 requested + 3 precreated) per metric
-	a.Equal(4, partitionCount, "expected one time partition set per metric")
+	a.Equal(4, partitionCount)
 }
 
 // TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts verifies that repeated calls to
@@ -1048,7 +1048,6 @@ func TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts(t *testing.T) {
 		},
 	}
 
-	var partitionCountAfterFirst int
 	for i := range 5 {
 		pgw, err := NewPostgresWriter(ctx, connStr, opts)
 		r.NoError(err)
@@ -1060,13 +1059,7 @@ func TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts(t *testing.T) {
 		err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_partition_tree('restart_test_metric') WHERE isleaf").Scan(&count)
 		conn.Close(ctx)
 		r.NoError(err)
-
-		if i == 0 {
-			partitionCountAfterFirst = count
-		} else {
-			a.Equal(partitionCountAfterFirst, count,
-				"partition count should not grow on restart %d", i+1)
-		}
+		a.Equal(4, count, "partition count should not grow on restart %d", i+1)
 	}
 }
 

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -645,24 +645,21 @@ func TestPartitionInterval(t *testing.T) {
 	conn, err := pgx.Connect(ctx, connStr)
 	r.NoError(err)
 
-	m := map[string]map[string]ExistingPartitionInfo{
+	m := map[string]ExistingPartitionInfo{
 		"test_metric": {
-			"test_db": {
-				time.Now(), time.Now().Add(time.Hour),
-			},
+			time.Now(), time.Now().Add(time.Hour),
 		},
 	}
-	err = pgw.EnsureMetricDbnameTime(m)
+	err = pgw.EnsureMetricTimePartsExist(m)
 	r.NoError(err)
 
 	var partitionsNum int
 	err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_partition_tree('test_metric');").Scan(&partitionsNum)
 	a.NoError(err)
-	// 1 the metric table itself + 1 dbname partition
-	// + 4 time partitions (1 we asked for + 3 precreated)
-	a.Equal(6, partitionsNum)
+	// 1 the metric table itself + 4 time partitions (1 we asked for + 3 precreated)
+	a.Equal(5, partitionsNum)
 
-	part := pgw.partitionMapMetricDbname["test_metric"]["test_db"]
+	part := pgw.partitionMapMetric["test_metric"]
 	// partition bounds should have a difference of 3 weeks
 	a.Equal(part.StartTime.Add(3*7*24*time.Hour), part.EndTime)
 }
@@ -744,29 +741,26 @@ func Test_Maintain(t *testing.T) {
 		err = pgw.EnsureMetricDummy("test_metric_b")
 		r.NoError(err)
 
-		// Create partitions for each dbname
+		// Create time-based partitions for each metric
 		_, err = conn.Exec(ctx, `
-			CREATE TABLE subpartitions.test_metric_a_db1 PARTITION OF public.test_metric_a FOR VALUES IN ('db1');
-			CREATE TABLE subpartitions.test_metric_a_db2 PARTITION OF public.test_metric_a FOR VALUES IN ('db2');
-			CREATE TABLE subpartitions.test_metric_a_db3 PARTITION OF public.test_metric_a FOR VALUES IN ('db3');
-			CREATE TABLE subpartitions.test_metric_b_db1 PARTITION OF public.test_metric_b FOR VALUES IN ('db1');
-			CREATE TABLE subpartitions.test_metric_b_db2 PARTITION OF public.test_metric_b FOR VALUES IN ('db2');
+			CREATE TABLE subpartitions.test_metric_a_2024w01 PARTITION OF public.test_metric_a FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
+			CREATE TABLE subpartitions.test_metric_b_2024w01 PARTITION OF public.test_metric_b FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
 		`)
 		r.NoError(err)
 
 		// Directly insert test data with different dbnames
 		_, err = conn.Exec(ctx, `
-			INSERT INTO test_metric_a (time, dbname, data) VALUES 
-				(now(), 'db1', '{}'::jsonb),
-				(now(), 'db2', '{}'::jsonb),
-				(now(), 'db3', '{}'::jsonb)
+			INSERT INTO test_metric_a (time, dbname, data) VALUES
+				('2024-01-03', 'db1', '{}'::jsonb),
+				('2024-01-03', 'db2', '{}'::jsonb),
+				('2024-01-03', 'db3', '{}'::jsonb)
 		`)
 		r.NoError(err)
 
 		_, err = conn.Exec(ctx, `
-			INSERT INTO test_metric_b (time, dbname, data) VALUES 
-				(now(), 'db1', '{}'::jsonb),
-				(now(), 'db2', '{}'::jsonb)
+			INSERT INTO test_metric_b (time, dbname, data) VALUES
+				('2024-01-03', 'db1', '{}'::jsonb),
+				('2024-01-03', 'db2', '{}'::jsonb)
 		`)
 		r.NoError(err)
 
@@ -794,16 +788,16 @@ func Test_Maintain(t *testing.T) {
 		err = pgw.EnsureMetricDummy("test_metric_c")
 		r.NoError(err)
 
-		// Create partition for db_active
+		// Create time partition for the metric
 		_, err = conn.Exec(ctx, `
-			CREATE TABLE subpartitions.test_metric_c_db_active PARTITION OF public.test_metric_c FOR VALUES IN ('db_active');
+			CREATE TABLE subpartitions.test_metric_c_2024w01 PARTITION OF public.test_metric_c FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
 		`)
 		r.NoError(err)
 
 		// Directly insert test data with one active dbname
 		_, err = conn.Exec(ctx, `
-			INSERT INTO test_metric_c (time, dbname, data) VALUES 
-				(now(), 'db_active', '{}'::jsonb)
+			INSERT INTO test_metric_c (time, dbname, data) VALUES
+				('2024-01-03', 'db_active', '{}'::jsonb)
 		`)
 		r.NoError(err)
 
@@ -845,14 +839,14 @@ func Test_Maintain(t *testing.T) {
 		r.NoError(err)
 
 		_, err = conn.Exec(ctx, `
-			CREATE TABLE subpartitions.test_metric_d_db1 PARTITION OF public.test_metric_d FOR VALUES IN ('db1');
+			CREATE TABLE subpartitions.test_metric_d_2024w01 PARTITION OF public.test_metric_d FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
 		`)
 		r.NoError(err)
 
 		// Directly insert test data for only db1
 		_, err = conn.Exec(ctx, `
-			INSERT INTO test_metric_d (time, dbname, data) VALUES 
-				(now(), 'db1', '{}'::jsonb)
+			INSERT INTO test_metric_d (time, dbname, data) VALUES
+				('2024-01-03', 'db1', '{}'::jsonb)
 		`)
 		r.NoError(err)
 
@@ -908,43 +902,39 @@ func Test_Maintain(t *testing.T) {
 		err = pgw.SyncMetric("test", "test_metric_2", AddOp)
 		r.NoError(err)
 
-		// create the 2nd level dbname partition
-		_, err = conn.Exec(ctx, "CREATE TABLE subpartitions.test_metric_2_dbname PARTITION OF public.test_metric_2 FOR VALUES IN ('test') PARTITION BY RANGE (time)")
-		a.NoError(err)
-
 		boundStart := time.Now().Add(-1 * 2 * 24 * time.Hour).Format("2006-01-02")
 		boundEnd := time.Now().Add(-1 * 24 * time.Hour).Format("2006-01-02")
 
-		// create the 3rd level time partition with end bound yesterday
+		// create the time partition with end bound yesterday
 		_, err = conn.Exec(ctx,
 			fmt.Sprintf(
-				`CREATE TABLE subpartitions.test_metric_2_dbname_time 
-			PARTITION OF subpartitions.test_metric_2_dbname 
+				`CREATE TABLE subpartitions.test_metric_2_yesterday
+			PARTITION OF public.test_metric_2
 			FOR VALUES FROM ('%s') TO ('%s')`,
 				boundStart, boundEnd),
 		)
 		a.NoError(err)
-		_, err = conn.Exec(ctx, "COMMENT ON TABLE subpartitions.test_metric_2_dbname_time IS $$pgwatch-generated-metric-dbname-time-lvl$$")
+		_, err = conn.Exec(ctx, "COMMENT ON TABLE subpartitions.test_metric_2_yesterday IS $$pgwatch-generated-metric-time-lvl$$")
 		a.NoError(err)
 
 		var partitionsNum int
 		err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_partition_tree('test_metric_2');").Scan(&partitionsNum)
 		a.NoError(err)
-		a.Equal(3, partitionsNum)
+		a.Equal(2, partitionsNum)
 
 		pgw.opts.RetentionInterval = "2 days"
 		pgw.DeleteOldPartitions() // 1 day < 2 days, shouldn't delete anything
 
 		err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_partition_tree('test_metric_2');").Scan(&partitionsNum)
 		a.NoError(err)
-		a.Equal(3, partitionsNum)
+		a.Equal(2, partitionsNum)
 
 		pgw.opts.RetentionInterval = "1 hour"
 		pgw.DeleteOldPartitions() // 1 day > 1 hour, should delete the partition
 
 		err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_partition_tree('test_metric_2');").Scan(&partitionsNum)
 		a.NoError(err)
-		a.Equal(2, partitionsNum)
+		a.Equal(1, partitionsNum)
 	})
 
 	t.Run("Epoch to Duration Conversion", func(_ *testing.T) {
@@ -976,9 +966,9 @@ func Test_Maintain(t *testing.T) {
 	})
 }
 
-// TestEnsureMetricDbnameTime_SpecialSourceNames verifies that source names with special characters
+// TestEnsureMetricTimePartsExist_SpecialSourceNames verifies that metric names with special characters
 // (dots, uppercase, hyphens, underscores) are accepted by the partition functions.
-func TestEnsureMetricDbnameTime_SpecialSourceNames(t *testing.T) {
+func TestEnsureMetricTimePartsExist_SpecialSourceNames(t *testing.T) {
 	r := require.New(t)
 	a := assert.New(t)
 
@@ -999,41 +989,41 @@ func TestEnsureMetricDbnameTime_SpecialSourceNames(t *testing.T) {
 	r.NoError(err)
 
 	specialNames := []string{
-		"source.new",
-		"Source.With.Dots",
-		"UPPERCASE_SOURCE",
-		"MixedCase_Source-123",
-		"source-with-hyphens",
-		"source_with_underscores",
-		"Source123.Test_Name-456",
+		"metric.new",
+		"Metric.With.Dots",
+		"UPPERCASE_METRIC",
+		"MixedCase_Metric-123",
+		"metric-with-hyphens",
+		"metric_with_underscores",
+		"Metric123.Test_Name-456",
 	}
 
-	m := make(map[string]map[string]ExistingPartitionInfo)
-	m["test_metric"] = make(map[string]ExistingPartitionInfo)
+	m := make(map[string]ExistingPartitionInfo)
 	for _, name := range specialNames {
-		m["test_metric"][name] = ExistingPartitionInfo{
+		m[name] = ExistingPartitionInfo{
 			StartTime: time.Now(),
 			EndTime:   time.Now().Add(time.Hour),
 		}
 	}
 
-	err = pgw.EnsureMetricDbnameTime(m)
-	r.NoError(err, "EnsureMetricDbnameTime should handle special source names")
+	err = pgw.EnsureMetricTimePartsExist(m)
+	r.NoError(err, "EnsureMetricTimePartsExist should handle special metric names")
 
 	conn, err := pgx.Connect(ctx, connStr)
 	r.NoError(err)
 	defer conn.Close(ctx)
 
 	var partitionCount int
-	err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_partition_tree('test_metric') WHERE level = 1").Scan(&partitionCount)
+	err = conn.QueryRow(ctx, `SELECT COUNT(*) FROM pg_partition_tree('"metric.new"') WHERE level = 1`).Scan(&partitionCount)
 	r.NoError(err)
-	a.Equal(len(specialNames), partitionCount, "expected one dbname-level partition per special source name")
+	// 4 time partitions (1 requested + 3 precreated) per metric
+	a.Equal(4, partitionCount, "expected one time partition set per metric")
 }
 
-// TestEnsureMetricDbnameTime_IdempotentAcrossRestarts verifies that repeated calls to
-// EnsureMetricDbnameTime with fresh writer instances (simulating process restarts)
+// TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts verifies that repeated calls to
+// EnsureMetricTimePartsExist with fresh writer instances (simulating process restarts)
 // do not create duplicate partitions.
-func TestEnsureMetricDbnameTime_IdempotentAcrossRestarts(t *testing.T) {
+func TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts(t *testing.T) {
 	r := require.New(t)
 	a := assert.New(t)
 
@@ -1051,12 +1041,10 @@ func TestEnsureMetricDbnameTime_IdempotentAcrossRestarts(t *testing.T) {
 		BatchingDelay:       time.Second,
 	}
 
-	m := map[string]map[string]ExistingPartitionInfo{
+	m := map[string]ExistingPartitionInfo{
 		"restart_test_metric": {
-			"test_source": {
-				StartTime: time.Now(),
-				EndTime:   time.Now().Add(time.Hour),
-			},
+			StartTime: time.Now(),
+			EndTime:   time.Now().Add(time.Hour),
 		},
 	}
 
@@ -1064,7 +1052,7 @@ func TestEnsureMetricDbnameTime_IdempotentAcrossRestarts(t *testing.T) {
 	for i := range 5 {
 		pgw, err := NewPostgresWriter(ctx, connStr, opts)
 		r.NoError(err)
-		r.NoError(pgw.EnsureMetricDbnameTime(m))
+		r.NoError(pgw.EnsureMetricTimePartsExist(m))
 
 		conn, err := pgx.Connect(ctx, connStr)
 		r.NoError(err)

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -966,9 +966,9 @@ func Test_Maintain(t *testing.T) {
 	})
 }
 
-// TestEnsureMetricTimePartsExist_SpecialSourceNames verifies that metric names with special characters
+// TestEnsureMetricTimePartsExist_SpecialMetricNames verifies that metric names with special characters
 // (dots, uppercase, hyphens, underscores) are accepted by the partition functions.
-func TestEnsureMetricTimePartsExist_SpecialSourceNames(t *testing.T) {
+func TestEnsureMetricTimePartsExist_SpecialMetricNames(t *testing.T) {
 	r := require.New(t)
 	a := assert.New(t)
 
@@ -1017,7 +1017,7 @@ func TestEnsureMetricTimePartsExist_SpecialSourceNames(t *testing.T) {
 	err = conn.QueryRow(ctx, `SELECT COUNT(*) FROM pg_partition_tree('"metric.new"') WHERE level = 1`).Scan(&partitionCount)
 	r.NoError(err)
 	// 4 time partitions (1 requested + 3 precreated) per metric
-	a.Equal(4, partitionCount, "expected one time partition set per metric")
+	a.Equal(4, partitionCount)
 }
 
 // TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts verifies that repeated calls to
@@ -1048,7 +1048,6 @@ func TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts(t *testing.T) {
 		},
 	}
 
-	var partitionCountAfterFirst int
 	for i := range 5 {
 		pgw, err := NewPostgresWriter(ctx, connStr, opts)
 		r.NoError(err)
@@ -1060,12 +1059,6 @@ func TestEnsureMetricTimePartsExist_IdempotentAcrossRestarts(t *testing.T) {
 		err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_partition_tree('restart_test_metric') WHERE isleaf").Scan(&count)
 		conn.Close(ctx)
 		r.NoError(err)
-
-		if i == 0 {
-			partitionCountAfterFirst = count
-		} else {
-			a.Equal(partitionCountAfterFirst, count,
-				"partition count should not grow on restart %d", i+1)
-		}
+		a.Equal(4, count, "partition count should not grow on restart %d", i+1)
 	}
 }

--- a/internal/sinks/sql/README.md
+++ b/internal/sinks/sql/README.md
@@ -1,7 +1,7 @@
 ## Rollout sequence
 
 pgwatch automatically handles database schema for metric measurements. If `timescale` extension is available then `timescale`
-schema will be used by default. Otherwise `metric-dbname-time` schema is applied.
+schema will be used by default. Otherwise `metric-time` schema is applied.
 
 If one wants to init the schema without running the monitoring, they should use `--init` command-line parameter, e.g.
 
@@ -11,9 +11,9 @@ pgwatch --config=postgresql://pgwatch:pgwatchadmin@localhost/pgwatch --sink=post
 
 ## Schema types
 
-### metric-dbname-time
+### metric-time
 
-A single top level table for each distinct metric in the "public" schema + 2 levels of subpartitions ("dbname" + weekly time based) in the "subpartitions" schema.
+A single top level table for each distinct metric in the "public" schema with time-based partitioning in the "subpartitions" schema.
 
 Provides the fastest query runtimes when having long retention intervals / lots of metrics data or slow disks and accessing mostly only a single DB's metrics at a time.
 
@@ -27,18 +27,13 @@ Something like below will be done by the gatherer AUTOMATICALLY:
 ```sql
 create table public."mymetric"
   (LIKE admin.metrics_template)
-  PARTITION BY LIST (dbname);
+  PARTITION BY RANGE (time);
 COMMENT ON TABLE public."mymetric" IS 'pgwatch-generated-metric-lvl';
 
-create table subpartitions."mymetric_mydbname"
+create table subpartitions."mymetric_y2019w01" -- week calculated dynamically of course
   PARTITION OF public."mymetric"
-  FOR VALUES IN ('my-dbname') PARTITION BY RANGE (time);
-COMMENT ON TABLE subpartitions."mymetric_mydbname" IS 'pgwatch-generated-metric-dbname-lvl';
-
-create table subpartitions."mymetric_mydbname_y2019w01" -- month calculated dynamically of course
-  PARTITION OF subpartitions."mymetric_mydbname"
   FOR VALUES FROM ('2019-01-01') TO ('2019-01-07');
-COMMENT ON TABLE subpartitions."mymetric_mydbname_y2019w01" IS 'pgwatch-generated-metric-dbname-time-lvl';
+COMMENT ON TABLE subpartitions."mymetric_y2019w01" IS 'pgwatch-generated-metric-time-lvl';
 ```
 
 ### timescale

--- a/internal/sinks/sql/admin_functions.sql
+++ b/internal/sinks/sql/admin_functions.sql
@@ -14,7 +14,7 @@ BEGIN
   END IF;
 
   IF l_schema_type = 'postgres' THEN
-    EXECUTE format('CREATE TABLE public.%I (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY LIST (dbname)', metric);
+    EXECUTE format('CREATE TABLE public.%I (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY RANGE (time)', metric);
   ELSIF l_schema_type = 'timescale' THEN
     PERFORM admin.ensure_partition_timescale(metric);
   END IF;
@@ -110,7 +110,7 @@ BEGIN
         c.relkind IN ('r', 'p')
         AND c.relnamespace = 'subpartitions'::regnamespace
         AND (regexp_match(pg_catalog.pg_get_expr(c.relpartbound, c.oid), E'TO \\((''.*?'')'))[1]::timestamp < (now()  - older_than)
-        AND pg_catalog.obj_description(c.oid, 'pg_class') IN ('pgwatch-generated-metric-time-lvl', 'pgwatch-generated-metric-dbname-time-lvl')
+        AND pg_catalog.obj_description(c.oid, 'pg_class') = 'pgwatch-generated-metric-time-lvl'
       ORDER BY 1;
   WHEN 'timescale' THEN
     RETURN QUERY
@@ -164,53 +164,6 @@ BEGIN
       RAISE EXCEPTION 'unsupported schema type: %', schema_type;
   END CASE;
   RETURN i;
-END;
-$SQL$ LANGUAGE plpgsql;
-
-/*
-drop_source_partitions removes all metric data for a decommissioned source
-    p_source_name - the dbname (source) whose partitions should be dropped
-Returns the number of patritions dropped
-*/
-CREATE OR REPLACE FUNCTION admin.drop_source_partitions(p_source_name text)
-RETURNS int AS
-$SQL$
-DECLARE
-  r record;
-  v_dropped_count int := 0;
-BEGIN
-  FOR r IN
-    SELECT
-      c.oid::regclass::text      AS partition_name,
-      parent.oid::regclass::text AS metric_table,
-      parent.relname             AS metric_name
-    FROM pg_catalog.pg_class c
-    JOIN pg_catalog.pg_inherits i      ON c.oid = i.inhrelid
-    JOIN pg_catalog.pg_class parent    ON parent.oid = i.inhparent
-    WHERE c.relnamespace = 'subpartitions'::regnamespace
-      AND pg_catalog.obj_description(parent.oid, 'pg_class') = 'pgwatch-generated-metric-lvl'
-      AND (regexp_match(
-             pg_catalog.pg_get_expr(c.relpartbound, c.oid),
-             E'FOR VALUES IN \\(''(.+?)''\\)'
-           ))[1] = p_source_name
-  LOOP
-    -- advisory lock matching ensure_partition_metric_dbname_time
-    PERFORM pg_advisory_xact_lock(
-      regexp_replace(md5(r.metric_name), E'\\D', '', 'g')::varchar(10)::int8
-    );
-
-    RAISE NOTICE 'detaching partition: % from %', r.partition_name, r.metric_table;
-    EXECUTE 'ALTER TABLE ' || r.metric_table || ' DETACH PARTITION ' || r.partition_name;
-
-    RAISE NOTICE 'dropping partition:  %', r.partition_name;
-    EXECUTE 'DROP TABLE IF EXISTS ' || r.partition_name;
-
-    v_dropped_count := v_dropped_count + 1;
-  END LOOP;
-
-  DELETE FROM admin.all_distinct_dbname_metrics WHERE dbname = p_source_name;
-
-  RETURN v_dropped_count;
 END;
 $SQL$ LANGUAGE plpgsql;
 

--- a/internal/sinks/sql/admin_schema.sql
+++ b/internal/sinks/sql/admin_schema.sql
@@ -95,5 +95,6 @@ INSERT INTO
     admin.migration (id, version)
 VALUES
     (0,  '01110 Apply postgres sink schema migrations'),
-    (1,  '01180 Apply admin functions migrations for v5');
+    (1,  '01180 Apply admin functions migrations for v5'),
+    (2,  '01409 Apply postgres sink partitioning scheme migrations');
     -- apply new migration value to `sinkSchema` in `cmd/pgwatch/version.go` file as well

--- a/internal/sinks/sql/admin_schema.sql
+++ b/internal/sinks/sql/admin_schema.sql
@@ -96,5 +96,5 @@ INSERT INTO
 VALUES
     (0,  '01110 Apply postgres sink schema migrations'),
     (1,  '01180 Apply admin functions migrations for v5'),
-    (2,  '01409 Apply postgres sink partitioning scheme migrations');
+    (2,  '01409 Switch to time-only partitioning');
     -- apply new migration value to `sinkSchema` in `cmd/pgwatch/version.go` file as well

--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -29,6 +29,7 @@ DECLARE
   l_partition_format text;
   l_time_suffix text;
   l_existing_upper_bound timestamptz;
+  l_table_oid oid;
 BEGIN
   -- Validate partition period
   IF partition_period < interval '1 hour' THEN
@@ -46,6 +47,12 @@ BEGIN
 
   PERFORM pg_advisory_xact_lock(regexp_replace( md5(metric) , E'\\D', '', 'g')::varchar(10)::int8);
 
+  -- Check if table exists and has LIST partitioning (legacy); if so, drop it for conversion to RANGE
+  SELECT to_regclass('public.' || quote_ident(metric)) INTO l_table_oid;
+  IF EXISTS (SELECT 1 FROM pg_partitioned_table WHERE partrelid = l_table_oid AND partstrat = 'l')
+     AND l_table_oid IS NOT NULL THEN
+    EXECUTE format('DROP TABLE public.%I CASCADE', metric);
+  END IF;
 
   -- 1. level
   IF to_regclass('public.' || quote_ident(metric)) IS NULL

--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -29,7 +29,6 @@ DECLARE
   l_partition_format text;
   l_time_suffix text;
   l_existing_upper_bound timestamptz;
-  l_table_oid oid;
 BEGIN
   -- Validate partition period
   IF partition_period < interval '1 hour' THEN
@@ -48,9 +47,15 @@ BEGIN
   PERFORM pg_advisory_xact_lock(regexp_replace( md5(metric) , E'\\D', '', 'g')::varchar(10)::int8);
 
   -- Check if table exists and has LIST partitioning (legacy); if so, drop it for conversion to RANGE
-  SELECT to_regclass('public.' || quote_ident(metric)) INTO l_table_oid;
-  IF EXISTS (SELECT 1 FROM pg_partitioned_table WHERE partrelid = l_table_oid AND partstrat = 'l')
-     AND l_table_oid IS NOT NULL THEN
+  IF EXISTS 
+      (
+        SELECT 1 
+        FROM pg_partitioned_table 
+        WHERE 
+          partrelid = to_regclass('public.' || quote_ident(metric))
+          AND
+          partstrat = 'l'
+      ) THEN
     EXECUTE format('DROP TABLE public.%I CASCADE', metric);
   END IF;
 

--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -46,19 +46,6 @@ BEGIN
 
   PERFORM pg_advisory_xact_lock(regexp_replace( md5(metric) , E'\\D', '', 'g')::varchar(10)::int8);
 
-  -- Check if table exists and has LIST partitioning (legacy); if so, drop it for conversion to RANGE
-  IF EXISTS 
-      (
-        SELECT 1 
-        FROM pg_partitioned_table 
-        WHERE 
-          partrelid = to_regclass('public.' || quote_ident(metric))
-          AND
-          partstrat = 'l'
-      ) THEN
-    EXECUTE format('DROP TABLE public.%I CASCADE', metric);
-  END IF;
-
   -- 1. level
   IF to_regclass('public.' || quote_ident(metric)) IS NULL
   THEN

--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -1,16 +1,14 @@
 /*
-  ensure_partition_metric_dbname_time creates partitioned metric tables if not already existing
+  ensure_partition_metric_time creates partitioned metric tables if not already existing
     metric - name of the metric (top level table)
-    dbname - name of the database (2nd level partition)
     metric_timestamp - timestamp of the metric (used to determine the time partition)
     partition_period - interval for partitioning (e.g., '1 week', '1 day', '1 month')
     partitions_to_precreate - how many future time partitions to create (default 3)
     part_available_from - output parameter, start time of the time partition where the given metric_timestamp fits in
     part_available_to - output parameter, end time of the time partition where the given metric_timestamp fits in
 */
-CREATE OR REPLACE FUNCTION admin.ensure_partition_metric_dbname_time(
+CREATE OR REPLACE FUNCTION admin.ensure_partition_metric_time(
     metric text,
-    dbname text,
     metric_timestamp timestamptz,
     partition_period interval default '1 week'::interval,
     partitions_to_precreate int default 3,
@@ -18,18 +16,16 @@ CREATE OR REPLACE FUNCTION admin.ensure_partition_metric_dbname_time(
     OUT part_available_to timestamptz)
 RETURNS record AS
 /*
-  creates a top level metric table, a dbname partition and a time partition if not already existing.
+  creates a top level metric table and time partitions if not already existing.
   returns time partition start/end date
 */
 $SQL$
 DECLARE
-  l_part_name_2nd text;
-  l_part_name_3rd text;
+  l_part_name text;
   l_part_start timestamptz;
   l_part_end timestamptz;
   ideal_length int;
   l_template_table text := 'admin.metrics_template';
-  MAX_IDENT_LEN CONSTANT integer := current_setting('max_identifier_length')::int;
   l_partition_format text;
   l_time_suffix text;
   l_existing_upper_bound timestamptz;
@@ -54,27 +50,12 @@ BEGIN
   -- 1. level
   IF to_regclass('public.' || quote_ident(metric)) IS NULL
   THEN
-    EXECUTE format('CREATE TABLE public.%I (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY LIST (dbname)', metric);
+    EXECUTE format('CREATE TABLE public.%I (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY RANGE (time)', metric);
     EXECUTE format('COMMENT ON TABLE public.%I IS $$pgwatch-generated-metric-lvl$$', metric);
   END IF;
 
   -- 2. level
-  l_part_name_2nd := metric || '_' || dbname;
-  IF char_length(l_part_name_2nd) > MAX_IDENT_LEN     -- use "dbname" hash instead of name for overly long ones
-  THEN
-    ideal_length = MAX_IDENT_LEN - char_length(format('%s_', metric));
-    l_part_name_2nd := metric || '_' || substring(md5(dbname) from 1 for ideal_length);
-  END IF;
 
-  IF to_regclass('subpartitions.' || quote_ident(l_part_name_2nd)) IS NULL
-  THEN
-    EXECUTE format('CREATE TABLE subpartitions.%I PARTITION OF public.%I FOR VALUES IN (%L) PARTITION BY RANGE (time)',
-                    l_part_name_2nd, metric, dbname);
-    EXECUTE format('COMMENT ON TABLE subpartitions.%I IS $$pgwatch-generated-metric-dbname-lvl$$', l_part_name_2nd);
-  END IF;
-
-  -- 3. level 
-  
   -- Get existing partition upper bound
   SELECT max(substring(pg_catalog.pg_get_expr(c.relpartbound, c.oid, true) from 'TO \(''([^'']+)''')::timestamptz)
   INTO l_existing_upper_bound
@@ -83,7 +64,7 @@ BEGIN
   JOIN pg_catalog.pg_class parent ON parent.oid = i.inhparent
   WHERE c.relispartition
     AND c.relnamespace = 'subpartitions'::regnamespace
-    AND parent.relname = l_part_name_2nd;
+    AND parent.relname = metric;
 
   -- Determine starting point for new partitions
   IF l_existing_upper_bound IS NOT NULL THEN
@@ -100,7 +81,7 @@ BEGIN
         -- For hourly periods (>= 1 hour, < 1 day)
         l_part_start := date_trunc('hour', metric_timestamp);
     END CASE;
-    
+
     -- For the first partition, set the available range
     part_available_from := l_part_start;
     part_available_to := l_part_start + partition_period;
@@ -109,7 +90,7 @@ BEGIN
   -- Create partitions
   FOR i IN 0..partitions_to_precreate LOOP
       l_part_end := l_part_start + partition_period;
-      
+
       -- Update the available range for the first partition only if we started from metric_timestamp
       IF i = 0 AND l_existing_upper_bound IS NULL THEN
           part_available_from := l_part_start;
@@ -125,19 +106,13 @@ BEGIN
       END IF;
 
       l_time_suffix := to_char(l_part_start, l_partition_format);
-      l_part_name_3rd := format('%s_%s_%s', metric, dbname, l_time_suffix);
+      l_part_name := format('%s_%s', metric, l_time_suffix);
 
-      IF char_length(l_part_name_3rd) > MAX_IDENT_LEN     -- use "dbname" hash instead of name for overly long ones
+      IF to_regclass('subpartitions.' || quote_ident(l_part_name)) IS NULL
       THEN
-          ideal_length = MAX_IDENT_LEN - char_length(format('%s__%s', metric, l_time_suffix));
-          l_part_name_3rd := format('%s_%s_%s', metric, substring(md5(dbname) from 1 for ideal_length), l_time_suffix);
-      END IF;
-
-      IF to_regclass('subpartitions.' || quote_ident(l_part_name_3rd)) IS NULL
-      THEN
-        EXECUTE format('CREATE TABLE subpartitions.%I PARTITION OF subpartitions.%I FOR VALUES FROM ($$%s$$) TO ($$%s$$)',
-                        l_part_name_3rd, l_part_name_2nd, l_part_start, l_part_end);
-        EXECUTE format('COMMENT ON TABLE subpartitions.%I IS $$pgwatch-generated-metric-dbname-time-lvl$$', l_part_name_3rd);
+        EXECUTE format('CREATE TABLE subpartitions.%I PARTITION OF public.%I FOR VALUES FROM ($$%s$$) TO ($$%s$$)',
+                        l_part_name, metric, l_part_start, l_part_end);
+        EXECUTE format('COMMENT ON TABLE subpartitions.%I IS $$pgwatch-generated-metric-time-lvl$$', l_part_name);
       END IF;
 
       l_part_start := l_part_end;
@@ -156,14 +131,12 @@ BEGIN
       JOIN pg_catalog.pg_class parent ON parent.oid = i.inhparent
       WHERE c.relispartition
         AND n.nspname = 'subpartitions'
-        AND parent.relname = l_part_name_2nd
+        AND parent.relname = metric
     ) AS partitions
-    WHERE metric_timestamp >= lower_text::timestamptz 
+    WHERE metric_timestamp >= lower_text::timestamptz
       AND metric_timestamp < upper_text::timestamptz
     LIMIT 1;
   END IF;
-  
+
 END;
 $SQL$ LANGUAGE plpgsql;
-
--- GRANT EXECUTE ON FUNCTION admin.ensure_partition_metric_dbname_time(text,text,timestamp with time zone,interval,integer) TO pgwatch;


### PR DESCRIPTION
- Simplified the partitioning schema by transitioning from 3-level (metric-dbname-time) to 2-level (metric-time) partitioning
    - This solves the performance issues caused by having thousands of partitions for setups with extremely large numbers of monitored databases
- Removed `drop_source_partitions` function
- The schema migration will 
    1. rename the metric table to `*_before_v6_migration`
    2. create a metric table with the original name and time-only partitioning
    3. loop on all partitions for every renamed metric table and:
        1. insert the data into the new table 
        2. detach the partition 
        3. drop it.
    - partitions in the new table will have a `1 day` partitioning interval for the old data.
- Change `--partition-interval` 's default to `1 day`
    
 Closes: #1409 
 Closes: #1392
 
 ---
 
 - Benchmarked the migration time on a sink database with 100 monitored sources, all built-in metrics used (i.e., 80), around 200_000 records, and 501 partitions in each metric table, and it took **1:16:13.67** to run.
     - Bigger setups with thousands of monitored dbs will take much longer.