### PR TITLE
[-] fix `checkpointer` metric

### DIFF
--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -349,7 +349,7 @@ metrics:
             It returns the number of timed and requested checkpoints, restart points, write and sync times, and buffer statistics.
             This metric helps administrators monitor the checkpointer's activity and its impact on database performance.
         sqls:
-            14: "; -- covered by bgwriter"
+            # 14: "; -- covered by bgwriter"
             17: |-
                 select /* pgwatch_generated */
                   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,


### PR DESCRIPTION
For pg sources with version < 17, the checkpointer metric is `14: "; -- covered by bgwriter"` which under the new batching mechanism causes the batch to fail and all subsequent metrics to be retried.

pgwatch logs:
```
2026-05-18 20:23:31.618 [ERROR] [source:test] [sql:; -- covered by bgwriter] [args:[]] [err:pipeline: QueryStatement: received unexpected message type *pgproto3.EmptyQueryResponse] [pid:125807] BatchQuery
2026-05-18 20:23:31.691 [ERROR] [source:test] [err:pipeline: QueryStatement: received unexpected message type *pgproto3.EmptyQueryResponse] [pid:125807] [time:101.102589ms] BatchClose
```

This PR comments this entry out in `metrics.yaml` to avoid 1. that batch failing 2. sending that empty statement over the network to the pg server in the retry.