### PR TITLE
[*] fix log message

### DIFF
--- a/internal/reaper/source_reaper.go
+++ b/internal/reaper/source_reaper.go
@@ -182,7 +182,7 @@ func (sr *SourceReaper) Run(ctx context.Context) {
 				sr.md.RUnlock()
 				sql := metric.GetSQL(version)
 				if sql == "" {
-					l.WithField("source", sr.md.Name).WithField("version", version).Warning("no SQL found for metric version")
+					l.WithField("metric", name).WithField("version", version).Warning("no SQL found for metric version")
 					sr.lastFetch[name] = time.Now()
 					break
 				}


### PR DESCRIPTION
- Include metric name in `no SQL found for metric version` log message, also source name is already included in the `l` logger in lines above.