### PR TITLE
[-] fix deadlock in `SourceReaper`

### DIFF
--- a/docs/reference/cli_env.md
+++ b/docs/reference/cli_env.md
@@ -39,11 +39,6 @@ It reads the configuration from the specified sources and metrics, then begins c
     Smaller size databases will be ignored and not monitored until they reach the threshold (default: 0).  
     ENV: `$PW_MIN_DB_SIZE_MB`
 
-- `--max-parallel-connections-per-db=`
-
-    Max parallel metric fetches per monitored database. Note the multiplication effect on multi-DB instances (default: 4).  
-    ENV: `$PW_MAX_PARALLEL_CONNECTIONS_PER_DB`
-
 - `--try-create-listed-exts-if-missing=`
 
     Try creating the listed extensions (comma sep.) on first connect for all monitored DBs when missing. Main usage - pg_stat_statements.  

--- a/internal/cmdopts/cmdconfig_integration_test.go
+++ b/internal/cmdopts/cmdconfig_integration_test.go
@@ -47,7 +47,7 @@ func TestConfigUpgrade_VerifyNoCircularDependency(t *testing.T) {
 	// After successful upgrade, InitConfigReaders should succeed
 	opts2 := &Options{
 		Metrics: metrics.CmdOpts{Metrics: connStr},
-		Sources: sources.CmdOpts{Sources: connStr, Refresh: 120, MaxParallelConnectionsPerDb: 1},
+		Sources: sources.CmdOpts{Sources: connStr, Refresh: 120},
 		Sinks:   sinks.CmdOpts{Sinks: []string{connStr}},
 	}
 	err = opts2.InitConfigReaders(ctx)

--- a/internal/cmdopts/cmdconfig_test.go
+++ b/internal/cmdopts/cmdconfig_test.go
@@ -305,7 +305,7 @@ func TestConfigUpgradeCommand_Errors(t *testing.T) {
 	t.Run("non-postgres configuration not supported", func(*testing.T) {
 		opts := &Options{
 			Metrics:      metrics.CmdOpts{Metrics: "/tmp/metrics.yaml"},
-			Sources:      sources.CmdOpts{Sources: "/tmp/sources.yaml", Refresh: 120, MaxParallelConnectionsPerDb: 1},
+			Sources:      sources.CmdOpts{Sources: "/tmp/sources.yaml", Refresh: 120},
 			Sinks:        sinks.CmdOpts{},
 			OutputWriter: t.Output(),
 		}
@@ -320,7 +320,7 @@ func TestConfigUpgradeCommand_Errors(t *testing.T) {
 	t.Run("init metrics reader fails", func(*testing.T) {
 		opts := &Options{
 			Metrics:      metrics.CmdOpts{Metrics: "postgresql://invalid@host/db"},
-			Sources:      sources.CmdOpts{Sources: "postgresql://invalid@host/db", Refresh: 120, MaxParallelConnectionsPerDb: 1},
+			Sources:      sources.CmdOpts{Sources: "postgresql://invalid@host/db", Refresh: 120},
 			Sinks:        sinks.CmdOpts{},
 			OutputWriter: t.Output(),
 		}

--- a/internal/cmdopts/cmdoptions.go
+++ b/internal/cmdopts/cmdoptions.go
@@ -207,9 +207,6 @@ func (c *Options) ValidateConfig() error {
 	if c.Sources.Refresh <= 1 {
 		return errors.New("--refresh must be greater than 1")
 	}
-	if c.Sources.MaxParallelConnectionsPerDb < 1 {
-		return errors.New("--max-parallel-connections-per-db must be >= 1")
-	}
 
 	// validate that input is boolean is set
 	if c.Sinks.BatchingDelay <= 0 || c.Sinks.BatchingDelay > time.Hour {

--- a/internal/cmdopts/cmdsource.go
+++ b/internal/cmdopts/cmdsource.go
@@ -58,7 +58,7 @@ func (cmd *SourcePingCommand) Execute(args []string) error {
 			_, e = sources.ResolveDatabasesFromPostgres(s)
 		default:
 			mdb := sources.NewSourceConn(s)
-			e = mdb.Connect(context.Background(), cmd.owner.Sources)
+			e = mdb.Connect(context.Background())
 		}
 		if e != nil {
 			fmt.Printf("FAIL:\t%s (%s)\n", s.Name, e)

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -42,6 +42,7 @@ func NewWithConfig(ctx context.Context, connConfig *pgxpool.Config, callbacks ..
 	if connConfig.ConnConfig.ConnectTimeout == 0 {
 		connConfig.ConnConfig.ConnectTimeout = time.Second * 5
 	}
+	connConfig.MaxConns = 1
 	connConfig.MaxConnIdleTime = 15 * time.Second
 	connConfig.MaxConnLifetime = pgConnRecycleSeconds * time.Second
 	connConfig.ConnConfig.RuntimeParams["application_name"] = applicationName

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -100,7 +100,7 @@ func (r *Reaper) Reap(ctx context.Context) {
 			srcL := logger.WithField("source", monitoredSource.Name)
 			ctx = log.WithLogger(ctx, srcL)
 
-			if monitoredSource.Connect(ctx, r.Sources) != nil {
+			if monitoredSource.Connect(ctx) != nil {
 				r.WriteInstanceDown(monitoredSource.Name)
 				srcL.Warning("could not init connection, retrying on next iteration")
 				continue

--- a/internal/reaper/source_reaper.go
+++ b/internal/reaper/source_reaper.go
@@ -242,7 +242,6 @@ func (sr *SourceReaper) executeBatch(ctx context.Context, entries []batchEntry) 
 	}
 
 	br := sr.md.Conn.SendBatch(ctx, batch)
-	defer func() { _ = br.Close() }()
 
 	var (
 		errs    []error
@@ -256,6 +255,11 @@ func (sr *SourceReaper) executeBatch(ctx context.Context, entries []batchEntry) 
 			continue
 		}
 		errs = append(errs, sr.CollectAndDispatch(ctx, rows, e.name, e.metric))
+	}
+	 
+	// Release the connection before potential retries to avoid deadlocking
+	if err := br.Close(); err != nil {
+		log.GetLogger(ctx).WithError(err).Error("Error executing batch - falling back to sequential execution")
 	}
 
 	for _, e := range retries {

--- a/internal/sources/cmdopts.go
+++ b/internal/sources/cmdopts.go
@@ -6,7 +6,6 @@ type CmdOpts struct {
 	Refresh                      int      `long:"refresh" mapstructure:"refresh" description:"How frequently to resync sources and metrics" env:"PW_REFRESH" default:"120"`
 	Groups                       []string `short:"g" long:"group" mapstructure:"group" description:"Groups for filtering which databases to monitor. By default all are monitored" env:"PW_GROUP"`
 	MinDbSizeMB                  int64    `long:"min-db-size-mb" mapstructure:"min-db-size-mb" description:"Smaller size DBs will be ignored and not monitored until they reach the threshold." env:"PW_MIN_DB_SIZE_MB" default:"0"`
-	MaxParallelConnectionsPerDb  int      `long:"max-parallel-connections-per-db" mapstructure:"max-parallel-connections-per-db" description:"Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances" env:"PW_MAX_PARALLEL_CONNECTIONS_PER_DB" default:"4"`
 	TryCreateListedExtsIfMissing string   `long:"try-create-listed-exts-if-missing" mapstructure:"try-create-listed-exts-if-missing" description:"Try creating the listed extensions (comma sep.) on first connect for all monitored DBs when missing. Main usage - pg_stat_statements" env:"PW_TRY_CREATE_LISTED_EXTS_IF_MISSING" default:""`
 	CreateHelpers                bool     `long:"create-helpers" mapstructure:"create-helpers" description:"Create helper database objects from metric definitions" env:"PW_CREATE_HELPERS"`
 }

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -90,9 +90,6 @@ func (md *SourceConn) Connect(ctx context.Context, opts CmdOpts) (err error) {
 		if md.Kind == SourcePgBouncer {
 			md.ConnConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 		}
-		if opts.MaxParallelConnectionsPerDb > 0 {
-			md.ConnConfig.MaxConns = int32(opts.MaxParallelConnectionsPerDb)
-		}
 		md.Conn, err = NewConnWithConfig(ctx, md.ConnConfig)
 		if err != nil {
 			return err

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -82,7 +82,7 @@ func (md *SourceConn) Ping(ctx context.Context) (err error) {
 
 // Connect will establish a connection to the database if it's not already connected.
 // If the connection is already established, it pings the server to ensure it's still alive.
-func (md *SourceConn) Connect(ctx context.Context, opts CmdOpts) (err error) {
+func (md *SourceConn) Connect(ctx context.Context) (err error) {
 	if md.Conn == nil {
 		if err = md.ParseConfig(); err != nil {
 			return err

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -23,7 +23,7 @@ func TestSourceConn_Connect(t *testing.T) {
 	t.Run("failed config parsing", func(t *testing.T) {
 		md := &sources.SourceConn{}
 		md.ConnStr = "invalid connection string"
-		err := md.Connect(ctx, sources.CmdOpts{})
+		err := md.Connect(ctx)
 		assert.Error(t, err)
 	})
 
@@ -32,7 +32,7 @@ func TestSourceConn_Connect(t *testing.T) {
 		sources.NewConnWithConfig = func(_ context.Context, _ *pgxpool.Config, _ ...db.ConnConfigCallback) (db.PgxPoolIface, error) {
 			return nil, assert.AnError
 		}
-		err := md.Connect(ctx, sources.CmdOpts{})
+		err := md.Connect(ctx)
 		assert.ErrorIs(t, err, assert.AnError)
 	})
 
@@ -46,12 +46,9 @@ func TestSourceConn_Connect(t *testing.T) {
 		md := &sources.SourceConn{}
 		md.Kind = sources.SourcePgBouncer
 
-		opts := sources.CmdOpts{}
-		opts.MaxParallelConnectionsPerDb = 3
-
 		mock.ExpectExec("SHOW VERSION").WillReturnResult(pgconn.NewCommandTag("SELECT 1"))
 
-		err = md.Connect(ctx, opts)
+		err = md.Connect(ctx)
 		assert.NoError(t, err)
 
 		assert.NoError(t, mock.ExpectationsWereMet())


### PR DESCRIPTION
- Ensure the batch releases the connection before any individual retries.
- Use a hardcoded `MaxConns` of 1 for the conn pool and deprecate `--max-parallel-connections-per-db`

Closes: #1412