### PR TITLE
[-] sanitize `NaN/Inf` float values in measurements, fixes #1416

### DIFF
--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"maps"
+	"math"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -97,11 +98,28 @@ func (m *Measurement) ScanRow(rows pgx.Rows) error {
 	if err != nil {
 		return err
 	}
-	// *rs = make(Measurement, len(values))
 	for i := range values {
-		(*m)[string(rows.FieldDescriptions()[i].Name)] = values[i]
+		(*m)[string(rows.FieldDescriptions()[i].Name)] = sanitizeValue(values[i])
 	}
 	return nil
+}
+
+// sanitizeValue replaces non-finite float values with nil so measurements
+// are always safe to marshal to JSON.
+func sanitizeValue(v any) any {
+	var f float64
+	switch val := v.(type) {
+	case float64:
+		f = val
+	case float32:
+		f = float64(val)
+	default:
+		return v
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return nil
+	}
+	return v
 }
 
 func NewMeasurement(epoch int64) Measurement {

--- a/internal/metrics/types_test.go
+++ b/internal/metrics/types_test.go
@@ -2,11 +2,16 @@ package metrics
 
 import (
 	"context"
+	"errors"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v5/internal/log"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var ctx = log.WithLogger(context.Background(), log.NewNoopLogger())
@@ -201,4 +206,66 @@ func TestFilterByNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSanitizeValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  any
+	}{
+		{"float64 NaN", math.NaN(), nil},
+		{"float64 +Inf", math.Inf(1), nil},
+		{"float64 -Inf", math.Inf(-1), nil},
+		{"float64 valid", float64(3.14), float64(3.14)},
+		{"float64 zero", float64(0), float64(0)},
+		{"float32 NaN", float32(math.NaN()), nil},
+		{"float32 +Inf", float32(math.Inf(1)), nil},
+		{"float32 -Inf", float32(math.Inf(-1)), nil},
+		{"float32 valid", float32(1.5), float32(1.5)},
+		{"int64", int64(42), int64(42)},
+		{"string", "hello", "hello"},
+		{"nil", nil, nil},
+		{"bool", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeValue(tt.input))
+		})
+	}
+}
+
+func TestScanRow(t *testing.T) {
+	conn, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer conn.Close()
+
+	conn.ExpectQuery("SELECT").
+		WillReturnRows(pgxmock.NewRows([]string{"epoch_ns", "value", "nan_col", "inf_col"}).
+			AddRow(int64(1000), int64(42), math.NaN(), math.Inf(1)))
+
+	rows, err := conn.Query(context.Background(), "SELECT")
+	require.NoError(t, err)
+
+	data, err := pgx.CollectRows(rows, RowToMeasurement)
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+
+	assert.Equal(t, int64(42), data[0]["value"])
+	assert.Nil(t, data[0]["nan_col"])
+	assert.Nil(t, data[0]["inf_col"])
+	assert.NoError(t, conn.ExpectationsWereMet())
+}
+
+// errRows is a pgx.Rows stub whose Values() returns an error.
+// Other methods are never called on the error path, so the nil
+// embedded interface is safe.
+type errRows struct{ pgx.Rows }
+
+func (e errRows) Values() ([]any, error) { return nil, errors.New("values error") }
+
+func TestScanRowError(t *testing.T) {
+	m := NewMeasurement(0)
+	err := m.ScanRow(errRows{})
+	assert.ErrorContains(t, err, "values error")
 }

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"math"
 	"maps"
 	"slices"
 	"strings"
@@ -284,6 +285,7 @@ type copyFromMeasurements struct {
 	envelopeIdx    int
 	measurementIdx int // index of the current measurement in the envelope
 	metricName     string
+	err            error
 }
 
 func (c *copyFromMeasurements) NextEnvelope() bool {
@@ -333,6 +335,11 @@ func (c *copyFromMeasurements) Values() ([]any, error) {
 		tagRow = make(map[string]string)
 	}
 	for k, v := range row {
+		if floatValue, ok := v.(float64); ok {
+			if math.IsNaN(floatValue) || math.IsInf(floatValue, 0) {
+				row[k] = nil
+			}
+		}
 		if after, ok := strings.CutPrefix(k, metrics.TagPrefix); ok {
 			tagRow[after] = fmt.Sprintf("%v", v)
 			delete(row, k)
@@ -341,13 +348,14 @@ func (c *copyFromMeasurements) Values() ([]any, error) {
 	jsonTags, terr := jsoniter.ConfigFastest.MarshalToString(tagRow)
 	json, err := jsoniter.ConfigFastest.MarshalToString(row)
 	if err != nil || terr != nil {
+		c.err = errors.Join(err, terr)
 		return nil, errors.Join(err, terr)
 	}
 	return []any{time.Unix(0, c.envelopes[c.envelopeIdx].Data.GetEpoch()), c.envelopes[c.envelopeIdx].DBName, json, jsonTags}, nil
 }
 
 func (c *copyFromMeasurements) Err() error {
-	return nil
+	return c.err
 }
 
 func (c *copyFromMeasurements) MetricName() (ident pgx.Identifier) {

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -335,8 +335,14 @@ func (c *copyFromMeasurements) Values() ([]any, error) {
 		tagRow = make(map[string]string)
 	}
 	for k, v := range row {
-		if floatValue, ok := v.(float64); ok {
-			if math.IsNaN(floatValue) || math.IsInf(floatValue, 0) {
+		switch val := v.(type) {
+		case float64:
+			if math.IsNaN(val) || math.IsInf(val, 0) {
+				row[k] = nil
+			}
+		case float32:
+			f := float64(val)
+			if math.IsNaN(f) || math.IsInf(f, 0) {
 				row[k] = nil
 			}
 		}
@@ -349,7 +355,7 @@ func (c *copyFromMeasurements) Values() ([]any, error) {
 	json, err := jsoniter.ConfigFastest.MarshalToString(row)
 	if err != nil || terr != nil {
 		c.err = errors.Join(err, terr)
-		return nil, errors.Join(err, terr)
+		return nil, c.err
 	}
 	return []any{time.Unix(0, c.envelopes[c.envelopeIdx].Data.GetEpoch()), c.envelopes[c.envelopeIdx].DBName, json, jsonTags}, nil
 }

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"math"
 	"maps"
 	"slices"
 	"strings"
@@ -335,17 +334,6 @@ func (c *copyFromMeasurements) Values() ([]any, error) {
 		tagRow = make(map[string]string)
 	}
 	for k, v := range row {
-		switch val := v.(type) {
-		case float64:
-			if math.IsNaN(val) || math.IsInf(val, 0) {
-				row[k] = nil
-			}
-		case float32:
-			f := float64(val)
-			if math.IsNaN(f) || math.IsInf(f, 0) {
-				row[k] = nil
-			}
-		}
 		if after, ok := strings.CutPrefix(k, metrics.TagPrefix); ok {
 			tagRow[after] = fmt.Sprintf("%v", v)
 			delete(row, k)


### PR DESCRIPTION
## Description

When a monitored host has no swap configured (`swap_total = 0`), `get_psutil_mem()` returns NaN for `swap_percent`. 

Two bugs in `copyFromMeasurements` caused this:

1. `Err()` always returned `nil`, hiding marshaling errors from pgx and causing a malformed COPY stream to be sent to PostgreSQL
2. No sanitization of `float64` NaN/Inf values before JSON marshaling

**Fix**: replace NaN/Inf float values with `nil` (JSON `null`) before marshaling in `Values()`, and store marshaling errors in `c.err` so `Err()` returns them correctly to pgx.

Fixes #1416
Related to #908

## AI & Automation Policy
- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used**: A local test file was generated with AI assistance to validate the changes - this file is not included in the PR.

## Checklist
- [x] Code compiles and existing tests pass locally.
- [ ] New or updated tests are included where applicable.
- [ ] Documentation is updated where applicable.