### PR TITLE
[-] handle pg sink being down gracefully, fixes #1426

### DIFF
--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -438,6 +438,10 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 		rowsBatched += n
 		if err != nil {
 			logger.Error(err)
+			if err := pgw.sinkDb.Ping(pgw.ctx); err != nil {
+				logger.WithError(err).Error("Sink db is not reachable, dropping cached measurements")
+				break
+			}
 			if PgError, ok := err.(*pgconn.PgError); ok {
 				pgw.forceRecreatePartitions = PgError.Code == "23514"
 			}

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -438,8 +438,8 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 		rowsBatched += n
 		if err != nil {
 			logger.Error(err)
-			if err := pgw.sinkDb.Ping(pgw.ctx); err != nil {
-				logger.WithError(err).Error("Sink db is not reachable, dropping cached measurements")
+			if _, ok := err.(*pgconn.ConnectError); ok {
+				logger.Errorf("Sink DB not reachable, dropping %d cached measurements", len(msgs))
 				break
 			}
 			if PgError, ok := err.(*pgconn.PgError); ok {

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -1081,3 +1081,39 @@ func TestEnsureMetricDbnameTime_IdempotentAcrossRestarts(t *testing.T) {
 		}
 	}
 }
+
+func TestFlush_CopyFromFailsAndPingSucceeds(t *testing.T) {
+	a := assert.New(t)
+	conn, err := pgxmock.NewPool()
+	a.NoError(err)
+	defer conn.Close()
+
+	pgw := &PostgresWriter{
+		ctx:                      ctx,
+		sinkDb:                   conn,
+		opts:                     &CmdOpts{PartitionInterval: "1 hour"},
+		partitionMapMetricDbname: make(map[string]map[string]ExistingPartitionInfo),
+		metricSchema:             DbStorageSchemaPostgres,
+	}
+
+	now := time.Now()
+	msgs := []metrics.MeasurementEnvelope{
+		{
+			MetricName: "test_metric",
+			Data: metrics.Measurements{
+				{"epoch_ns": now.UnixNano(), "value": 1},
+			},
+			DBName: "test_db",
+		},
+	}
+
+	conn.ExpectQuery("(?i)SELECT.*ensure_partition_metric_dbname_time").
+		WithArgs("test_metric", "test_db", pgxmock.AnyArg(), "1 hour").
+		WillReturnRows(pgxmock.NewRows([]string{"start_time", "end_time"}).AddRow(now.Add(-time.Hour), now.Add(time.Hour)))
+	conn.ExpectCopyFrom(pgx.Identifier{"test_metric"}, targetColumns[:]).WillReturnError(errors.New("copy failed"))
+	conn.ExpectPing().WillReturnError(nil)
+
+	pgw.flush(msgs)
+
+	a.NoError(conn.ExpectationsWereMet())
+}

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -1083,18 +1083,24 @@ func TestEnsureMetricDbnameTime_IdempotentAcrossRestarts(t *testing.T) {
 }
 
 func TestFlush_CopyFromFailsAndPingSucceeds(t *testing.T) {
-	a := assert.New(t)
-	conn, err := pgxmock.NewPool()
-	a.NoError(err)
-	defer conn.Close()
+	r := require.New(t)
 
-	pgw := &PostgresWriter{
-		ctx:                      ctx,
-		sinkDb:                   conn,
-		opts:                     &CmdOpts{PartitionInterval: "1 hour"},
-		partitionMapMetricDbname: make(map[string]map[string]ExistingPartitionInfo),
-		metricSchema:             DbStorageSchemaPostgres,
+	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
+	r.NoError(err)
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	r.NoError(err)
+
+	opts := &CmdOpts{
+		PartitionInterval:   "1 day",
+		RetentionInterval:   "7 days",
+		MaintenanceInterval: "12 hours",
+		BatchingDelay:       time.Second,
 	}
+
+	pgw, err := NewPostgresWriter(ctx, connStr, opts)
+	r.NoError(err)
+	pgTearDown()
 
 	now := time.Now()
 	msgs := []metrics.MeasurementEnvelope{
@@ -1107,13 +1113,5 @@ func TestFlush_CopyFromFailsAndPingSucceeds(t *testing.T) {
 		},
 	}
 
-	conn.ExpectQuery("(?i)SELECT.*ensure_partition_metric_dbname_time").
-		WithArgs("test_metric", "test_db", pgxmock.AnyArg(), "1 hour").
-		WillReturnRows(pgxmock.NewRows([]string{"start_time", "end_time"}).AddRow(now.Add(-time.Hour), now.Add(time.Hour)))
-	conn.ExpectCopyFrom(pgx.Identifier{"test_metric"}, targetColumns[:]).WillReturnError(errors.New("copy failed"))
-	conn.ExpectPing().WillReturnError(nil)
-
 	pgw.flush(msgs)
-
-	a.NoError(conn.ExpectationsWereMet())
 }

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -1082,7 +1082,7 @@ func TestEnsureMetricDbnameTime_IdempotentAcrossRestarts(t *testing.T) {
 	}
 }
 
-func TestFlush_CopyFromFailsAndPingSucceeds(t *testing.T) {
+func TestFlush_SinkDBIsDown(t *testing.T) {
 	r := require.New(t)
 
 	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
@@ -1100,18 +1100,19 @@ func TestFlush_CopyFromFailsAndPingSucceeds(t *testing.T) {
 
 	pgw, err := NewPostgresWriter(ctx, connStr, opts)
 	r.NoError(err)
+	// Bring the sink db down
 	pgTearDown()
 
-	now := time.Now()
 	msgs := []metrics.MeasurementEnvelope{
 		{
 			MetricName: "test_metric",
 			Data: metrics.Measurements{
-				{"epoch_ns": now.UnixNano(), "value": 1},
+				{"epoch_ns": time.Now().UnixNano(), "value": 1},
 			},
 			DBName: "test_db",
 		},
 	}
 
+	// It should return, Issue:#1426 will keep it spinning forever
 	pgw.flush(msgs)
 }


### PR DESCRIPTION
- If `CopyFrom()` fails due to a connection error, assume that the sink DB is down and break from the write loop without writing the metrics.
- The to-be-flushed metrics will be lost and removed from the pgwatch cache.

New behaviour:

Now, pgwatch will issue a retry connection and possibly complain with a connection error once per flush. 

Also, I chose to drop the to-be-written metrics from the pg sink cache so the system doesn't get slow as the measurements accumulate which will then trigger a `highLoadTimeOut` delay (i.e. 5 seconds) for every new measurement added!!!, which won't be good if other sinks are waiting for the data next (e.g, Prometheus or an additional pg sink).

Closes #1426 