### PR TITLE
[*] repurpose `duplicate_count` in `DROP INDEX` recommendations

### DIFF
--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -1510,7 +1510,7 @@ metrics:
                         quote_ident(schemaname)||'.'||quote_ident(indexrelname) as index_full_name,
                         quote_ident(schemaname)||'.'||quote_ident(relname) as table_full_name,
                         pg_relation_size(indexrelid) as index_size_b,
-                        null::int as duplicate_count,
+                        1 as affected_count,
                         array[indexrelid] as oids,
                         null::text as index_def
                     from pg_index
@@ -1526,7 +1526,7 @@ metrics:
                         quote_ident(schemaname)||'.'||quote_ident(indexrelname) as index_full_name,
                         quote_ident(schemaname)||'.'||quote_ident(relname) as table_full_name,
                         pg_relation_size(indexrelid) as index_size_b,
-                        null::int as duplicate_count,
+                        1 as affected_count,
                         array[indexrelid] as oids,
                         null::text as index_def
                     from pg_stat_user_indexes
@@ -1574,7 +1574,7 @@ metrics:
                         null::text as index_full_name,
                         quote_ident(schemaname)||'.'||quote_ident(relid::regclass::text) as table_full_name,
                         dg.max_size_b as index_size_b,
-                        dg.dup_count::int as duplicate_count,
+                        dg.dup_count::int as affected_count,
                         dg.oids,
                         normalized_def::text as index_def
                     from duplicate_groups dg

--- a/internal/metrics/metrics.yaml
+++ b/internal/metrics/metrics.yaml
@@ -1593,7 +1593,7 @@ metrics:
                     table_full_name as tag_table_full_name,
                     index_full_name as tag_object_name,
                     index_size_b,
-                    duplicate_count,
+                    affected_count,
                     oids,
                     index_def
                 from all_recommendations
@@ -1601,7 +1601,7 @@ metrics:
                 limit 100;
         node_status: primary
         gauges:
-            - "duplicate_count"
+            - "affected_count"
             - "index_size_b"
         storage_name: "recommendations"
     reco_nested_views:


### PR DESCRIPTION
## Description

The current query has a usecase-specific column, which semantically doesn't feel right (the usecase is a value like 'duplicate' or 'invalid' whereas the column name is `duplicate_count`.  Also, with the proposed change a query which has looked like

```
WITH q_invalid AS (
  SELECT count(*) as cnt
    FROM recommendations
   WHERE time = (SELECT max(time) 
                   FROM recommendations 
                  WHERE $__timeFilter(time)
                    AND dbname = '$dbname' 
                    AND tag_data->>'reco_topic' = 'drop_index' 
                    AND tag_data->>'issue_type' = 'invalid'
                )
  AND dbname = '$dbname' AND tag_data->>'reco_topic' = 'drop_index' AND tag_data->>'issue_type' = 'invalid'
)
SELECT sum((data->>'duplicate_count')::int8) + (select cnt from q_invalid)::int8
  FROM recommendations
 WHERE time = (
               select max(time)
                 from recommendations
                where $__timeFilter(time)
                  AND dbname = '$dbname' 
                  AND tag_data->>'reco_topic' = 'drop_index' 
                  AND tag_data->>'issue_type' = 'duplicate'
              )
  AND dbname = '$dbname' AND tag_data->>'reco_topic' = 'drop_index' AND tag_data->>'issue_type' = 'duplicate'
```

would turn into the arguably easier to understand

```
WITH collection_time AS (
    SELECT max(time) AS max_time
      FROM recommendations 
     WHERE $__timeFilter(time)
       AND dbname = '$dbname' 
       AND tag_data->>'reco_topic' = 'drop_index'
)
SELECT sum((data->>'affected_count')
  FROM recommendations 
  JOIN collection_time ON time = max_time
 WHERE dbname = '$dbname' 
   AND tag_data->>'reco_topic' = 'drop_index'
   AND tag_data->>'issue_type' IN ('duplicate', 'invalid')
```

## AI & Automation Policy

<!-- See AI_POLICY.md for full terms. All boxes must be checked before this PR can be merged. -->

- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used** _(leave blank if none)_:

<!-- e.g. "Drafted with the assistance of GitHub Copilot", "Issue revealed by Gemini" -->

## Checklist

- [x] Code compiles and existing tests pass locally.
- [x] New or updated tests are included where applicable.
- [x] Documentation is updated where applicable.
