### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/docker/compose.pgpool.yml
+++ b/docker/compose.pgpool.yml
@@ -1,6 +1,6 @@
 services:
   pgpool:
-    image: bitnamilegacy/pgpool:4.6.3
+    image: soldevelo/pgpool:4.6.3
     container_name: pgpool
     ports:
       - "7432:5432"


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnamilegacy/pgpool:4.6.3` → [`soldevelo/pgpool:4.6.3`](https://hub.docker.com/r/soldevelo/pgpool)