### PR TITLE
[-] use random JWT secret instead of hardcoded key

### DIFF
--- a/internal/webserver/jwt.go
+++ b/internal/webserver/jwt.go
@@ -1,8 +1,10 @@
 package webserver
 
 import (
+	"crypto/rand"
 	"errors"
 	"net/http"
+	"sync"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -70,7 +72,36 @@ func NewEnsureAuth(handlerToWrap http.HandlerFunc) *EnsureAuth {
 	return &EnsureAuth{handlerToWrap}
 }
 
-var sampleSecretKey = []byte("5m3R7K4754p4m")
+var (
+	secretKeyOnce sync.Once
+	secretKey     []byte
+)
+
+// jwtSecretKey returns the HS256 signing key used for Web UI/API tokens.
+// The key is a cryptographically random 32-byte value generated once per
+// process at first use. Generating it at runtime (instead of hardcoding a
+// value in the source) prevents attackers from forging valid tokens.
+//
+// The key is intentionally not persisted: every process restart rotates it,
+// which invalidates any previously issued token. This is a security feature,
+// not a limitation - it bounds the lifetime of leaked tokens and forces users
+// to re-authenticate with the configured credentials rather than relying on
+// long-lived sessions.
+//
+// Operational note: because each instance generates its own key, tokens are
+// not portable across instances. Multi-replica/HA deployments should use
+// sticky sessions at the load balancer.
+func jwtSecretKey() []byte {
+	secretKeyOnce.Do(func() {
+		secretKey = make([]byte, 32)
+		if _, err := rand.Read(secretKey); err != nil {
+			// crypto/rand.Read should never fail; if it does there is no safe
+			// way to continue issuing/validating tokens, so fail loudly.
+			panic("webserver: unable to generate JWT secret key: " + err.Error())
+		}
+	})
+	return secretKey
+}
 
 func generateJWT(username string) (string, error) {
 	token := jwt.New(jwt.SigningMethodHS256)
@@ -80,7 +111,7 @@ func generateJWT(username string) (string, error) {
 	claims["username"] = username
 	claims["exp"] = time.Now().Add(time.Hour * 8).Unix()
 
-	return token.SignedString(sampleSecretKey)
+	return token.SignedString(jwtSecretKey())
 }
 
 func validateToken(r *http.Request) (err error) {
@@ -96,7 +127,7 @@ func validateToken(r *http.Request) (err error) {
 
 	_, err = jwt.Parse(t,
 		func(_ *jwt.Token) (any, error) {
-			return sampleSecretKey, nil
+			return jwtSecretKey(), nil
 		},
 		jwt.WithExpirationRequired(),
 		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))

--- a/internal/webserver/jwt_test.go
+++ b/internal/webserver/jwt_test.go
@@ -118,10 +118,30 @@ func TestJWT_Expiration(t *testing.T) {
 	claims["authorized"] = true
 	claims["username"] = "user"
 	claims["exp"] = time.Now().Add(-time.Hour).Unix() // expired
-	token, _ := tok.SignedString(sampleSecretKey)
+	token, _ := tok.SignedString(jwtSecretKey())
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	r.Header.Set("Token", token)
 	err := validateToken(r)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token is expired")
+}
+
+func TestJWTSecretKey_RandomAndStable(t *testing.T) {
+	// It must be at least 32 bytes of entropy and stable within a process.
+	assert.GreaterOrEqual(t, len(jwtSecretKey()), 32)
+	assert.Equal(t, jwtSecretKey(), jwtSecretKey())
+}
+
+func TestValidateToken_RejectsHardcodedKey(t *testing.T) {
+	// A token forged with the old, publicly known key must be rejected.
+	tok := jwt.New(jwt.SigningMethodHS256)
+	claims := tok.Claims.(jwt.MapClaims)
+	claims["authorized"] = false
+	claims["username"] = "intruder"
+	claims["exp"] = time.Now().Add(time.Hour).Unix()
+	forged, err := tok.SignedString([]byte("5m3R7K4754p4m"))
+	assert.NoError(t, err)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Token", forged)
+	assert.Error(t, validateToken(r))
 }


### PR DESCRIPTION
The Web UI/API signed and validated all JWTs with a hardcoded key published in the source, letting anyone forge accepted tokens and bypass authentication.

Generate a random 32-byte HS256 key at startup via `crypto/rand`. Tokens now rotate on every restart, invalidating leaked ones.

