### PR TITLE
[-] fix v12 "Replication lag" panel, closes #1444

### DIFF
--- a/grafana/postgres/v12/1-global-db-overview.json
+++ b/grafana/postgres/v12/1-global-db-overview.json
@@ -2144,7 +2144,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "select\n  $__timeGroup(time, $agg_interval),\n  tag_data->>'application_name'::text as client_info,\n  avg((data->>'total_lag')::bigint) as \" \"\nfrom replication\nwhere dbname in ($dbname) and $__timeFilter(time)\n  and (data->>'total_lag')::bigint > 0\ngroup by 1, 2\norder by 1",
+          "rawSql": "select\n  $__timeGroup(time, $agg_interval),\n  tag_data->>'application_name'::text as client_info,\n  avg((data->>'replay_lag_b')::bigint) as \" \"\nfrom replication\nwhere dbname in ($dbname) and $__timeFilter(time)\n  and (data->>'replay_lag_b')::bigint > 0\ngroup by 1, 2\norder by 1",
           "refId": "A",
           "select": [
             [


### PR DESCRIPTION
## Description

The v12 "Replication lag (byte)" panel (`grafana/postgres/v12/1-global-db-overview.json`) queries `data->>'total_lag'`, but the `replication` metric never emits a `total_lag` field — it provides `sent_lag_b`, `write_lag_b`, `flush_lag_b`, and `replay_lag_b` (`internal/metrics/metrics.yaml`). So `data->>'total_lag'` is always NULL and the panel shows "No data".

This changes the panel to use `replay_lag_b`, which matches the equivalent "Replication lag (bytes)" panel in the v13 dashboard (`grafana/postgres/v13/1-global-database-overview.json`). `total_lag` appears nowhere else in the repository.

The v13 panel additionally drops the `> 0` filter on the `where` clause; I kept the v12 filter as-is and only corrected the field name, to keep this minimal — happy to also drop the filter if you'd prefer to match v13 exactly.

Testing: this is a Grafana dashboard JSON change (no Go code), so compilation and existing Go tests are unaffected. The edited file was validated as well-formed JSON, and `replay_lag_b` was confirmed present in the `replication` metric in `metrics.yaml`. pgwatch has no test harness for dashboard JSON.

Fixes #1444

## AI & Automation Policy

- [x] I am the human author and take full personal responsibility for every change in this PR.
- [x] No AI or automated generative tool was used in any part of this PR **OR** I have disclosed all tool(s) below.

**AI/automation tools used**: Drafted with the assistance of Claude Code; every change was reviewed and verified against the repository before submitting.

## Checklist

- [x] Code compiles and existing tests pass locally. <!-- no Go code changed; dashboard JSON validated as well-formed -->
- [ ] New or updated tests are included where applicable. <!-- pgwatch has no dashboard-JSON test harness -->
- [x] Documentation is updated where applicable.
