### PR TITLE
[-] fix potential race conditions, fixes #1359

### DIFF
--- a/internal/reaper/database.go
+++ b/internal/reaper/database.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v5/internal/log"
@@ -24,10 +25,12 @@ var _ Reaper = (*DbConnReaper)(nil)
 // and batches SQL queries via pgx.Batch when the source is a real Postgres
 // connection (non-pgbouncer, non-pgpool).
 type DbConnReaper struct {
-	reaper          *reaper
-	md              *sources.DbConn
-	lastFetch       map[string]time.Time
-	lastUptimeS     int64               // last seen postmaster_uptime_s for restart detection
+	reaper      *reaper
+	md          *sources.DbConn
+	lastFetch   map[string]time.Time
+	lastUptimeS int64 // last seen postmaster_uptime_s for restart detection
+
+	degradedMu      sync.RWMutex
 	degradedMetrics map[string]struct{} // metrics that failed individual retry; executed via fetchMetric until they recover
 }
 
@@ -39,6 +42,28 @@ func NewDbConnReaper(r *reaper, md *sources.DbConn) *DbConnReaper {
 		lastFetch:       make(map[string]time.Time),
 		degradedMetrics: make(map[string]struct{}),
 	}
+}
+
+// isDegraded reports whether the named metric is in the degraded set.
+func (sr *DbConnReaper) isDegraded(name string) bool {
+	sr.degradedMu.RLock()
+	_, ok := sr.degradedMetrics[name]
+	sr.degradedMu.RUnlock()
+	return ok
+}
+
+// markDegraded adds name to the degraded set.
+func (sr *DbConnReaper) markDegraded(name string) {
+	sr.degradedMu.Lock()
+	sr.degradedMetrics[name] = struct{}{}
+	sr.degradedMu.Unlock()
+}
+
+// clearDegraded removes name from the degraded set.
+func (sr *DbConnReaper) clearDegraded(name string) {
+	sr.degradedMu.Lock()
+	delete(sr.degradedMetrics, name)
+	sr.degradedMu.Unlock()
 }
 
 // activeMetrics returns a snapshot copy of the currently active metric intervals
@@ -189,12 +214,12 @@ func (sr *DbConnReaper) Reap(ctx context.Context) {
 					sr.lastFetch[name] = time.Now()
 					break
 				}
-				if _, degraded := sr.degradedMetrics[name]; degraded {
+				if sr.isDegraded(name) {
 					if err = sr.fetchMetric(ctx, batchEntry{metricName: name, metric: metric, sql: sql}); err != nil {
 						l.WithError(err).WithField("metric", name).Error("degraded metric fetch failed")
 					} else {
 						l.WithField("metric", name).Info("degraded metric recovered, returning to batch execution")
-						delete(sr.degradedMetrics, name)
+						sr.clearDegraded(name)
 					}
 					sr.lastFetch[name] = time.Now()
 					break
@@ -263,9 +288,9 @@ func (sr *DbConnReaper) executeBatch(ctx context.Context, entries []batchEntry) 
 
 	for _, e := range retries {
 		if err := sr.fetchMetric(ctx, e); err != nil {
-		errs = append(errs, fmt.Errorf("failed to fetch metric %s: %v", e.metricName, err))
-		log.GetLogger(ctx).WithField("metric", e.metricName).Warning("metric degraded after repeated failures, switching to individual fetch")
-		sr.degradedMetrics[e.metricName] = struct{}{}
+			errs = append(errs, fmt.Errorf("failed to fetch metric %s: %v", e.metricName, err))
+			log.GetLogger(ctx).WithField("metric", e.metricName).Warning("metric degraded after repeated failures, switching to individual fetch")
+			sr.markDegraded(e.metricName)
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/reaper/database_integration_test.go
+++ b/internal/reaper/database_integration_test.go
@@ -226,10 +226,12 @@ func TestIntegration_SourceReaper_RunExcludesMetricsByNodeStatus(t *testing.T) {
 		for _, state := range states {
 			ctx, cancel := context.WithCancel(log.WithLogger(context.Background(), log.NewNoopLogger()))
 
-			md.IsInRecovery = true
-			if state == "standby" {
-				md.IsInRecovery = false
-			}
+		md.Lock()
+		md.IsInRecovery = true
+		if state == "standby" {
+			md.IsInRecovery = false
+		}
+		md.Unlock()
 
 			helperSetNodeStatus(state)
 
@@ -253,10 +255,12 @@ func TestIntegration_SourceReaper_RunExcludesMetricsByNodeStatus(t *testing.T) {
 		for _, state := range states {
 			ctx, cancel := context.WithCancel(log.WithLogger(context.Background(), log.NewNoopLogger()))
 
-			md.IsInRecovery = false
-			if state == "standby" {
-				md.IsInRecovery = true
-			}
+		md.Lock()
+		md.IsInRecovery = false
+		if state == "standby" {
+			md.IsInRecovery = true
+		}
+		md.Unlock()
 
 			helperSetNodeStatus(state)
 

--- a/internal/reaper/database_test.go
+++ b/internal/reaper/database_test.go
@@ -967,7 +967,7 @@ func TestSourceReaper_DegradedMetricRecovery(t *testing.T) {
 		}
 		ctx := log.WithLogger(t.Context(), log.NewNoopLogger())
 		sr := NewDbConnReaper(r, md)
-		sr.degradedMetrics[metricName] = struct{}{} // pre-seed: metric already degraded
+		sr.markDegraded(metricName) // pre-seed: metric already degraded
 
 		// Iteration 1: FetchRuntimeInfo + degraded individual fetch → fails → stays degraded
 		mock.ExpectQuery("select /\\* pgwatch_generated \\*/").WillReturnError(assert.AnError)
@@ -983,14 +983,14 @@ func TestSourceReaper_DegradedMetricRecovery(t *testing.T) {
 		// Run goroutine completes iteration 1 (pgxmock is in-memory, no real I/O) then
 		// blocks on time.After — the only durably-blocking operation in the loop.
 		synctest.Wait()
-		assert.Contains(t, sr.degradedMetrics, metricName, "should still be degraded after first failure")
+		assert.True(t, sr.isDegraded(metricName), "should still be degraded after first failure")
 
 		// Advance the fake clock past the interval to trigger iteration 2.
 		// The Run goroutine's time.After(30s) fires first; it runs iteration 2 and
 		// blocks again before the test goroutine's sleep finishes.
 		time.Sleep(time.Duration(metricInterval)*time.Second + time.Millisecond)
 		synctest.Wait()
-		assert.NotContains(t, sr.degradedMetrics, metricName, "should recover after successful fetchMetric")
+		assert.False(t, sr.isDegraded(metricName), "should recover after successful fetchMetric")
 
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})

--- a/internal/reaper/logparser.go
+++ b/internal/reaper/logparser.go
@@ -43,6 +43,7 @@ type LogParser struct {
 	ctx              context.Context
 	LogsMatchRegex   *regexp.Regexp
 	SourceConn       *sources.DbConn
+	realDbname       string // snapshot of SourceConn.RealDbname at construction time (avoids lock per log line)
 	Interval         time.Duration
 	StoreCh          chan<- metrics.MeasurementEnvelope
 	eventCounts      map[string]int64 // for the specific DB. [WARNING: 34, ERROR: 10, ...], zeroed on storage send
@@ -83,10 +84,14 @@ func NewLogParser(ctx context.Context, mdb *sources.DbConn, storeCh chan<- metri
 
 	logger.Debugf("Considering log files in folder: %s", cfg.Directory)
 
+	mdb.RLock()
+	realDbname := mdb.RealDbname
+	mdb.RUnlock()
 	return &LogParser{
 		ctx:              ctx,
 		LogsMatchRegex:   logsRegex,
 		SourceConn:       mdb,
+		realDbname:       realDbname,
 		Interval:         mdb.GetMetricInterval(specialMetricServerLogEventCounts),
 		StoreCh:          storeCh,
 		LogConfig:        cfg,

--- a/internal/reaper/logparser_local.go
+++ b/internal/reaper/logparser_local.go
@@ -148,7 +148,7 @@ func (lp *LogParser) parseLogsLocal() error {
 					time.Sleep(time.Minute)
 					break
 				}
-				if lp.SourceConn.RealDbname == databaseName {
+			if lp.realDbname == databaseName {
 					lp.eventCounts[errorSeverity]++
 				}
 				lp.eventCountsTotal[errorSeverity]++

--- a/internal/reaper/logparser_remote.go
+++ b/internal/reaper/logparser_remote.go
@@ -119,7 +119,7 @@ func (lp *LogParser) parseLogsRemote() error {
 					}
 
 					databaseName := result["database_name"]
-					if lp.SourceConn.RealDbname == databaseName {
+				if lp.realDbname == databaseName {
 						lp.eventCounts[errorSeverity]++
 					}
 					lp.eventCountsTotal[errorSeverity]++

--- a/internal/reaper/logparser_test.go
+++ b/internal/reaper/logparser_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -824,4 +825,50 @@ incomplete line without proper fields
 			// Also acceptable: no measurement sent at all
 		}
 	})
+}
+
+// TestRace_LogParserRealDbname verifies that concurrent FetchRuntimeInfo writes to
+// RealDbname and logparser reads of lp.realDbname do not cause a data race.
+// lp.realDbname is snapshotted at LogParser construction time, so only the
+// constructor call itself must be protected (via RLock in NewLogParser).
+func TestRace_LogParserRealDbname(t *testing.T) {
+	md := sources.NewDbConn(sources.Source{Name: "race-test"})
+
+	// Construct a LogParser directly (no DB needed) reusing the internal struct.
+	lp := &LogParser{
+		LogConfig:        &LogConfig{},
+		ctx:              t.Context(),
+		LogsMatchRegex:   regexp.MustCompile(csvLogDefaultRegEx),
+		SourceConn:       md,
+		realDbname:       "initial",
+		Interval:         time.Second,
+		StoreCh:          make(chan metrics.MeasurementEnvelope, 1),
+		eventCounts:      make(map[string]int64),
+		eventCountsTotal: make(map[string]int64),
+		fileOffsets:      make(map[string]uint64),
+	}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: simulate FetchRuntimeInfo updating RealDbname under Lock.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			md.Lock()
+			md.RealDbname = "updateddb"
+			md.Unlock()
+		}
+	}()
+
+	// Reader: logparser reads lp.realDbname (a plain string copy, no lock needed after construction).
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = lp.realDbname
+		}
+	}()
+
+	wg.Wait()
 }

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -134,7 +134,7 @@ func (r *reaper) Reap(ctx context.Context) {
 				md.RLock()
 				isInRecovery := md.IsInRecovery
 				versionStr := md.VersionStr
-				approxDbSize := md.ApproxDbSize
+				DBSizeMB := md.ApproxDbSize / 1048576
 				var metricsConfig metrics.MetricIntervals
 				if md.IsInRecovery && len(md.MetricsStandby) > 0 {
 					metricsConfig = maps.Clone(md.MetricsStandby)
@@ -156,7 +156,7 @@ func (r *reaper) Reap(ctx context.Context) {
 				r.CreateSourceHelpers(ctx, srcL, md)
 
 				if md.IsPostgresSource() {
-					DBSizeMB := approxDbSize / 1048576 // only remove from monitoring when we're certain it's under the threshold
+					// only remove from monitoring when we're certain it's under the threshold
 					if DBSizeMB != 0 && DBSizeMB < r.Sources.MinDbSizeMB {
 						srcL.Infof("ignored due to the --min-db-size-mb filter, current size %d MB", DBSizeMB)
 						hostsToShutDownDueToRoleChange[src.Name] = true // for the case when DB size was previously above the threshold

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -223,7 +223,10 @@ func (r *reaper) CreateSourceHelpers(ctx context.Context, srcL log.Logger, monit
 	if r.prevLoopMonitoredDBs.GetMonitoredDatabase(monitoredSource.Name) != nil {
 		return // already created
 	}
-	if !monitoredSource.IsPostgresSource() || monitoredSource.IsInRecovery {
+	monitoredSource.RLock()
+	isInRecovery := monitoredSource.IsInRecovery
+	monitoredSource.RUnlock()
+	if !monitoredSource.IsPostgresSource() || isInRecovery {
 		return // no need to create anything for non-postgres sources
 	}
 
@@ -360,12 +363,16 @@ func (r *reaper) WriteMeasurements(ctx context.Context) {
 }
 
 func (r *reaper) AddSysinfoToMeasurements(data metrics.Measurements, md *sources.DbConn) {
+	md.RLock()
+	realDbname := md.RealDbname
+	systemIdentifier := md.SystemIdentifier
+	md.RUnlock()
 	for _, dr := range data {
-		if r.Sinks.RealDbnameField > "" && md.RealDbname > "" {
-			dr[r.Sinks.RealDbnameField] = md.RealDbname
+		if r.Sinks.RealDbnameField > "" && realDbname > "" {
+			dr[r.Sinks.RealDbnameField] = realDbname
 		}
-		if r.Sinks.SystemIdentifierField > "" && md.SystemIdentifier > "" {
-			dr[r.Sinks.SystemIdentifierField] = md.SystemIdentifier
+		if r.Sinks.SystemIdentifierField > "" && systemIdentifier > "" {
+			dr[r.Sinks.SystemIdentifierField] = systemIdentifier
 		}
 	}
 }

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -123,96 +123,96 @@ func (r *reaper) Reap(ctx context.Context) {
 			}
 
 			switch md := monitoredSource.(type) {
-		case *sources.DbConn:
-			if err = md.FetchRuntimeInfo(ctx, true); err != nil {
-				srcL.WithError(err).Error("could not start metric gathering")
-				continue
-			}
+			case *sources.DbConn:
+				if err = md.FetchRuntimeInfo(ctx, true); err != nil {
+					srcL.WithError(err).Error("could not start metric gathering")
+					continue
+				}
 
-			// Snapshot mutable RuntimeInfo fields under RLock so subsequent reads
-			// in this iteration are consistent and race-free against the per-source
-			// DbConnReaper goroutine calling FetchRuntimeInfo concurrently.
-			md.RLock()
-			isInRecovery := md.IsInRecovery
-			versionStr := md.VersionStr
-			approxDbSize := md.ApproxDbSize
-			var metricsMain, metricsStandby metrics.MetricIntervals
-			if md.Metrics != nil {
-				metricsMain = maps.Clone(md.Metrics)
-			}
-			if md.MetricsStandby != nil {
-				metricsStandby = maps.Clone(md.MetricsStandby)
-			}
-			md.RUnlock()
+				// Snapshot mutable RuntimeInfo fields under RLock so subsequent reads
+				// in this iteration are consistent and race-free against the per-source
+				// DbConnReaper goroutine calling FetchRuntimeInfo concurrently.
+				md.RLock()
+				isInRecovery := md.IsInRecovery
+				versionStr := md.VersionStr
+				approxDbSize := md.ApproxDbSize
+				var metricsMain, metricsStandby metrics.MetricIntervals
+				if md.Metrics != nil {
+					metricsMain = maps.Clone(md.Metrics)
+				}
+				if md.MetricsStandby != nil {
+					metricsStandby = maps.Clone(md.MetricsStandby)
+				}
+				md.RUnlock()
 
-			srcL.WithField("recovery", isInRecovery).Infof("Connect OK. Version: %s", versionStr)
-			if isInRecovery && md.OnlyIfMaster {
-				srcL.Info("not added to monitoring due to 'master only' property")
+				srcL.WithField("recovery", isInRecovery).Infof("Connect OK. Version: %s", versionStr)
+				if isInRecovery && md.OnlyIfMaster {
+					srcL.Info("not added to monitoring due to 'master only' property")
+					if md.IsPostgresSource() {
+						srcL.Info("to be removed from monitoring due to 'master only' property and status change")
+						hostsToShutDownDueToRoleChange[src.Name] = true
+					}
+					continue
+				}
+
+				if isInRecovery && len(metricsStandby) > 0 {
+					metricsConfig = metricsStandby
+				} else {
+					metricsConfig = metricsMain
+				}
+
+				r.CreateSourceHelpers(ctx, srcL, md)
+
 				if md.IsPostgresSource() {
-					srcL.Info("to be removed from monitoring due to 'master only' property and status change")
-					hostsToShutDownDueToRoleChange[src.Name] = true
-				}
-				continue
-			}
-
-			if isInRecovery && len(metricsStandby) > 0 {
-				metricsConfig = metricsStandby
-			} else {
-				metricsConfig = metricsMain
-			}
-
-			r.CreateSourceHelpers(ctx, srcL, md)
-
-			if md.IsPostgresSource() {
-				DBSizeMB := approxDbSize / 1048576 // only remove from monitoring when we're certain it's under the threshold
-				if DBSizeMB != 0 && DBSizeMB < r.Sources.MinDbSizeMB {
-					srcL.Infof("ignored due to the --min-db-size-mb filter, current size %d MB", DBSizeMB)
-					hostsToShutDownDueToRoleChange[src.Name] = true // for the case when DB size was previously above the threshold
-					continue
-				}
-
-				lastKnownStatusInRecovery := hostLastKnownStatusInRecovery[src.Name]
-				if lastKnownStatusInRecovery != isInRecovery {
-					if isInRecovery && len(metricsStandby) > 0 {
-						srcL.Warning("Switching metrics collection to standby config...")
-						metricsConfig = metricsStandby
-					} else if !isInRecovery {
-						srcL.Warning("Switching metrics collection to primary config...")
-						metricsConfig = metricsMain
+					DBSizeMB := approxDbSize / 1048576 // only remove from monitoring when we're certain it's under the threshold
+					if DBSizeMB != 0 && DBSizeMB < r.Sources.MinDbSizeMB {
+						srcL.Infof("ignored due to the --min-db-size-mb filter, current size %d MB", DBSizeMB)
+						hostsToShutDownDueToRoleChange[src.Name] = true // for the case when DB size was previously above the threshold
+						continue
 					}
-					// else: it already has primary config do nothing + no warn
-				}
-			}
-			hostLastKnownStatusInRecovery[src.Name] = isInRecovery
 
-			// Sync metric names with sinks for the active config
-			for metricName := range metricsConfig {
-				mvp, metricDefExists := metricDefs.GetMetricDef(metricName)
-				if !metricDefExists {
-					epoch, ok := lastSQLFetchError.Load(metricName)
-					if !ok || ((time.Now().Unix() - epoch.(int64)) > 3600) {
-						srcL.WithField("metric", metricName).Warning("metric definition not found")
-						lastSQLFetchError.Store(metricName, time.Now().Unix())
+					lastKnownStatusInRecovery := hostLastKnownStatusInRecovery[src.Name]
+					if lastKnownStatusInRecovery != isInRecovery {
+						if isInRecovery && len(metricsStandby) > 0 {
+							srcL.Warning("Switching metrics collection to standby config...")
+							metricsConfig = metricsStandby
+						} else if !isInRecovery {
+							srcL.Warning("Switching metrics collection to primary config...")
+							metricsConfig = metricsMain
+						}
+						// else: it already has primary config do nothing + no warn
 					}
-					continue
 				}
-				metricNameForStorage := metricName
-				if _, isSpecialMetric := specialMetrics[metricName]; !isSpecialMetric && mvp.StorageName > "" {
-					metricNameForStorage = mvp.StorageName
-				}
-				if err := r.SinksWriter.SyncMetric(src.Name, metricNameForStorage, sinks.AddOp); err != nil {
-					srcL.Error(err)
-				}
-			}
+				hostLastKnownStatusInRecovery[src.Name] = isInRecovery
 
-			// Start SourceReaper for this source if not already running
-			if _, exists := r.cancelFuncs[src.Name]; !exists {
-				srcL.Info("starting source reaper")
-				sr := NewDbConnReaper(r, md)
-				sourceCtx, cancelFunc := context.WithCancel(ctx)
-				r.cancelFuncs[src.Name] = cancelFunc
-				go sr.Reap(sourceCtx)
-			}
+				// Sync metric names with sinks for the active config
+				for metricName := range metricsConfig {
+					mvp, metricDefExists := metricDefs.GetMetricDef(metricName)
+					if !metricDefExists {
+						epoch, ok := lastSQLFetchError.Load(metricName)
+						if !ok || ((time.Now().Unix() - epoch.(int64)) > 3600) {
+							srcL.WithField("metric", metricName).Warning("metric definition not found")
+							lastSQLFetchError.Store(metricName, time.Now().Unix())
+						}
+						continue
+					}
+					metricNameForStorage := metricName
+					if _, isSpecialMetric := specialMetrics[metricName]; !isSpecialMetric && mvp.StorageName > "" {
+						metricNameForStorage = mvp.StorageName
+					}
+					if err := r.SinksWriter.SyncMetric(src.Name, metricNameForStorage, sinks.AddOp); err != nil {
+						srcL.Error(err)
+					}
+				}
+
+				// Start SourceReaper for this source if not already running
+				if _, exists := r.cancelFuncs[src.Name]; !exists {
+					srcL.Info("starting source reaper")
+					sr := NewDbConnReaper(r, md)
+					sourceCtx, cancelFunc := context.WithCancel(ctx)
+					r.cancelFuncs[src.Name] = cancelFunc
+					go sr.Reap(sourceCtx)
+				}
 			case *sources.PromConn:
 				if _, exists := r.cancelFuncs[src.Name]; !exists {
 					srcL.Info("starting prometheus source reaper")

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -2,6 +2,7 @@ package reaper
 
 import (
 	"context"
+	"maps"
 	"runtime"
 	"slices"
 	"strings"
@@ -122,79 +123,96 @@ func (r *reaper) Reap(ctx context.Context) {
 			}
 
 			switch md := monitoredSource.(type) {
-			case *sources.DbConn:
-				if err = md.FetchRuntimeInfo(ctx, true); err != nil {
-					srcL.WithError(err).Error("could not start metric gathering")
-					continue
-				}
-				srcL.WithField("recovery", md.IsInRecovery).Infof("Connect OK. Version: %s", md.VersionStr)
-				if md.IsInRecovery && md.OnlyIfMaster {
-					srcL.Info("not added to monitoring due to 'master only' property")
-					if md.IsPostgresSource() {
-						srcL.Info("to be removed from monitoring due to 'master only' property and status change")
-						hostsToShutDownDueToRoleChange[src.Name] = true
-					}
-					continue
-				}
+		case *sources.DbConn:
+			if err = md.FetchRuntimeInfo(ctx, true); err != nil {
+				srcL.WithError(err).Error("could not start metric gathering")
+				continue
+			}
 
-				if md.IsInRecovery && len(md.MetricsStandby) > 0 {
-					metricsConfig = md.MetricsStandby
-				} else {
-					metricsConfig = md.Metrics
-				}
+			// Snapshot mutable RuntimeInfo fields under RLock so subsequent reads
+			// in this iteration are consistent and race-free against the per-source
+			// DbConnReaper goroutine calling FetchRuntimeInfo concurrently.
+			md.RLock()
+			isInRecovery := md.IsInRecovery
+			versionStr := md.VersionStr
+			approxDbSize := md.ApproxDbSize
+			var metricsMain, metricsStandby metrics.MetricIntervals
+			if md.Metrics != nil {
+				metricsMain = maps.Clone(md.Metrics)
+			}
+			if md.MetricsStandby != nil {
+				metricsStandby = maps.Clone(md.MetricsStandby)
+			}
+			md.RUnlock()
 
-				r.CreateSourceHelpers(ctx, srcL, md)
-
+			srcL.WithField("recovery", isInRecovery).Infof("Connect OK. Version: %s", versionStr)
+			if isInRecovery && md.OnlyIfMaster {
+				srcL.Info("not added to monitoring due to 'master only' property")
 				if md.IsPostgresSource() {
-					DBSizeMB := md.ApproxDbSize / 1048576 // only remove from monitoring when we're certain it's under the threshold
-					if DBSizeMB != 0 && DBSizeMB < r.Sources.MinDbSizeMB {
-						srcL.Infof("ignored due to the --min-db-size-mb filter, current size %d MB", DBSizeMB)
-						hostsToShutDownDueToRoleChange[src.Name] = true // for the case when DB size was previously above the threshold
-						continue
-					}
-
-					lastKnownStatusInRecovery := hostLastKnownStatusInRecovery[src.Name]
-					if lastKnownStatusInRecovery != md.IsInRecovery {
-						if md.IsInRecovery && len(md.MetricsStandby) > 0 {
-							srcL.Warning("Switching metrics collection to standby config...")
-							metricsConfig = md.MetricsStandby
-						} else if !md.IsInRecovery {
-							srcL.Warning("Switching metrics collection to primary config...")
-							metricsConfig = md.Metrics
-						}
-						// else: it already has primary config do nothing + no warn
-					}
+					srcL.Info("to be removed from monitoring due to 'master only' property and status change")
+					hostsToShutDownDueToRoleChange[src.Name] = true
 				}
-				hostLastKnownStatusInRecovery[src.Name] = md.IsInRecovery
+				continue
+			}
 
-				// Sync metric names with sinks for the active config
-				for metricName := range metricsConfig {
-					mvp, metricDefExists := metricDefs.GetMetricDef(metricName)
-					if !metricDefExists {
-						epoch, ok := lastSQLFetchError.Load(metricName)
-						if !ok || ((time.Now().Unix() - epoch.(int64)) > 3600) {
-							srcL.WithField("metric", metricName).Warning("metric definition not found")
-							lastSQLFetchError.Store(metricName, time.Now().Unix())
-						}
-						continue
-					}
-					metricNameForStorage := metricName
-					if _, isSpecialMetric := specialMetrics[metricName]; !isSpecialMetric && mvp.StorageName > "" {
-						metricNameForStorage = mvp.StorageName
-					}
-					if err := r.SinksWriter.SyncMetric(src.Name, metricNameForStorage, sinks.AddOp); err != nil {
-						srcL.Error(err)
-					}
+			if isInRecovery && len(metricsStandby) > 0 {
+				metricsConfig = metricsStandby
+			} else {
+				metricsConfig = metricsMain
+			}
+
+			r.CreateSourceHelpers(ctx, srcL, md)
+
+			if md.IsPostgresSource() {
+				DBSizeMB := approxDbSize / 1048576 // only remove from monitoring when we're certain it's under the threshold
+				if DBSizeMB != 0 && DBSizeMB < r.Sources.MinDbSizeMB {
+					srcL.Infof("ignored due to the --min-db-size-mb filter, current size %d MB", DBSizeMB)
+					hostsToShutDownDueToRoleChange[src.Name] = true // for the case when DB size was previously above the threshold
+					continue
 				}
 
-				// Start SourceReaper for this source if not already running
-				if _, exists := r.cancelFuncs[src.Name]; !exists {
-					srcL.Info("starting source reaper")
-					sr := NewDbConnReaper(r, md)
-					sourceCtx, cancelFunc := context.WithCancel(ctx)
-					r.cancelFuncs[src.Name] = cancelFunc
-					go sr.Reap(sourceCtx)
+				lastKnownStatusInRecovery := hostLastKnownStatusInRecovery[src.Name]
+				if lastKnownStatusInRecovery != isInRecovery {
+					if isInRecovery && len(metricsStandby) > 0 {
+						srcL.Warning("Switching metrics collection to standby config...")
+						metricsConfig = metricsStandby
+					} else if !isInRecovery {
+						srcL.Warning("Switching metrics collection to primary config...")
+						metricsConfig = metricsMain
+					}
+					// else: it already has primary config do nothing + no warn
 				}
+			}
+			hostLastKnownStatusInRecovery[src.Name] = isInRecovery
+
+			// Sync metric names with sinks for the active config
+			for metricName := range metricsConfig {
+				mvp, metricDefExists := metricDefs.GetMetricDef(metricName)
+				if !metricDefExists {
+					epoch, ok := lastSQLFetchError.Load(metricName)
+					if !ok || ((time.Now().Unix() - epoch.(int64)) > 3600) {
+						srcL.WithField("metric", metricName).Warning("metric definition not found")
+						lastSQLFetchError.Store(metricName, time.Now().Unix())
+					}
+					continue
+				}
+				metricNameForStorage := metricName
+				if _, isSpecialMetric := specialMetrics[metricName]; !isSpecialMetric && mvp.StorageName > "" {
+					metricNameForStorage = mvp.StorageName
+				}
+				if err := r.SinksWriter.SyncMetric(src.Name, metricNameForStorage, sinks.AddOp); err != nil {
+					srcL.Error(err)
+				}
+			}
+
+			// Start SourceReaper for this source if not already running
+			if _, exists := r.cancelFuncs[src.Name]; !exists {
+				srcL.Info("starting source reaper")
+				sr := NewDbConnReaper(r, md)
+				sourceCtx, cancelFunc := context.WithCancel(ctx)
+				r.cancelFuncs[src.Name] = cancelFunc
+				go sr.Reap(sourceCtx)
+			}
 			case *sources.PromConn:
 				if _, exists := r.cancelFuncs[src.Name]; !exists {
 					srcL.Info("starting prometheus source reaper")

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -137,12 +137,8 @@ func (r *reaper) Reap(ctx context.Context) {
 				versionStr := md.VersionStr
 				approxDbSize := md.ApproxDbSize
 				var metricsMain, metricsStandby metrics.MetricIntervals
-				if md.Metrics != nil {
-					metricsMain = maps.Clone(md.Metrics)
-				}
-				if md.MetricsStandby != nil {
-					metricsStandby = maps.Clone(md.MetricsStandby)
-				}
+				metricsMain = maps.Clone(md.Metrics)
+				metricsStandby = maps.Clone(md.MetricsStandby)
 				md.RUnlock()
 
 				srcL.WithField("recovery", isInRecovery).Infof("Connect OK. Version: %s", versionStr)

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -135,9 +135,12 @@ func (r *reaper) Reap(ctx context.Context) {
 				isInRecovery := md.IsInRecovery
 				versionStr := md.VersionStr
 				approxDbSize := md.ApproxDbSize
-				var metricsMain, metricsStandby metrics.MetricIntervals
-				metricsMain = maps.Clone(md.Metrics)
-				metricsStandby = maps.Clone(md.MetricsStandby)
+				var metricsConfig metrics.MetricIntervals
+				if md.IsInRecovery && len(md.MetricsStandby) > 0 {
+					metricsConfig = maps.Clone(md.MetricsStandby)
+				} else {
+					metricsConfig = maps.Clone(md.Metrics)
+				}
 				md.RUnlock()
 
 				srcL.WithField("recovery", isInRecovery).Infof("Connect OK. Version: %s", versionStr)
@@ -148,12 +151,6 @@ func (r *reaper) Reap(ctx context.Context) {
 						hostsToShutDownDueToRoleChange[src.Name] = true
 					}
 					continue
-				}
-				var metricsConfig metrics.MetricIntervals
-				if md.IsInRecovery && len(md.MetricsStandby) > 0 {
-					metricsConfig = md.MetricsStandby
-				} else {
-					metricsConfig = metricsMain
 				}
 
 				r.CreateSourceHelpers(ctx, srcL, md)

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/cybertec-postgresql/pgwatch/v5/internal/cmdopts"
@@ -564,4 +565,77 @@ func TestReaper_PrintMemStats(t *testing.T) {
 	ctx := log.WithLogger(t.Context(), log.NewNoopLogger())
 	r := newReaper(ctx, &cmdopts.Options{})
 	assert.NotPanics(t, r.PrintMemStats)
+}
+
+// TestRace_AddSysinfoToMeasurements verifies no data race between concurrent
+// RuntimeInfo writes (simulating FetchRuntimeInfo) and AddSysinfoToMeasurements reads.
+func TestRace_AddSysinfoToMeasurements(t *testing.T) {
+	r := &reaper{
+		Options: &cmdopts.Options{
+			Sinks: sinks.CmdOpts{
+				RealDbnameField:       "real_dbname",
+				SystemIdentifierField: "sys_id",
+			},
+		},
+	}
+	md := sources.NewDbConn(sources.Source{Name: "race-test"})
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: simulate FetchRuntimeInfo updating RuntimeInfo fields under Lock.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			md.Lock()
+			md.RealDbname = "realdb"
+			md.SystemIdentifier = "12345"
+			md.Unlock()
+		}
+	}()
+
+	// Reader: AddSysinfoToMeasurements must RLock before reading.
+	go func() {
+		defer wg.Done()
+		data := metrics.Measurements{metrics.Measurement{}}
+		for range iterations {
+			r.AddSysinfoToMeasurements(data, md)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestRace_CreateSourceHelpers verifies no data race between concurrent
+// RuntimeInfo writes and CreateSourceHelpers reading IsInRecovery.
+func TestRace_CreateSourceHelpers(t *testing.T) {
+	ctx := log.WithLogger(t.Context(), log.NewNoopLogger())
+	r := newReaper(ctx, &cmdopts.Options{})
+	md := sources.NewDbConn(sources.Source{
+		Name: "race-test",
+		Kind: sources.SourcePostgres,
+	})
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			md.Lock()
+			md.IsInRecovery = !md.IsInRecovery
+			md.Unlock()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			r.CreateSourceHelpers(ctx, r.logger, md)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -570,7 +570,7 @@ func TestReaper_PrintMemStats(t *testing.T) {
 
 // TestRace_AddSysinfoToMeasurements verifies no data race between concurrent
 // RuntimeInfo writes (simulating FetchRuntimeInfo) and AddSysinfoToMeasurements reads.
-func TestRace_AddSysinfoToMeasurements(t *testing.T) {
+func TestRace_AddSysinfoToMeasurements(*testing.T) {
 	r := &reaper{
 		Options: &cmdopts.Options{
 			Sinks: sinks.CmdOpts{
@@ -644,7 +644,7 @@ func TestRace_CreateSourceHelpers(t *testing.T) {
 // TestRace_MainLoopRuntimeInfoSnapshot verifies that the main reaper loop's
 // RLock snapshot of IsInRecovery, VersionStr, ApproxDbSize, Metrics, and
 // MetricsStandby does not race against concurrent FetchRuntimeInfo writes.
-func TestRace_MainLoopRuntimeInfoSnapshot(t *testing.T) {
+func TestRace_MainLoopRuntimeInfoSnapshot(*testing.T) {
 	md := sources.NewDbConn(sources.Source{
 		Name: "race-test",
 		Kind: sources.SourcePostgres,

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -3,6 +3,7 @@ package reaper
 import (
 	"context"
 	"errors"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -634,6 +635,54 @@ func TestRace_CreateSourceHelpers(t *testing.T) {
 		defer wg.Done()
 		for range iterations {
 			r.CreateSourceHelpers(ctx, r.logger, md)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestRace_MainLoopRuntimeInfoSnapshot verifies that the main reaper loop's
+// RLock snapshot of IsInRecovery, VersionStr, ApproxDbSize, Metrics, and
+// MetricsStandby does not race against concurrent FetchRuntimeInfo writes.
+func TestRace_MainLoopRuntimeInfoSnapshot(t *testing.T) {
+	md := sources.NewDbConn(sources.Source{
+		Name: "race-test",
+		Kind: sources.SourcePostgres,
+	})
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: simulate FetchRuntimeInfo updating RuntimeInfo fields under Lock.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			md.Lock()
+			md.IsInRecovery = !md.IsInRecovery
+			md.VersionStr = "PostgreSQL 16.0"
+			md.ApproxDbSize = 1024
+			md.Metrics = metrics.MetricIntervals{"cpu": 30}
+			md.MetricsStandby = metrics.MetricIntervals{"cpu": 60}
+			md.Unlock()
+		}
+	}()
+
+	// Reader: snapshot under RLock exactly as the main loop does after FetchRuntimeInfo.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			md.RLock()
+			_ = md.IsInRecovery
+			_ = md.VersionStr
+			_ = md.ApproxDbSize
+			if md.Metrics != nil {
+				_ = maps.Clone(md.Metrics)
+			}
+			if md.MetricsStandby != nil {
+				_ = maps.Clone(md.MetricsStandby)
+			}
+			md.RUnlock()
 		}
 	}()
 

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -174,9 +174,8 @@ func (md *DbConn) GetClusterIdentifier() string {
 		return ""
 	}
 	md.RLock()
-	sysID := md.SystemIdentifier
-	md.RUnlock()
-	return fmt.Sprintf("%s:%s:%d", sysID, md.ConnConfig.ConnConfig.Host, md.ConnConfig.ConnConfig.Port)
+	defer md.RUnlock()
+	return fmt.Sprintf("%s:%s:%d", md.SystemIdentifier, md.ConnConfig.ConnConfig.Host, md.ConnConfig.ConnConfig.Port)
 }
 
 // GetDatabaseName returns the database name from the connection string

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -339,11 +339,13 @@ where
 
 // TryCreateMissingExtensions should be called once on daemon startup if some commonly wanted extension (most notably pg_stat_statements) is missing.
 func (md *DbConn) TryCreateMissingExtensions(ctx context.Context, extensions []string) (string, error) {
+	// Snapshot the already-known extensions under RLock; release before doing any I/O.
 	md.RLock()
-	defer md.RUnlock()
+	knownExts := maps.Clone(md.Extensions)
+	md.RUnlock()
 
 	sqlAvailableExts := `select name::text from pg_available_extensions order by 1`
-	CreatedExts := make([]string, 0)
+	createdExts := make([]string, 0)
 
 	data, err := md.Conn.Query(ctx, sqlAvailableExts)
 	if err != nil {
@@ -355,7 +357,7 @@ func (md *DbConn) TryCreateMissingExtensions(ctx context.Context, extensions []s
 	}
 
 	for _, extToCreate := range extensions {
-		if _, ok := md.Extensions[extToCreate]; ok {
+		if _, ok := knownExts[extToCreate]; ok {
 			continue
 		}
 		if _, ok := slices.BinarySearch(availableExts, extToCreate); !ok {
@@ -365,19 +367,21 @@ func (md *DbConn) TryCreateMissingExtensions(ctx context.Context, extensions []s
 		if _, e := md.Conn.Exec(ctx, fmt.Sprintf(`create extension if not exists "%s"`, extToCreate)); e != nil {
 			err = errors.Join(err, fmt.Errorf("failed to create extension %s: %w", extToCreate, e))
 		} else {
-			CreatedExts = append(CreatedExts, extToCreate)
+			createdExts = append(createdExts, extToCreate)
 		}
 	}
-	return strings.Join(CreatedExts, ","), err
+	return strings.Join(createdExts, ","), err
 }
 
 // TryCreateMetricsHelpers should be called once on daemon startup to try to create "metric fetching helper" functions automatically
 func (md *DbConn) TryCreateMetricsHelpers(ctx context.Context, getSQLFn func(string) string) (err error) {
+	// Clone the metric map under RLock; release before doing any I/O.
 	md.RLock()
-	defer md.RUnlock()
-	var sql string
 	metricsMap := maps.Clone(md.Metrics)
 	maps.Insert(metricsMap, maps.All(md.MetricsStandby))
+	md.RUnlock()
+
+	var sql string
 	for metricName := range metricsMap {
 		if sql = getSQLFn(metricName); sql == "" {
 			continue

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v5/internal/db"
@@ -54,7 +55,6 @@ var _ SourceConn = (*DbConn)(nil)
 var _ SourceConn = (*PromConn)(nil)
 
 type RuntimeInfo struct {
-	LastCheckedOn    time.Time
 	IsInRecovery     bool
 	VersionStr       string
 	Version          int
@@ -76,6 +76,7 @@ type (
 		Conn       db.PgxPoolIface
 		ConnConfig *pgxpool.Config
 		RuntimeInfo
+		lastCheckedNs atomic.Int64 // nanoseconds of last successful FetchRuntimeInfo; 0 = never
 		sync.RWMutex
 	}
 
@@ -231,15 +232,18 @@ func VersionToInt(version string) (v int) {
 }
 
 func (md *DbConn) FetchRuntimeInfo(ctx context.Context, forceRefetch bool) (err error) {
+	// Fast path: check the atomic timestamp without acquiring any lock.
+	// This avoids lock contention when the cached value is still fresh.
+	if !forceRefetch && time.Duration(time.Now().UnixNano()-md.lastCheckedNs.Load()) < 5*time.Minute {
+		return nil
+	}
+
 	md.Lock()
 	defer md.Unlock()
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
-	if !forceRefetch && md.LastCheckedOn.After(time.Now().Add(time.Minute*-5)) { // use cached version for 5 min
-		return nil
-	}
 	switch md.Kind {
 	case SourcePgBouncer, SourcePgPool:
 		if md.VersionStr, md.Version, err = md.FetchVersion(ctx, func() string {
@@ -289,7 +293,7 @@ FROM
 		}
 
 	}
-	md.LastCheckedOn = time.Now()
+	md.lastCheckedNs.Store(time.Now().UnixNano())
 	return err
 }
 

--- a/internal/sources/conn.go
+++ b/internal/sources/conn.go
@@ -172,7 +172,10 @@ func (md *DbConn) GetClusterIdentifier() string {
 	if err := md.ParseConfig(); err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s:%d", md.SystemIdentifier, md.ConnConfig.ConnConfig.Host, md.ConnConfig.ConnConfig.Port)
+	md.RLock()
+	sysID := md.SystemIdentifier
+	md.RUnlock()
+	return fmt.Sprintf("%s:%s:%d", sysID, md.ConnConfig.ConnConfig.Host, md.ConnConfig.ConnConfig.Port)
 }
 
 // GetDatabaseName returns the database name from the connection string

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -736,3 +736,93 @@ func TestRace_GetClusterIdentifier(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestRace_TryCreateMissingExtensions verifies that concurrent FetchRuntimeInfo
+// writes to Extensions and TryCreateMissingExtensions reads do not race.
+func TestRace_TryCreateMissingExtensions(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	md := sources.NewDbConn(sources.Source{Kind: sources.SourcePostgres})
+	md.Conn = mock
+
+	const iterations = 50
+	// Each TryCreateMissingExtensions call queries available extensions then skips
+	// creation because "pg_stat_statements" will be in knownExts after the first write.
+	for range iterations {
+		mock.ExpectQuery("select name").
+			WillReturnRows(pgxmock.NewRows([]string{"name"}).AddRow("pg_stat_statements"))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: simulate FetchRuntimeInfo updating Extensions under Lock.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			md.Lock()
+			md.Extensions = map[string]int{"pg_stat_statements": 10800}
+			md.Unlock()
+		}
+	}()
+
+	// Reader: TryCreateMissingExtensions snapshots Extensions under RLock then does I/O unlocked.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_, _ = md.TryCreateMissingExtensions(context.Background(), []string{"pg_stat_statements"})
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestRace_TryCreateMetricsHelpers verifies that concurrent SetMetricIntervals
+// writes and TryCreateMetricsHelpers reads do not race.
+func TestRace_TryCreateMetricsHelpers(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	md := sources.NewDbConn(sources.Source{
+		Kind:    sources.SourcePostgres,
+		Metrics: metrics.MetricIntervals{"metric1": 30},
+	})
+	md.Conn = mock
+
+	const iterations = 50
+	for range iterations {
+		mock.ExpectExec("CREATE FUNCTION metric1").
+			WillReturnResult(pgxmock.NewResult("CREATE", 1))
+	}
+
+	getSQLFn := func(metric string) string {
+		if metric == "metric1" {
+			return "CREATE FUNCTION metric1"
+		}
+		return ""
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: simulate SetMetricIntervals updating Metrics under Lock.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			md.SetMetricIntervals(metrics.MetricIntervals{"metric1": 30}, nil)
+		}
+	}()
+
+	// Reader: TryCreateMetricsHelpers clones Metrics under RLock then does I/O unlocked.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = md.TryCreateMetricsHelpers(context.Background(), getSQLFn)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -693,4 +694,45 @@ func TestRedactURL(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestRace_GetClusterIdentifier verifies that concurrent FetchRuntimeInfo writes
+// and GetClusterIdentifier reads do not cause a data race.
+func TestRace_GetClusterIdentifier(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	md := sources.NewDbConn(sources.Source{
+		Kind:    sources.SourcePgBouncer,
+		ConnStr: "postgres://user:pass@localhost:5432/db",
+	})
+	md.Conn = mock
+
+	const iterations = 50
+	// FetchRuntimeInfo for pgbouncer needs one SHOW VERSION per forceRefetch=true call.
+	for range iterations {
+		mock.ExpectQuery("SHOW VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("PgBouncer 1.12.0"))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = md.FetchRuntimeInfo(context.Background(), true)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = md.GetClusterIdentifier()
+		}
+	}()
+
+	wg.Wait()
 }

--- a/internal/sources/conn_test.go
+++ b/internal/sources/conn_test.go
@@ -235,12 +235,9 @@ func TestSourceConn_FetchRuntimeInfo(t *testing.T) {
 	})
 
 	t.Run("cached version", func(t *testing.T) {
-		md := &sources.DbConn{
-			RuntimeInfo: sources.RuntimeInfo{
-				LastCheckedOn: time.Now().Add(-time.Minute),
-				Version:       42,
-			},
-		}
+		md := sources.NewDbConn(sources.Source{})
+		md.SetLastCheckedForTesting(time.Now().Add(-time.Minute)) // within 5-minute TTL
+		md.Version = 42
 		err := md.FetchRuntimeInfo(ctx, false)
 		assert.NoError(t, err)
 		assert.Equal(t, 42, md.Version)
@@ -823,6 +820,43 @@ func TestRace_TryCreateMetricsHelpers(t *testing.T) {
 			_ = md.TryCreateMetricsHelpers(context.Background(), getSQLFn)
 		}
 	}()
+
+	wg.Wait()
+}
+
+// TestRace_FetchRuntimeInfoAtomicCache verifies that the atomic lastCheckedNs
+// fast path and double-checked lock in FetchRuntimeInfo are race-free under
+// concurrent calls from multiple goroutines.
+func TestRace_FetchRuntimeInfoAtomicCache(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	md := sources.NewDbConn(sources.Source{Kind: sources.SourcePgBouncer})
+	md.Conn = mock
+
+	const goroutines = 4
+	const iterations = 50
+
+	// Pre-seed enough mock responses for the worst-case where every call bypasses the cache.
+	for range goroutines * iterations {
+		mock.ExpectQuery("SHOW VERSION").
+			WithArgs(pgx.QueryExecModeSimpleProtocol).
+			WillReturnRows(pgxmock.NewRows([]string{"version"}).AddRow("PgBouncer 1.12.0"))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				// Mix forced and cached calls to exercise both fast and slow paths.
+				_ = md.FetchRuntimeInfo(context.Background(), false)
+			}
+		}()
+	}
 
 	wg.Wait()
 }

--- a/internal/sources/export_test.go
+++ b/internal/sources/export_test.go
@@ -1,0 +1,9 @@
+package sources
+
+import "time"
+
+// SetLastCheckedForTesting sets the atomic lastCheckedNs timestamp on a DbConn.
+// It is only used in tests to simulate a recently-fetched state without hitting the DB.
+func (md *DbConn) SetLastCheckedForTesting(t time.Time) {
+	md.lastCheckedNs.Store(t.UnixNano())
+}


### PR DESCRIPTION
- GetClusterIdentifier: snapshot SystemIdentifier under RLock before
  formatting the cluster key; ParseConfig remains outside the lock as
  it writes ConnConfig only before any goroutine starts.
- AddSysinfoToMeasurements: snapshot RealDbname and SystemIdentifier
  under RLock before iterating measurements, removing a data race with
  concurrent FetchRuntimeInfo writes.
- CreateSourceHelpers: snapshot IsInRecovery under RLock instead of
  reading the field bare.
- LogParser: add realDbname string field snapshotted under RLock in
  NewLogParser; parseLogsLocal/parseLogsRemote now read lp.realDbname
  (a plain copy) instead of lp.SourceConn.RealDbname on every log line.
- DbConnReaper.degradedMetrics: guard with degradedMu sync.RWMutex;
  add isDegraded/markDegraded/clearDegraded helpers so the field is
  never accessed bare from outside the Reap goroutine.
- Integration test: wrap bare md.IsInRecovery writes in md.Lock/Unlock
  to match the lock protocol FetchRuntimeInfo uses.
- Add TestRace_GetClusterIdentifier, TestRace_AddSysinfoToMeasurements,
  TestRace_CreateSourceHelpers, TestRace_LogParserRealDbname to catch
  regressions under go test -race.## Description
