### PR TITLE
[*] add cache for Postgres continous discovery

### DIFF
--- a/internal/cmdopts/cmdsource.go
+++ b/internal/cmdopts/cmdsource.go
@@ -51,12 +51,13 @@ func (cmd *SourcePingCommand) Execute(args []string) error {
 		}
 	}
 	var e error
+	resolver := sources.NewResolver()
 	for _, s := range foundSources {
 		switch s.Kind {
 		case sources.SourcePatroniDiscovery:
-			_, e = sources.ResolveDatabasesFromPatroni(s)
+			_, e = resolver.ResolveDatabasesFromPatroni(s)
 		case sources.SourcePostgresDiscovery:
-			_, e = sources.ResolveDatabasesFromPostgres(s)
+			_, e = resolver.ResolveDatabasesFromPostgres(s)
 		default:
 			mdb := sources.NewSourceConn(s)
 			// we don't want to log connection errors here, so we use a noop logger in the context

--- a/internal/cmdopts/cmdsource_test.go
+++ b/internal/cmdopts/cmdsource_test.go
@@ -91,10 +91,22 @@ func TestSourceResolveCommand_Execute(t *testing.T) {
 	})
 
 	t.Run("ResolveError", func(t *testing.T) {
+		// a distinct conn_str has no cached resolution, so the error propagates
+		f2, err := os.CreateTemp(t.TempDir(), "sample.config.yaml")
+		require.NoError(t, err)
+		defer f2.Close()
+
+		_, err = f2.WriteString(`
+- name: test1
+  kind: postgres-continuous-discovery
+  is_enabled: true
+  conn_str: postgresql://foo@quux/baz`)
+		require.NoError(t, err)
+
 		mock.ExpectQuery("select.+datname").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnError(assert.AnError)
-		os.Args = []string{0: "config_test", "--sources=" + f.Name(), "source", "resolve"}
+		os.Args = []string{0: "config_test", "--sources=" + f2.Name(), "source", "resolve"}
 		_, err = New(nil)
 		assert.ErrorIs(t, err, assert.AnError)
 		assert.NoError(t, mock.ExpectationsWereMet())

--- a/internal/sources/export_test.go
+++ b/internal/sources/export_test.go
@@ -7,3 +7,11 @@ import "time"
 func (md *DbConn) SetLastCheckedForTesting(t time.Time) {
 	md.lastCheckedNs.Store(t.UnixNano())
 }
+
+// ResetResolverCachesForTesting clears all resolver fallback caches under the
+// shared mutex so tests start from a known state without hitting the DCS.
+func ResetResolverCachesForTesting() {
+	resolverCacheMu.Lock()
+	defer resolverCacheMu.Unlock()
+	lastFoundClusterMembers = make(map[string][]PatroniClusterMember)
+}

--- a/internal/sources/export_test.go
+++ b/internal/sources/export_test.go
@@ -9,9 +9,10 @@ func (md *DbConn) SetLastCheckedForTesting(t time.Time) {
 }
 
 // ResetResolverCachesForTesting clears all resolver fallback caches under the
-// shared mutex so tests start from a known state without hitting the DCS.
+// shared mutex so tests start from a known state without hitting the DCS or DB.
 func ResetResolverCachesForTesting() {
 	resolverCacheMu.Lock()
 	defer resolverCacheMu.Unlock()
 	lastFoundClusterMembers = make(map[string][]PatroniClusterMember)
+	lastFoundDatabases = make(map[postgresDiscoveryKey]SourceConns)
 }

--- a/internal/sources/export_test.go
+++ b/internal/sources/export_test.go
@@ -7,12 +7,3 @@ import "time"
 func (md *DbConn) SetLastCheckedForTesting(t time.Time) {
 	md.lastCheckedNs.Store(t.UnixNano())
 }
-
-// ResetResolverCachesForTesting clears all resolver fallback caches under the
-// shared mutex so tests start from a known state without hitting the DCS or DB.
-func ResetResolverCachesForTesting() {
-	resolverCacheMu.Lock()
-	defer resolverCacheMu.Unlock()
-	lastFoundClusterMembers = make(map[string][]PatroniClusterMember)
-	lastFoundDatabases = make(map[postgresDiscoveryKey]SourceConns)
-}

--- a/internal/sources/resolver.go
+++ b/internal/sources/resolver.go
@@ -85,8 +85,30 @@ var logger log.Logger = log.FallbackLogger
 var (
 	// needed for cases where DCS is temporarily down; don't want to immediately remove monitoring of DBs
 	lastFoundClusterMembers = make(map[string][]PatroniClusterMember)
-	resolverCacheMu         sync.Mutex // guards resolver fallback caches
+	// lastFoundDatabases is keyed by the source's identity (name + conn string + include/exclude patterns) so a
+	// reconfigured source never inherits the previous target's database list. Guarded by resolverCacheMu.
+	lastFoundDatabases = make(map[postgresDiscoveryKey]SourceConns)
+	resolverCacheMu    sync.Mutex // guards resolver fallback caches
 )
+
+// postgresDiscoveryKey uniquely identifies a Postgres discovery source for caching purposes.
+// It MUST incorporate every field that would change the set of discovered databases; otherwise a
+// reconfigured source could be served the previous target's last-known-good list.
+type postgresDiscoveryKey struct {
+	name           string
+	connStr        string
+	includePattern string
+	excludePattern string
+}
+
+func postgresDiscoveryKeyOf(s Source) postgresDiscoveryKey {
+	return postgresDiscoveryKey{
+		name:           s.Name,
+		connStr:        s.ConnStr,
+		includePattern: s.IncludePattern,
+		excludePattern: s.ExcludePattern,
+	}
+}
 
 func getConsulClusterMembers(Source) ([]PatroniClusterMember, error) {
 	return nil, errors.ErrUnsupported
@@ -368,8 +390,35 @@ func ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
 }
 
 // ResolveDatabasesFromPostgres reads all the databases from the given cluster,
-// additionally matching/not matching specified regex patterns
+// additionally matching/not matching specified regex patterns.
+//
+// On any helper error (pool create or discovery query) and the presence of a
+// previously-cached successful result for the same source identity, the cached
+// list is returned with a nil error: a transient discovery failure (DNS hiccup,
+// connect timeout, discovery-SQL permission error) must not tear down monitoring
+// of already-known databases. The accepted trade-off is that a database dropped
+// server-side while discovery keeps failing stays monitored from cache (surfaced
+// as per-cycle connect errors reported as down) until the next successful
+// resolution replaces the entry.
 func ResolveDatabasesFromPostgres(s Source) (resolvedDbs SourceConns, err error) {
+	resolvedDbs, err = resolveDatabasesFromPostgres(s)
+	key := postgresDiscoveryKeyOf(s)
+	resolverCacheMu.Lock()
+	defer resolverCacheMu.Unlock()
+	if err == nil {
+		lastFoundDatabases[key] = resolvedDbs
+		return resolvedDbs, nil
+	}
+	cached, ok := lastFoundDatabases[key]
+	if ok && len(cached) > 0 {
+		logger.WithField("source", s.Name).WithError(err).Warning("postgres discovery failed; serving last-known-good database list from cache")
+		return cached, nil
+	}
+	return nil, err
+}
+
+// resolveDatabasesFromPostgres is the inner helper that actually runs the discovery query.
+func resolveDatabasesFromPostgres(s Source) (resolvedDbs SourceConns, err error) {
 	var (
 		c      db.PgxPoolIface
 		dbname string

--- a/internal/sources/resolver.go
+++ b/internal/sources/resolver.go
@@ -82,8 +82,11 @@ func (pcm PatroniClusterMember) IsPrimary() bool {
 
 var logger log.Logger = log.FallbackLogger
 
-var lastFoundClusterMembers = make(map[string][]PatroniClusterMember) // needed for cases where DCS is temporarily down
-// don't want to immediately remove monitoring of DBs
+var (
+	// needed for cases where DCS is temporarily down; don't want to immediately remove monitoring of DBs
+	lastFoundClusterMembers = make(map[string][]PatroniClusterMember)
+	resolverCacheMu         sync.Mutex // guards resolver fallback caches
+)
 
 func getConsulClusterMembers(Source) ([]PatroniClusterMember, error) {
 	return nil, errors.ErrUnsupported
@@ -204,7 +207,9 @@ func getEtcdClusterMembers(s Source, hc HostConfig) ([]PatroniClusterMember, err
 		ret = append(ret, PatroniClusterMember{Scope: scope, ConnURL: connURL, Role: role, Name: name})
 	}
 
+	resolverCacheMu.Lock()
 	lastFoundClusterMembers[s.Name] = ret
+	resolverCacheMu.Unlock()
 	return ret, nil
 }
 
@@ -327,11 +332,16 @@ func ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
 			return nil, err
 		}
 		logger.Debug("failed to get info from DCS, using previous member info if any")
-		if clusterMembers, ok = lastFoundClusterMembers[source.Name]; ok { // mask error from main loop not to remove monitored DBs due to "jitter"
+		resolverCacheMu.Lock()
+		clusterMembers, ok = lastFoundClusterMembers[source.Name] // mask error from main loop not to remove monitored DBs due to "jitter"
+		resolverCacheMu.Unlock()
+		if ok {
 			err = nil
 		}
 	} else {
+		resolverCacheMu.Lock()
 		lastFoundClusterMembers[source.Name] = clusterMembers
+		resolverCacheMu.Unlock()
 	}
 	if len(clusterMembers) == 0 {
 		return mds, err

--- a/internal/sources/resolver.go
+++ b/internal/sources/resolver.go
@@ -26,9 +26,55 @@ import (
 	"go.uber.org/zap"
 )
 
+// Resolver discovers the monitored databases behind continuous-monitoring
+// sources (Patroni, Postgres discovery). It owns the last-known-good fallback
+// caches so that a transient DCS/DB outage does not tear down monitoring of
+// already-known databases.
+//
+// A Resolver is safe for concurrent use. Create independent Resolvers via
+// NewResolver when isolated cache state is desired (e.g. in tests or when
+// running several unrelated resolution pipelines in one process).
+type Resolver struct {
+	mu sync.Mutex // guards the fallback caches below
+	// lastFoundClusterMembers is needed for cases where DCS is temporarily down;
+	// we don't want to immediately remove monitoring of DBs. Keyed by source name.
+	lastFoundClusterMembers map[string][]PatroniClusterMember
+	// lastFoundDatabases is keyed by the source's identity (name + conn string +
+	// include/exclude patterns) so a reconfigured source never inherits the
+	// previous target's database list.
+	lastFoundDatabases map[postgresDiscoveryKey]SourceConns
+}
+
+// NewResolver returns a Resolver with freshly initialized, empty caches.
+func NewResolver() *Resolver {
+	return &Resolver{
+		lastFoundClusterMembers: make(map[string][]PatroniClusterMember),
+		lastFoundDatabases:      make(map[postgresDiscoveryKey]SourceConns),
+	}
+}
+
+// defaultResolver backs the convenience methods on Source and Sources so that
+// existing callers keep a single process-wide fallback cache without having to
+// thread a Resolver through.
+var defaultResolver = NewResolver()
+
 // ResolveDatabases() updates list of monitored objects from continuous monitoring sources, e.g. patroni.
 // Each source is resolved concurrently so that a slow or unreachable source does not block the others.
-func (srcs Sources) ResolveDatabases(onError func(string)) (_ SourceConns, err error) {
+// It delegates to the package-wide defaultResolver.
+func (srcs Sources) ResolveDatabases(onError func(string)) (SourceConns, error) {
+	return defaultResolver.ResolveDatabases(srcs, onError)
+}
+
+// ResolveDatabases() return a slice of found databases for continuous monitoring sources, e.g. patroni.
+// It delegates to the package-wide defaultResolver.
+func (s Source) ResolveDatabases() (SourceConns, error) {
+	return defaultResolver.ResolveDatabase(s)
+}
+
+// ResolveDatabases updates the list of monitored objects from continuous monitoring
+// sources, e.g. patroni. Each source is resolved concurrently so that a slow or
+// unreachable source does not block the others.
+func (r *Resolver) ResolveDatabases(srcs Sources, onError func(string)) (_ SourceConns, err error) {
 	type result struct {
 		dbs SourceConns
 		err error
@@ -37,7 +83,7 @@ func (srcs Sources) ResolveDatabases(onError func(string)) (_ SourceConns, err e
 	var wg sync.WaitGroup
 	for i, s := range srcs {
 		wg.Go(func() {
-			dbs, e := s.ResolveDatabases()
+			dbs, e := r.ResolveDatabase(s)
 			results[i] = result{dbs, e}
 		})
 	}
@@ -56,13 +102,14 @@ func (srcs Sources) ResolveDatabases(onError func(string)) (_ SourceConns, err e
 	return resolvedDbs, err
 }
 
-// ResolveDatabases() return a slice of found databases for continuous monitoring sources, e.g. patroni
-func (s Source) ResolveDatabases() (SourceConns, error) {
+// ResolveDatabase returns a slice of found databases for a single continuous
+// monitoring source, e.g. patroni.
+func (r *Resolver) ResolveDatabase(s Source) (SourceConns, error) {
 	switch s.Kind {
 	case SourcePatroniDiscovery:
-		return ResolveDatabasesFromPatroni(s)
+		return r.ResolveDatabasesFromPatroni(s)
 	case SourcePostgresDiscovery:
-		return ResolveDatabasesFromPostgres(s)
+		return r.ResolveDatabasesFromPostgres(s)
 	case SourcePrometheus:
 		return SourceConns{NewPromConn(s)}, nil
 	}
@@ -81,15 +128,6 @@ func (pcm PatroniClusterMember) IsPrimary() bool {
 }
 
 var logger log.Logger = log.FallbackLogger
-
-var (
-	// needed for cases where DCS is temporarily down; don't want to immediately remove monitoring of DBs
-	lastFoundClusterMembers = make(map[string][]PatroniClusterMember)
-	// lastFoundDatabases is keyed by the source's identity (name + conn string + include/exclude patterns) so a
-	// reconfigured source never inherits the previous target's database list. Guarded by resolverCacheMu.
-	lastFoundDatabases = make(map[postgresDiscoveryKey]SourceConns)
-	resolverCacheMu    sync.Mutex // guards resolver fallback caches
-)
 
 // postgresDiscoveryKey uniquely identifies a Postgres discovery source for caching purposes.
 // It MUST incorporate every field that would change the set of discovered databases; otherwise a
@@ -171,7 +209,7 @@ func getTransport(conf HostConfig) (*tls.Config, error) {
 	return tlsClientConfig, nil
 }
 
-func getEtcdClusterMembers(s Source, hc HostConfig) ([]PatroniClusterMember, error) {
+func (r *Resolver) getEtcdClusterMembers(s Source, hc HostConfig) ([]PatroniClusterMember, error) {
 	var ret = make([]PatroniClusterMember, 0)
 	var cfg client.Config
 
@@ -229,9 +267,9 @@ func getEtcdClusterMembers(s Source, hc HostConfig) ([]PatroniClusterMember, err
 		ret = append(ret, PatroniClusterMember{Scope: scope, ConnURL: connURL, Role: role, Name: name})
 	}
 
-	resolverCacheMu.Lock()
-	lastFoundClusterMembers[s.Name] = ret
-	resolverCacheMu.Unlock()
+	r.mu.Lock()
+	r.lastFoundClusterMembers[s.Name] = ret
+	r.mu.Unlock()
 	return ret, nil
 }
 
@@ -327,7 +365,7 @@ func NewHostConfig(URI string) (hc HostConfig, err error) {
 	return hc, nil
 }
 
-func ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
+func (r *Resolver) ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
 	var mds SourceConns
 	var clusterMembers []PatroniClusterMember
 	var err error
@@ -340,7 +378,7 @@ func ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
 
 	switch hostConfig.DcsType {
 	case dcsTypeEtcd:
-		clusterMembers, err = getEtcdClusterMembers(source, hostConfig)
+		clusterMembers, err = r.getEtcdClusterMembers(source, hostConfig)
 	case dcsTypeZookeeper:
 		clusterMembers, err = getZookeeperClusterMembers(source, hostConfig)
 	case dcsTypeConsul:
@@ -354,16 +392,16 @@ func ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
 			return nil, err
 		}
 		logger.Debug("failed to get info from DCS, using previous member info if any")
-		resolverCacheMu.Lock()
-		clusterMembers, ok = lastFoundClusterMembers[source.Name] // mask error from main loop not to remove monitored DBs due to "jitter"
-		resolverCacheMu.Unlock()
+		r.mu.Lock()
+		clusterMembers, ok = r.lastFoundClusterMembers[source.Name] // mask error from main loop not to remove monitored DBs due to "jitter"
+		r.mu.Unlock()
 		if ok {
 			err = nil
 		}
 	} else {
-		resolverCacheMu.Lock()
-		lastFoundClusterMembers[source.Name] = clusterMembers
-		resolverCacheMu.Unlock()
+		r.mu.Lock()
+		r.lastFoundClusterMembers[source.Name] = clusterMembers
+		r.mu.Unlock()
 	}
 	if len(clusterMembers) == 0 {
 		return mds, err
@@ -380,7 +418,7 @@ func ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
 			src.Name += "_" + patroniMember.Scope
 		}
 		src.Name += "_" + patroniMember.Name
-		if dbs, err := ResolveDatabasesFromPostgres(src); err == nil {
+		if dbs, err := r.ResolveDatabasesFromPostgres(src); err == nil {
 			mds = append(mds, dbs...)
 		} else {
 			logger.WithError(err).Error("failed to resolve databases for Patroni member: ", patroniMember.Name)
@@ -400,16 +438,16 @@ func ResolveDatabasesFromPatroni(source Source) (SourceConns, error) {
 // server-side while discovery keeps failing stays monitored from cache (surfaced
 // as per-cycle connect errors reported as down) until the next successful
 // resolution replaces the entry.
-func ResolveDatabasesFromPostgres(s Source) (resolvedDbs SourceConns, err error) {
+func (r *Resolver) ResolveDatabasesFromPostgres(s Source) (resolvedDbs SourceConns, err error) {
 	resolvedDbs, err = resolveDatabasesFromPostgres(s)
 	key := postgresDiscoveryKeyOf(s)
-	resolverCacheMu.Lock()
-	defer resolverCacheMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if err == nil {
-		lastFoundDatabases[key] = resolvedDbs
+		r.lastFoundDatabases[key] = resolvedDbs
 		return resolvedDbs, nil
 	}
-	cached, ok := lastFoundDatabases[key]
+	cached, ok := r.lastFoundDatabases[key]
 	if ok && len(cached) > 0 {
 		logger.WithField("source", s.Name).WithError(err).Warning("postgres discovery failed; serving last-known-good database list from cache")
 		return cached, nil

--- a/internal/sources/resolver_test.go
+++ b/internal/sources/resolver_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	client "go.etcd.io/etcd/client/v3"
@@ -431,3 +433,212 @@ func TestNewHostConfig_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+// stubNewConnWithDatnames replaces sources.NewConn with a stub that builds a fresh
+// pgxmock pool per call so each invocation gets its own mocked discovery query.
+// The returned rows closure is invoked inside the stub to construct the row set
+// for the current call; this lets a single stub serve concurrent goroutines.
+func stubNewConnWithDatnames(t *testing.T, rowsFn func() []string) {
+	t.Helper()
+	orig := sources.NewConn
+	sources.NewConn = func(_ context.Context, _ string, _ ...db.ConnConfigCallback) (db.PgxPoolIface, error) {
+		mock, err := pgxmock.NewPool()
+		if err != nil {
+			return nil, err
+		}
+		rows := pgxmock.NewRows([]string{"datname"})
+		for _, n := range rowsFn() {
+			rows.AddRow(n)
+		}
+		mock.ExpectQuery("pg_database").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(rows)
+		return mock, nil
+	}
+	t.Cleanup(func() { sources.NewConn = orig })
+}
+
+// stubNewConnWithError makes sources.NewConn return the given error verbatim.
+func stubNewConnWithError(t *testing.T, err error) {
+	t.Helper()
+	orig := sources.NewConn
+	sources.NewConn = func(_ context.Context, _ string, _ ...db.ConnConfigCallback) (db.PgxPoolIface, error) {
+		return nil, err
+	}
+	t.Cleanup(func() { sources.NewConn = orig })
+}
+
+func TestResolveDatabasesFromPostgres_LKGFallbackOnFailure(t *testing.T) {
+	sources.ResetResolverCachesForTesting()
+
+	md := sources.Source{
+		Name:    "lkg_failure",
+		Kind:    sources.SourcePostgresDiscovery,
+		ConnStr: "postgres://user:pw@a:5432/postgres?sslmode=disable",
+	}
+
+	// Wave 1: success populates the cache.
+	stubNewConnWithDatnames(t, func() []string { return []string{"db1", "db2", "db3"} })
+	dbs, err := sources.ResolveDatabasesFromPostgres(md)
+	require.NoError(t, err)
+	require.Len(t, dbs, 3)
+	firstNames := []string{dbs[0].GetSource().Name, dbs[1].GetSource().Name, dbs[2].GetSource().Name}
+
+	// Wave 2: discovery fails; cache MUST be served with nil error.
+	sentinel := errors.New("boom")
+	stubNewConnWithError(t, sentinel)
+	dbs, err = sources.ResolveDatabasesFromPostgres(md)
+	require.NoError(t, err, "expected cached fallback to swallow the error")
+	require.Len(t, dbs, 3, "expected the previously cached list to be returned")
+	gotNames := []string{dbs[0].GetSource().Name, dbs[1].GetSource().Name, dbs[2].GetSource().Name}
+	assert.Equal(t, firstNames, gotNames)
+}
+
+func TestResolveDatabasesFromPostgres_LKGReplacementOnSuccess(t *testing.T) {
+	sources.ResetResolverCachesForTesting()
+
+	md := sources.Source{
+		Name:    "lkg_replace",
+		Kind:    sources.SourcePostgresDiscovery,
+		ConnStr: "postgres://user:pw@b:5432/postgres?sslmode=disable",
+	}
+
+	// Seed cache with the first list.
+	stubNewConnWithDatnames(t, func() []string { return []string{"alpha", "beta"} })
+	dbs, err := sources.ResolveDatabasesFromPostgres(md)
+	require.NoError(t, err)
+	require.Len(t, dbs, 2)
+
+	// Replace with a new, different list via a successful resolution.
+	stubNewConnWithDatnames(t, func() []string { return []string{"gamma", "delta", "epsilon"} })
+	dbs, err = sources.ResolveDatabasesFromPostgres(md)
+	require.NoError(t, err)
+	require.Len(t, dbs, 3)
+	newNames := []string{dbs[0].GetSource().Name, dbs[1].GetSource().Name, dbs[2].GetSource().Name}
+	assert.Contains(t, newNames, "lkg_replace_gamma")
+	assert.Contains(t, newNames, "lkg_replace_delta")
+	assert.Contains(t, newNames, "lkg_replace_epsilon")
+
+	// Discovery fails now: the NEW list must be served, not the old one.
+	stubNewConnWithError(t, errors.New("still down"))
+	dbs, err = sources.ResolveDatabasesFromPostgres(md)
+	require.NoError(t, err)
+	require.Len(t, dbs, 3)
+	for _, d := range dbs {
+		n := d.GetSource().Name
+		assert.NotContains(t, []string{"lkg_replace_alpha", "lkg_replace_beta"}, n,
+			"stale entry %q was served from cache", n)
+	}
+}
+
+func TestResolveDatabasesFromPostgres_EmptyCacheErrorPropagates(t *testing.T) {
+	sources.ResetResolverCachesForTesting()
+
+	sentinel := errors.New("no cache yet")
+	stubNewConnWithError(t, sentinel)
+
+	md := sources.Source{
+		Name:    "lkg_empty",
+		Kind:    sources.SourcePostgresDiscovery,
+		ConnStr: "postgres://user:pw@c:5432/postgres?sslmode=disable",
+	}
+
+	dbs, err := sources.ResolveDatabasesFromPostgres(md)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Empty(t, dbs, "no cached entry should have been served")
+}
+
+func TestResolveDatabasesFromPostgres_CacheKeyIdentity(t *testing.T) {
+	sources.ResetResolverCachesForTesting()
+
+	base := sources.Source{
+		Name:    "lkg_key",
+		Kind:    sources.SourcePostgresDiscovery,
+		ConnStr: "postgres://user:pw@d:5432/postgres?sslmode=disable",
+	}
+
+	stubNewConnWithDatnames(t, func() []string { return []string{"one", "two"} })
+	dbs, err := sources.ResolveDatabasesFromPostgres(base)
+	require.NoError(t, err)
+	require.Len(t, dbs, 2)
+
+	// Same Name, DIFFERENT ConnStr: failing must not serve the cached entry.
+	sentinelA := errors.New("connstr-A down")
+	stubNewConnWithError(t, sentinelA)
+	other := sources.Source{
+		Name:    base.Name,
+		Kind:    sources.SourcePostgresDiscovery,
+		ConnStr: "postgres://user:pw@d-other:5432/postgres?sslmode=disable",
+	}
+	dbs, err = sources.ResolveDatabasesFromPostgres(other)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinelA)
+	assert.Empty(t, dbs, "a reconfigured ConnStr must not serve the previous target's list")
+
+	// Same ConnStr, changed IncludePattern: failing must not serve the cached entry either.
+	sentinelB := errors.New("include-pattern changed")
+	stubNewConnWithError(t, sentinelB)
+	repattern := sources.Source{
+		Name:           base.Name,
+		Kind:           sources.SourcePostgresDiscovery,
+		ConnStr:        base.ConnStr,
+		IncludePattern: "^foo_",
+	}
+	dbs, err = sources.ResolveDatabasesFromPostgres(repattern)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinelB)
+	assert.Empty(t, dbs, "a reconfigured include_pattern must not serve the previous result set")
+}
+
+func TestResolveDatabasesFromPostgres_ConcurrentFallback(t *testing.T) {
+	sources.ResetResolverCachesForTesting()
+
+	const n = 8
+	srcs := make(sources.Sources, n)
+	for i := range n {
+		srcs[i] = sources.Source{
+			Name:    fmt.Sprintf("concurrent_%d", i),
+			Kind:    sources.SourcePostgresDiscovery,
+			ConnStr: fmt.Sprintf("postgres://user:pw@h%d:5432/postgres?sslmode=disable", i),
+		}
+	}
+
+	// Wave 1: every source resolves successfully, each to a single distinct datname.
+	stubNewConnWithDatnames(t, func() []string {
+		// The stub doesn't know which source is calling; that's fine - the source
+		// name is taken from the Source struct, not from the mocked rows. We just
+		// need at least one row so resolution does not error.
+		return []string{"only"}
+	})
+	dbs, err := srcs.ResolveDatabases(func(string) {})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(dbs), n, "each source should produce one resolved DB")
+
+	// Wave 2: discovery fails for every source. Cached lists must be served.
+	stubNewConnWithError(t, errors.New("discovery down"))
+	// Add one brand-new source that has no cached entry.
+	extra := sources.Source{
+		Name:    "concurrent_extra",
+		Kind:    sources.SourcePostgresDiscovery,
+		ConnStr: "postgres://user:pw@extra:5432/postgres?sslmode=disable",
+	}
+	srcs2 := append(sources.Sources{}, srcs...)
+	srcs2 = append(srcs2, extra)
+
+	var onErrorNames sync.Map
+	dbs2, err := srcs2.ResolveDatabases(func(name string) {
+		onErrorNames.Store(name, struct{}{})
+	})
+	require.Error(t, err, "the never-cached extra source must propagate its error")
+	// Every original (cached) source still contributes its last-known DBs.
+	for i := range n {
+		require.NotNil(t, dbs2.GetMonitoredDatabase(fmt.Sprintf("concurrent_%d_only", i)),
+			"source %d should be served from cache", i)
+	}
+	// Extra source never cached: its name must appear in onError.
+	if _, ok := onErrorNames.Load(extra.Name); !ok {
+		t.Fatalf("expected onError to fire for never-cached source %q", extra.Name)
+	}
+}
+

--- a/internal/sources/resolver_test.go
+++ b/internal/sources/resolver_test.go
@@ -70,7 +70,7 @@ func TestResolveDatabasesFromPostgres_ResolverTimeout(t *testing.T) {
 	md.ConnStr = connStr
 
 	start := time.Now()
-	_, err := sources.ResolveDatabasesFromPostgres(md)
+	_, err := sources.NewResolver().ResolveDatabasesFromPostgres(md)
 	elapsed := time.Since(start)
 
 	require.Error(t, err, "expected an error from a stalled resolver")
@@ -469,7 +469,7 @@ func stubNewConnWithError(t *testing.T, err error) {
 }
 
 func TestResolveDatabasesFromPostgres_LKGFallbackOnFailure(t *testing.T) {
-	sources.ResetResolverCachesForTesting()
+	resolver := sources.NewResolver()
 
 	md := sources.Source{
 		Name:    "lkg_failure",
@@ -479,7 +479,7 @@ func TestResolveDatabasesFromPostgres_LKGFallbackOnFailure(t *testing.T) {
 
 	// Wave 1: success populates the cache.
 	stubNewConnWithDatnames(t, func() []string { return []string{"db1", "db2", "db3"} })
-	dbs, err := sources.ResolveDatabasesFromPostgres(md)
+	dbs, err := resolver.ResolveDatabasesFromPostgres(md)
 	require.NoError(t, err)
 	require.Len(t, dbs, 3)
 	firstNames := []string{dbs[0].GetSource().Name, dbs[1].GetSource().Name, dbs[2].GetSource().Name}
@@ -487,7 +487,7 @@ func TestResolveDatabasesFromPostgres_LKGFallbackOnFailure(t *testing.T) {
 	// Wave 2: discovery fails; cache MUST be served with nil error.
 	sentinel := errors.New("boom")
 	stubNewConnWithError(t, sentinel)
-	dbs, err = sources.ResolveDatabasesFromPostgres(md)
+	dbs, err = resolver.ResolveDatabasesFromPostgres(md)
 	require.NoError(t, err, "expected cached fallback to swallow the error")
 	require.Len(t, dbs, 3, "expected the previously cached list to be returned")
 	gotNames := []string{dbs[0].GetSource().Name, dbs[1].GetSource().Name, dbs[2].GetSource().Name}
@@ -495,7 +495,7 @@ func TestResolveDatabasesFromPostgres_LKGFallbackOnFailure(t *testing.T) {
 }
 
 func TestResolveDatabasesFromPostgres_LKGReplacementOnSuccess(t *testing.T) {
-	sources.ResetResolverCachesForTesting()
+	resolver := sources.NewResolver()
 
 	md := sources.Source{
 		Name:    "lkg_replace",
@@ -505,13 +505,13 @@ func TestResolveDatabasesFromPostgres_LKGReplacementOnSuccess(t *testing.T) {
 
 	// Seed cache with the first list.
 	stubNewConnWithDatnames(t, func() []string { return []string{"alpha", "beta"} })
-	dbs, err := sources.ResolveDatabasesFromPostgres(md)
+	dbs, err := resolver.ResolveDatabasesFromPostgres(md)
 	require.NoError(t, err)
 	require.Len(t, dbs, 2)
 
 	// Replace with a new, different list via a successful resolution.
 	stubNewConnWithDatnames(t, func() []string { return []string{"gamma", "delta", "epsilon"} })
-	dbs, err = sources.ResolveDatabasesFromPostgres(md)
+	dbs, err = resolver.ResolveDatabasesFromPostgres(md)
 	require.NoError(t, err)
 	require.Len(t, dbs, 3)
 	newNames := []string{dbs[0].GetSource().Name, dbs[1].GetSource().Name, dbs[2].GetSource().Name}
@@ -521,7 +521,7 @@ func TestResolveDatabasesFromPostgres_LKGReplacementOnSuccess(t *testing.T) {
 
 	// Discovery fails now: the NEW list must be served, not the old one.
 	stubNewConnWithError(t, errors.New("still down"))
-	dbs, err = sources.ResolveDatabasesFromPostgres(md)
+	dbs, err = resolver.ResolveDatabasesFromPostgres(md)
 	require.NoError(t, err)
 	require.Len(t, dbs, 3)
 	for _, d := range dbs {
@@ -532,7 +532,7 @@ func TestResolveDatabasesFromPostgres_LKGReplacementOnSuccess(t *testing.T) {
 }
 
 func TestResolveDatabasesFromPostgres_EmptyCacheErrorPropagates(t *testing.T) {
-	sources.ResetResolverCachesForTesting()
+	resolver := sources.NewResolver()
 
 	sentinel := errors.New("no cache yet")
 	stubNewConnWithError(t, sentinel)
@@ -543,14 +543,14 @@ func TestResolveDatabasesFromPostgres_EmptyCacheErrorPropagates(t *testing.T) {
 		ConnStr: "postgres://user:pw@c:5432/postgres?sslmode=disable",
 	}
 
-	dbs, err := sources.ResolveDatabasesFromPostgres(md)
+	dbs, err := resolver.ResolveDatabasesFromPostgres(md)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, sentinel)
 	assert.Empty(t, dbs, "no cached entry should have been served")
 }
 
 func TestResolveDatabasesFromPostgres_CacheKeyIdentity(t *testing.T) {
-	sources.ResetResolverCachesForTesting()
+	resolver := sources.NewResolver()
 
 	base := sources.Source{
 		Name:    "lkg_key",
@@ -559,7 +559,7 @@ func TestResolveDatabasesFromPostgres_CacheKeyIdentity(t *testing.T) {
 	}
 
 	stubNewConnWithDatnames(t, func() []string { return []string{"one", "two"} })
-	dbs, err := sources.ResolveDatabasesFromPostgres(base)
+	dbs, err := resolver.ResolveDatabasesFromPostgres(base)
 	require.NoError(t, err)
 	require.Len(t, dbs, 2)
 
@@ -571,7 +571,7 @@ func TestResolveDatabasesFromPostgres_CacheKeyIdentity(t *testing.T) {
 		Kind:    sources.SourcePostgresDiscovery,
 		ConnStr: "postgres://user:pw@d-other:5432/postgres?sslmode=disable",
 	}
-	dbs, err = sources.ResolveDatabasesFromPostgres(other)
+	dbs, err = resolver.ResolveDatabasesFromPostgres(other)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, sentinelA)
 	assert.Empty(t, dbs, "a reconfigured ConnStr must not serve the previous target's list")
@@ -585,14 +585,14 @@ func TestResolveDatabasesFromPostgres_CacheKeyIdentity(t *testing.T) {
 		ConnStr:        base.ConnStr,
 		IncludePattern: "^foo_",
 	}
-	dbs, err = sources.ResolveDatabasesFromPostgres(repattern)
+	dbs, err = resolver.ResolveDatabasesFromPostgres(repattern)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, sentinelB)
 	assert.Empty(t, dbs, "a reconfigured include_pattern must not serve the previous result set")
 }
 
 func TestResolveDatabasesFromPostgres_ConcurrentFallback(t *testing.T) {
-	sources.ResetResolverCachesForTesting()
+	resolver := sources.NewResolver()
 
 	const n = 8
 	srcs := make(sources.Sources, n)
@@ -611,7 +611,7 @@ func TestResolveDatabasesFromPostgres_ConcurrentFallback(t *testing.T) {
 		// need at least one row so resolution does not error.
 		return []string{"only"}
 	})
-	dbs, err := srcs.ResolveDatabases(func(string) {})
+	dbs, err := resolver.ResolveDatabases(srcs, func(string) {})
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(dbs), n, "each source should produce one resolved DB")
 
@@ -627,7 +627,7 @@ func TestResolveDatabasesFromPostgres_ConcurrentFallback(t *testing.T) {
 	srcs2 = append(srcs2, extra)
 
 	var onErrorNames sync.Map
-	dbs2, err := srcs2.ResolveDatabases(func(name string) {
+	dbs2, err := resolver.ResolveDatabases(srcs2, func(name string) {
 		onErrorNames.Store(name, struct{}{})
 	})
 	require.Error(t, err, "the never-cached extra source must propagate its error")
@@ -641,4 +641,3 @@ func TestResolveDatabasesFromPostgres_ConcurrentFallback(t *testing.T) {
 		t.Fatalf("expected onError to fire for never-cached source %q", extra.Name)
 	}
 }
-


### PR DESCRIPTION
A transient failure of the discovery query (DNS hiccup, connect timeout, or a permission error that affects only the discovery SQL, e.g. #890) MUST NOT tear down monitoring of the source's already-known databases.

This PR extracts discovery functionality into a separate `Resolver` struct and adds caching