### PR TITLE
[+] improve `admin.drop_all_metric_tables` routine, closes #1474

### DIFF
--- a/cmd/pgwatch/version.go
+++ b/cmd/pgwatch/version.go
@@ -8,7 +8,7 @@ var (
 	version      = "unknown"
 	date         = "unknown"
 	configSchema = "00824"
-	sinkSchema   = "01409"
+	sinkSchema   = "01474"
 )
 
 func printVersion() {

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -573,7 +573,7 @@ func (pgw *PostgresWriter) NeedsMigration() (bool, error) {
 }
 
 // MigrationsCount is the total number of migrations in admin.migration table
-const MigrationsCount = 3
+const MigrationsCount = 4
 
 // migrations holds function returning all upgrade migrations needed
 var migrations func() migrator.Option = func() migrator.Option {
@@ -715,6 +715,14 @@ var migrations func() migrator.Option = func() migrator.Option {
 				}
 
 				return nil
+			},
+		},
+
+		&migrator.Migration{
+			Name: "01474 Change drop_all_metric_tables to procedure",
+			Func: func(ctx context.Context, tx pgx.Tx) error {
+				_, err := tx.Exec(ctx, sqlMetricAdminFunctions)
+				return err
 			},
 		},
 

--- a/internal/sinks/postgres_migration_test.go
+++ b/internal/sinks/postgres_migration_test.go
@@ -41,21 +41,24 @@ func TestMigrationsCountInvariant(t *testing.T) {
 		MigrationsCount, seeded)
 }
 
-// simulatePreV6Migration rolls the seeded admin.migration table back to a pre-01409 state so
-// that the migrator considers the "01409 Switch to time-only partitioning" migration pending.
-// A fresh NewPostgresSinkMigrator bootstrap seeds all migrations as applied (the current install
-// path); here we emulate an older database that must still be upgraded.
+// simulatePreV6Migration wipes every row from admin.migration so that the next
+// mig.Migrate() replays the full migration chain (01110 → 01180 → 01409 → 01474)
+// against the freshly-bootstrapped database. A fresh NewPostgresSinkMigrator
+// bootstrap seeds all migrations as applied (the current install path); here
+// we emulate an older database that must be upgraded from scratch so every
+// migration is exercised in every test that calls this helper.
 //
-// The migrator determines pending migrations purely from the row count in admin.migration, so we
-// delete the last-applied migration row, leaving MigrationsCount-1 rows behind.
+// Callers that need a specific pre-migration object state (e.g. the legacy
+// function form of admin.drop_all_metric_tables) must recreate that object
+// after this call returns.
 func simulatePreV6Migration(t *testing.T, conn *pgx.Conn) {
 	t.Helper()
-	_, err := conn.Exec(ctx, `DELETE FROM admin.migration WHERE id = (SELECT max(id) FROM admin.migration)`)
+	_, err := conn.Exec(ctx, `DELETE FROM admin.migration`)
 	require.NoError(t, err)
 
 	var count int
 	require.NoError(t, conn.QueryRow(ctx, `SELECT count(*) FROM admin.migration`).Scan(&count))
-	require.Equal(t, MigrationsCount-1, count, "exactly one migration should be pending after rollback")
+	require.Equal(t, 0, count, "all migration rows should be wiped after rollback")
 }
 
 // oldSchemaMetricTable creates a metric table using the pre-v6 (dbname -> time) two-level
@@ -212,4 +215,156 @@ func TestMigration01409_EmptyTable(t *testing.T) {
 	r.NoError(conn.QueryRow(ctx,
 		`SELECT count(*) FROM pg_partition_tree($1) WHERE isleaf`, metric).Scan(&leaves))
 	a.GreaterOrEqual(leaves, 1, "a single empty time partition should exist")
+}
+
+// TestMigration01474_DropAllMetricTablesProcedure verifies that an older database that
+// still has admin.drop_all_metric_tables as a function gets upgraded in place to the
+// new procedure by migration 01474, and the upgraded routine actually drops partitions
+// partition-by-partition (not in one bulk DROP).
+func TestMigration01474_DropAllMetricTablesProcedure(t *testing.T) {
+	if os.Getenv("PGWATCH_TEST_SKIP_MIGRATION") != "" {
+		t.Skip("migration integration test skipped via PGWATCH_TEST_SKIP_MIGRATION")
+	}
+	r := require.New(t)
+	a := assert.New(t)
+
+	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
+	r.NoError(err)
+	defer pgTearDown()
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	r.NoError(err)
+
+	mig, err := NewPostgresSinkMigrator(ctx, connStr)
+	r.NoError(err)
+
+	conn, err := pgx.Connect(ctx, connStr)
+	r.NoError(err)
+	defer conn.Close(ctx)
+
+	// Simulate a pre-01474 database: drop the procedure seeded by bootstrap and recreate
+	// the legacy function; delete the highest migration row so the migrator picks 01474 up.
+	_, err = conn.Exec(ctx, `
+		DROP PROCEDURE IF EXISTS admin.drop_all_metric_tables();
+		CREATE FUNCTION admin.drop_all_metric_tables() RETURNS int AS $$ BEGIN RETURN 0; END $$ LANGUAGE plpgsql;
+		DELETE FROM admin.migration WHERE id = (SELECT max(id) FROM admin.migration);
+	`)
+	r.NoError(err)
+
+	// Before the migration the routine must be a function (prokind = 'f').
+	var prokindBefore string
+	r.NoError(conn.QueryRow(ctx, `
+		SELECT p.prokind FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = 'admin' AND p.proname = 'drop_all_metric_tables'
+	`).Scan(&prokindBefore))
+	a.Equal("f", prokindBefore, "legacy routine must start as a function")
+
+	// Build a tiny dummy metric with one partition so the upgraded procedure has something
+	_, err = conn.Exec(ctx, `
+		CREATE TABLE public.upgraded_metric (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY RANGE (time);
+		COMMENT ON TABLE public.upgraded_metric IS 'pgwatch-generated-metric-lvl';
+		INSERT INTO admin.all_distinct_dbname_metrics (dbname, metric) VALUES ('db1', 'upgraded_metric');
+		CREATE TABLE subpartitions.upgraded_metric_2024w01 PARTITION OF public.upgraded_metric FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
+		COMMENT ON TABLE subpartitions.upgraded_metric_2024w01 IS 'pgwatch-generated-metric-time-lvl';
+	`)
+	r.NoError(err)
+
+	r.NoError(mig.Migrate())
+
+	// After migration the routine must be a procedure (prokind = 'p').
+	var prokindAfter string
+	r.NoError(conn.QueryRow(ctx, `
+		SELECT p.prokind FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = 'admin' AND p.proname = 'drop_all_metric_tables'
+	`).Scan(&prokindAfter))
+	a.Equal("p", prokindAfter, "admin.drop_all_metric_tables must be upgraded to a procedure")
+
+	// The upgraded procedure must actually drop partition-by-partition. The bare
+	// conn (not a transaction-wrapped one) is required: CALL ... COMMIT is rejected
+	// inside an explicit transaction block.
+	_, err = conn.Exec(ctx, "CALL admin.drop_all_metric_tables();")
+	r.NoError(err, "upgraded procedure must execute end-to-end")
+
+	var leftover *string
+	r.NoError(conn.QueryRow(ctx, "SELECT to_regclass('public.upgraded_metric')::text").Scan(&leftover))
+	a.Nil(leftover, "top-level metric table must be dropped by the upgraded procedure")
+	var subpartCount int
+	r.NoError(conn.QueryRow(ctx, "SELECT count(*) FROM pg_class WHERE relnamespace = 'subpartitions'::regnamespace").Scan(&subpartCount))
+	a.Equal(0, subpartCount, "partition must be dropped by the upgraded procedure")
+	var listingCount int
+	r.NoError(conn.QueryRow(ctx, "SELECT count(*) FROM admin.all_distinct_dbname_metrics").Scan(&listingCount))
+	a.Equal(0, listingCount, "listing table must be truncated by the upgraded procedure")
+
+	needs, err := mig.NeedsMigration()
+	r.NoError(err)
+	a.False(needs, "no migrations should be pending after the upgrade")
+}
+
+// TestMigration_AllMigrationsRunFromEmpty is the explicit all-migrations exercise.
+// It wipes every row from admin.migration, runs mig.Migrate() against the fresh
+// bootstrap, and asserts that every registered migration in the migrator chain
+// actually executed and recorded itself in admin.migration — including the new
+// 01474 routine. The migrator's "did it run" signal is purely the row count in
+// admin.migration, so this test guards against two failure modes at once:
+//   - a registered migration that fails silently (count stays below MigrationsCount)
+//   - MigrationsCount drifting above the actual number of registered migrations
+func TestMigration_AllMigrationsRunFromEmpty(t *testing.T) {
+	if os.Getenv("PGWATCH_TEST_SKIP_MIGRATION") != "" {
+		t.Skip("migration integration test skipped via PGWATCH_TEST_SKIP_MIGRATION")
+	}
+	r := require.New(t)
+	a := assert.New(t)
+
+	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
+	r.NoError(err)
+	defer pgTearDown()
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	r.NoError(err)
+
+	mig, err := NewPostgresSinkMigrator(ctx, connStr)
+	r.NoError(err)
+
+	conn, err := pgx.Connect(ctx, connStr)
+	r.NoError(err)
+	defer conn.Close(ctx)
+
+	simulatePreV6Migration(t, conn)
+
+	// After wipe: exactly zero applied migrations.
+	var before int
+	r.NoError(conn.QueryRow(ctx, "SELECT count(*) FROM admin.migration").Scan(&before))
+	a.Equal(0, before)
+
+	r.NoError(mig.Migrate(), "migrate from empty must run the entire chain without error")
+
+	// After migrate: every registered migration row must be present.
+	var after int
+	r.NoError(conn.QueryRow(ctx, "SELECT count(*) FROM admin.migration").Scan(&after))
+	a.Equal(MigrationsCount, after,
+		"every registered migration (incl. 01474) must record itself in admin.migration after a wipe + migrate")
+
+	// The new routine from 01474 must have been created as a procedure.
+	var prokind string
+	r.NoError(conn.QueryRow(ctx, `
+		SELECT p.prokind FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = 'admin' AND p.proname = 'drop_all_metric_tables'
+	`).Scan(&prokind))
+	a.Equal("p", prokind, "01474 must install the routine as a procedure")
+
+	// ensure_partition_metric_time must have been (re)installed by 01180.
+	var fnExists bool
+	r.NoError(conn.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+		               WHERE n.nspname = 'admin' AND p.proname = 'ensure_partition_metric_time')
+	`).Scan(&fnExists))
+	a.True(fnExists, "01180 must install admin.ensure_partition_metric_time")
+
+	// needs-migration must report clean.
+	needs, err := mig.NeedsMigration()
+	r.NoError(err)
+	a.False(needs, "no migrations should be pending after a full replay")
+
+	// Idempotency: a second migrate must be a clean no-op.
+	r.NoError(mig.Migrate(), "second migrate after full replay must be a no-op")
 }

--- a/internal/sinks/postgres_schema_test.go
+++ b/internal/sinks/postgres_schema_test.go
@@ -91,7 +91,7 @@ func TestPostgresWriterNeedsMigrationNoMigrationNeeded(t *testing.T) {
 	conn.ExpectQuery(`SELECT to_regclass`).
 		WithArgs("admin.migration").
 		WillReturnRows(pgxmock.NewRows([]string{"to_regclass"}).AddRow(true))
-	conn.ExpectQuery(`SELECT count`).WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(3))
+	conn.ExpectQuery(`SELECT count`).WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(MigrationsCount))
 
 	pgw := &PostgresWriter{ctx: ctx, sinkDb: conn}
 	needs, err := pgw.NeedsMigration()

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -79,8 +79,6 @@ func TestNewWriterFromPostgresConn(t *testing.T) {
 		a.NoError(conn.ExpectationsWereMet())
 	})
 
-
-
 	t.Run("ReadMetricSchemaTypeFail", func(*testing.T) {
 		conn, err := pgxmock.NewPool()
 		a.NoError(err)
@@ -1096,4 +1094,85 @@ func TestFlush_SinkDBIsDown(t *testing.T) {
 
 	// It should return, Issue:#1426 will keep it spinning forever
 	pgw.flush(msgs)
+}
+
+// TestDropAllMetricTables verifies that admin.drop_all_metric_tables() is a procedure that
+// drops every top-level metric table partition by partition and cleans up the listing table.
+// The partition-by-partition drop with COMMIT between drops is the contract that lets large
+// installs avoid blowing past max_locks_per_transaction. See issue #1474.
+func TestDropAllMetricTables(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+
+	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
+	r.NoError(err)
+	defer pgTearDown()
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	r.NoError(err)
+	conn, err := pgx.Connect(ctx, connStr)
+	r.NoError(err)
+	defer conn.Close(ctx)
+
+	opts := &CmdOpts{
+		PartitionInterval:   "1 hour",
+		RetentionInterval:   "1 hour",
+		MaintenanceInterval: "0 days",
+		BatchingDelay:       time.Hour,
+	}
+
+	pgw, err := NewPostgresWriter(ctx, connStr, opts)
+	r.NoError(err)
+
+	// Create two dummy metric tables and seed a listing row for each.
+	r.NoError(pgw.SyncMetric("test", "test_metric_a", AddOp))
+	r.NoError(pgw.SyncMetric("test", "test_metric_b", AddOp))
+
+	// Attach a single weekly partition to each so the partition-by-partition drop branch
+	// is exercised.
+	_, err = conn.Exec(ctx, `
+		CREATE TABLE subpartitions.test_metric_a_2024w01 PARTITION OF public.test_metric_a FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
+		COMMENT ON TABLE subpartitions.test_metric_a_2024w01 IS 'pgwatch-generated-metric-time-lvl';
+		CREATE TABLE subpartitions.test_metric_b_2024w01 PARTITION OF public.test_metric_b FOR VALUES FROM ('2024-01-01') TO ('2024-01-08');
+		COMMENT ON TABLE subpartitions.test_metric_b_2024w01 IS 'pgwatch-generated-metric-time-lvl';
+	`)
+	r.NoError(err)
+
+	// Sanity: the two test top-level metric tables exist before the call.
+	var regA0, regB0 *string
+	r.NoError(conn.QueryRow(ctx, "SELECT to_regclass('public.test_metric_a')::text, to_regclass('public.test_metric_b')::text").Scan(&regA0, &regB0))
+	r.NotNil(regA0, "public.test_metric_a must exist after SyncMetric")
+	r.NotNil(regB0, "public.test_metric_b must exist after SyncMetric")
+
+	var topLevelCount int
+	r.NoError(conn.QueryRow(ctx, "SELECT count(*) FROM admin.get_top_level_metric_tables() WHERE table_name IN ('test_metric_a', 'test_metric_b')").Scan(&topLevelCount))
+	a.Equal(2, topLevelCount)
+
+	// Invoke the procedure on a bare connection (CALL is rejected inside an explicit transaction).
+	_, err = conn.Exec(ctx, "CALL admin.drop_all_metric_tables();")
+	r.NoError(err)
+
+	// Both top-level tables must be gone.
+	var regA, regB *string
+	r.NoError(conn.QueryRow(ctx, "SELECT to_regclass('public.test_metric_a')::text, to_regclass('public.test_metric_b')::text").Scan(&regA, &regB))
+	a.Nil(regA, "public.test_metric_a should be dropped")
+	a.Nil(regB, "public.test_metric_b should be dropped")
+
+	// The leaf partitions must be gone too (not left behind as detached tables).
+	var subpartCount int
+	r.NoError(conn.QueryRow(ctx, "SELECT count(*) FROM pg_class WHERE relnamespace = 'subpartitions'::regnamespace").Scan(&subpartCount))
+	a.Equal(0, subpartCount, "no tables should remain in the subpartitions schema")
+
+	// The listing table must be truncated.
+	var listingCount int
+	r.NoError(conn.QueryRow(ctx, "SELECT count(*) FROM admin.all_distinct_dbname_metrics").Scan(&listingCount))
+	a.Equal(0, listingCount)
+
+	// The routine must exist as a procedure (prokind = 'p'), not a function.
+	var prokind string
+	r.NoError(conn.QueryRow(ctx, `
+		SELECT p.prokind FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = 'admin' AND p.proname = 'drop_all_metric_tables'
+	`).Scan(&prokind))
+	a.Equal("p", prokind, "admin.drop_all_metric_tables must be a procedure")
 }

--- a/internal/sinks/sql/admin_functions.sql
+++ b/internal/sinks/sql/admin_functions.sql
@@ -42,25 +42,65 @@ $SQL$
 $SQL$ LANGUAGE sql;
 
 /*
-  drop_all_metric_tables() drops all top-level metric tables (and all their partitions/chunks)
+  drop_all_metric_tables() drops all top level metric tables partition by partition
+  (chunk by chunk for TimescaleDB), committing between drops to avoid exceeding
+  max_locks_per_transaction. Must be called outside a transaction block:
+    CALL admin.drop_all_metric_tables();
 */
-CREATE OR REPLACE FUNCTION admin.drop_all_metric_tables()
-RETURNS int AS
+DROP ROUTINE IF EXISTS admin.drop_all_metric_tables();
+
+CREATE OR REPLACE PROCEDURE admin.drop_all_metric_tables()
+AS
 $SQL$
 DECLARE
-  r record;
-  i int := 0;
+  l_schema_type text;
+  l_table text;
+  l_part text;
+  l_tables text[];
+  l_parts text[];
+  l_dropped int := 0;
 BEGIN
-  FOR r IN SELECT table_name FROM admin.get_top_level_metric_tables()
+  SELECT st.schema_type INTO l_schema_type FROM admin.storage_schema_type st;
+
+  SELECT COALESCE(array_agg(table_name), ARRAY[]::text[])
+  INTO l_tables
+  FROM admin.get_top_level_metric_tables();
+
+  FOREACH l_table IN ARRAY l_tables
   LOOP
-    RAISE NOTICE 'dropping %', r.table_name;
-    EXECUTE 'DROP TABLE ' || r.table_name;
-    i := i + 1;
+    IF l_schema_type = 'timescale' THEN
+      SELECT COALESCE(array_agg(chunk::text), ARRAY[]::text[])
+      INTO l_parts
+      FROM show_chunks(l_table::regclass) AS chunk;
+    ELSE
+      SELECT COALESCE(array_agg(relid::text ORDER BY level DESC, relid::text), ARRAY[]::text[])
+      INTO l_parts
+      FROM pg_partition_tree(l_table::regclass)
+      WHERE level > 0;
+    END IF;
+
+    FOREACH l_part IN ARRAY l_parts
+    LOOP
+      IF l_schema_type = 'timescale' THEN
+        RAISE NOTICE 'dropping chunk %', l_part;
+        PERFORM drop_chunks(l_part::regclass);
+      ELSE
+        RAISE NOTICE 'dropping partition %', l_part;
+        EXECUTE 'DROP TABLE IF EXISTS ' || l_part;
+      END IF;
+      COMMIT;
+    END LOOP;
+
+    RAISE NOTICE 'dropping table %', l_table;
+    EXECUTE 'DROP TABLE ' || l_table;
+    l_dropped := l_dropped + 1;
+    COMMIT;
   END LOOP;
-  
+
   EXECUTE 'TRUNCATE admin.all_distinct_dbname_metrics';
-  
-  RETURN i;
+  COMMIT;
+
+  RAISE NOTICE 'dropped % top-level metric tables', l_dropped;
 END;
 $SQL$ LANGUAGE plpgsql;
 

--- a/internal/sinks/sql/admin_schema.sql
+++ b/internal/sinks/sql/admin_schema.sql
@@ -96,5 +96,7 @@ INSERT INTO
 VALUES
     (0,  '01110 Apply postgres sink schema migrations'),
     (1,  '01180 Apply admin functions migrations for v5'),
-    (2,  '01409 Switch to time-only partitioning');
+    (2,  '01409 Switch to time-only partitioning'),
+    (3,  '01474 Change drop_all_metric_tables to procedure');
     -- apply new migration value to `sinkSchema` in `cmd/pgwatch/version.go` file as well
+


### PR DESCRIPTION
`admin.drop_all_metric_tables` is a procedure now that drops all tables partition by partition, instead of the bulk drop table approach used, which is easy to fail due to `max_locks_per_transaction`