### PR TITLE
[-] fix webui column resizing glitches

### DIFF
--- a/internal/webui/src/components/GridActions/GridActions.styles.ts
+++ b/internal/webui/src/components/GridActions/GridActions.styles.ts
@@ -5,7 +5,8 @@ export const useGridActionsStyles = makeStyles()(
     root: {
       display: "flex",
       width: "100%",
-      justifyContent: "space-between",
+      gap: 4,
+      justifyContent: "center",
     },
   }),
 );

--- a/internal/webui/src/components/GridToolbar/GridToolbar.tsx
+++ b/internal/webui/src/components/GridToolbar/GridToolbar.tsx
@@ -11,7 +11,7 @@ export const GridToolbar = (props: Props) => {
   const { onNewClick, children } = props;
 
   return (
-    <GridToolbarContainer>
+    <GridToolbarContainer sx={{ justifyContent: "flex-start" }}>
       <GridToolbarColumnsButton slotProps={{ button: { size: "small" } }} />
       <GridToolbarFilterButton slotProps={{ button: { size: "small" } }} />
       <Button startIcon={<AddIcon />} onClick={onNewClick}>New</Button>

--- a/internal/webui/src/hooks/useGridState.ts
+++ b/internal/webui/src/hooks/useGridState.ts
@@ -1,85 +1,72 @@
 import { useCallback, useMemo, useState } from 'react';
 import { GridColDef, GridColumnVisibilityModel } from '@mui/x-data-grid';
 
-export interface GridColumnSizingModel {
-  [field: string]: number;
+interface GridState {
+  columnVisibility?: GridColumnVisibilityModel;
 }
 
-interface GridState {
-  columnVisibility: GridColumnVisibilityModel;
-  columnSizing: GridColumnSizingModel;
-}
+const readSavedState = (storageKey: string): GridState => {
+  const saved = localStorage.getItem(storageKey);
+  return saved ? JSON.parse(saved) : {};
+};
+
+const persistState = (storageKey: string, state: GridState) => {
+  const current = readSavedState(storageKey);
+  localStorage.setItem(storageKey, JSON.stringify({ ...current, ...state }));
+};
 
 export const useGridState = (
   storageKey: string,
   columns: GridColDef[],
   defaultHidden: GridColumnVisibilityModel = {}
 ) => {
-  const [gridState, setGridState] = useState<GridState>(() => {
-    // Initialize default column visibility
+  // Column widths are intentionally left as uncontrolled defaults (from the
+  // column definitions) and are NOT persisted. This lets the DataGrid fully
+  // own the resize interaction, which avoids the glitchy/jumpy resizing caused
+  // by controlling widths, and resets column widths on each session.
+  const [columnVisibility, setColumnVisibility] = useState<GridColumnVisibilityModel>(() => {
+    const saved = readSavedState(storageKey);
     const defaultVisibility = columns?.reduce((acc, col) => ({
       ...acc,
       [col.field]: defaultHidden[col.field] === false ? false : true
-    }), {});
-
-    // Initialize default column sizing from column definitions
-    const defaultSizing = columns?.reduce((acc, col) => ({
-      ...acc,
-      [col.field]: col.width || 150 // Use column width or default to 150
-    }), {});
-
-    // Load saved state from localStorage
-    const saved = localStorage.getItem(storageKey);
-    const savedState = saved ? JSON.parse(saved) : {};
+    }), {} as GridColumnVisibilityModel);
 
     return {
-      columnVisibility: {
-        ...defaultVisibility,
-        ...(savedState.columnVisibility || {})
-      },
-      columnSizing: {
-        ...defaultSizing,
-        ...(savedState.columnSizing || {})
-      }
+      ...defaultVisibility,
+      ...(saved.columnVisibility || {})
     };
   });
 
-  const saveToStorage = useCallback((newState: GridState) => {
-    localStorage.setItem(storageKey, JSON.stringify(newState));
+  const handleColumnVisibilityChange = useCallback((newModel: GridColumnVisibilityModel) => {
+    setColumnVisibility(newModel);
+    persistState(storageKey, { columnVisibility: newModel });
   }, [storageKey]);
 
-  const handleColumnVisibilityChange = useCallback((newModel: GridColumnVisibilityModel) => {
-    setGridState(prev => {
-      const newState = { ...prev, columnVisibility: newModel };
-      saveToStorage(newState);
-      return newState;
-    });
-  }, [saveToStorage]);
+  // Make the last visible column stretch to fill the remaining horizontal
+  // space, so the grid always spans the full width of the screen. The "last"
+  // column is determined dynamically from the current visibility, so it stays
+  // correct when columns are hidden/shown via the filters.
+  const columnsWithFill = useMemo(() => {
+    const fillField = [...columns]
+      .reverse()
+      .find((col) => columnVisibility[col.field] !== false)
+      ?.field;
 
-  const handleColumnWidthChange = useCallback((params: any) => {
-    setGridState(prev => {
-      const newState = {
-        ...prev,
-        columnSizing: {
-          ...prev.columnSizing,
-          [params.field || params.colDef?.field]: params.width
-        }
+    return columns.map((col) => {
+      if (col.field !== fillField) {
+        return col;
+      }
+      return {
+        ...col,
+        flex: col.flex ?? 1,
+        minWidth: col.minWidth ?? col.width ?? 150,
       };
-      saveToStorage(newState);
-      return newState;
     });
-  }, [saveToStorage]);
-
-  const columnsWithSizing = useMemo(() => columns?.map(col => ({
-    ...col,
-    width: gridState.columnSizing[col.field] || col.width || 150
-  })), [columns, gridState.columnSizing]);
+  }, [columns, columnVisibility]);
 
   return {
-    columnVisibility: gridState.columnVisibility,
-    columnSizing: gridState.columnSizing,
-    columnsWithSizing,
+    columnVisibility,
+    columns: columnsWithFill,
     onColumnVisibilityChange: handleColumnVisibilityChange,
-    onColumnWidthChange: handleColumnWidthChange,
   };
 };

--- a/internal/webui/src/pages/MetricsPage/components/MetricsGrid/MetricsGrid.tsx
+++ b/internal/webui/src/pages/MetricsPage/components/MetricsGrid/MetricsGrid.tsx
@@ -16,13 +16,12 @@ export const MetricsGrid = () => {
 
   const { classes } = usePageStyles();
 
-  const columns = useMetricsGridColumns();
+  const gridColumns = useMetricsGridColumns();
   const { 
     columnVisibility, 
-    columnsWithSizing, 
+    columns,
     onColumnVisibilityChange, 
-    onColumnWidthChange
-  } = useGridState('METRICS_GRID', columns);
+  } = useGridState('METRICS_GRID', gridColumns);
 
   const rows: MetricGridRow[] | [] = useMemo(() => {
     if (data) {
@@ -55,7 +54,7 @@ export const MetricsGrid = () => {
       <MetricFormProvider>
         <DataGrid
           getRowId={(row) => row.Key}
-          columns={columnsWithSizing}
+          columns={columns}
           rows={rows}
           pageSizeOptions={[]}
           showToolbar
@@ -64,7 +63,6 @@ export const MetricsGrid = () => {
           }}
           columnVisibilityModel={columnVisibility}
           onColumnVisibilityModelChange={onColumnVisibilityChange}
-          onColumnWidthChange={onColumnWidthChange}
           initialState={{
             sorting: {
               sortModel: [{ field: 'Key', sort: 'asc' }],

--- a/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
+++ b/internal/webui/src/pages/PresetsPage/components/PresetsGrid/PresetsGrid.tsx
@@ -16,13 +16,12 @@ export const PresetsGrid = () => {
 
   const { data, isLoading, isError, error } = usePresets();
 
-  const columns = usePresetsGridColumns();
+  const gridColumns = usePresetsGridColumns();
   const { 
     columnVisibility, 
-    columnsWithSizing, 
+    columns,
     onColumnVisibilityChange, 
-    onColumnWidthChange
-  } = useGridState('PRESETS_GRID', columns);
+  } = useGridState('PRESETS_GRID', gridColumns);
 
   const rows: PresetGridRow[] | [] = useMemo(() => {
     if (data) {
@@ -55,7 +54,7 @@ export const PresetsGrid = () => {
       <PresetFormProvider>
         <DataGrid
           getRowId={(row) => row.Key}
-          columns={columnsWithSizing}
+          columns={columns}
           rows={rows}
           pageSizeOptions={[]}
           showToolbar
@@ -64,7 +63,6 @@ export const PresetsGrid = () => {
           }}
           columnVisibilityModel={columnVisibility}
           onColumnVisibilityModelChange={onColumnVisibilityChange}
-          onColumnWidthChange={onColumnWidthChange}
         />
         <PresetFormDialog />
       </PresetFormProvider>

--- a/internal/webui/src/pages/SourcesPage/components/SourcesGrid/SourcesGrid.tsx
+++ b/internal/webui/src/pages/SourcesPage/components/SourcesGrid/SourcesGrid.tsx
@@ -14,13 +14,12 @@ export const SourcesGrid = () => {
 
   const { data, isLoading, isError, error } = useSources();
 
-  const columns = useSourcesGridColumns();
+  const gridColumns = useSourcesGridColumns();
   const { 
     columnVisibility, 
-    columnsWithSizing, 
+    columns,
     onColumnVisibilityChange, 
-    onColumnWidthChange
-  } = useGridState('SOURCES_GRID', columns, {
+  } = useGridState('SOURCES_GRID', gridColumns, {
     Kind: false,
     IncludePattern: false,
     ExcludePattern: false,
@@ -48,7 +47,7 @@ export const SourcesGrid = () => {
       <SourceFormProvider>
         <DataGrid
           getRowId={(row) => row.Name}
-          columns={columnsWithSizing}
+          columns={columns}
           rows={data ?? []}
           pageSizeOptions={[]}
           showToolbar
@@ -57,7 +56,6 @@ export const SourcesGrid = () => {
           }}
           columnVisibilityModel={columnVisibility}
           onColumnVisibilityModelChange={onColumnVisibilityChange}
-          onColumnWidthChange={onColumnWidthChange}
         />
         <SourceFormDialog />
       </SourceFormProvider>


### PR DESCRIPTION
The web UI still has some resizing glitches.

- Glitches fixed
- The column resizing in the "SOURCES" tab is no longer persisted in local storage and is reset on refresh, following the behaviour of the other tabs.
- The last column now expands to fill the remaining space of the screen if width < screen_width