### PR TITLE
[-] fix partition creation after long downtime, closes #1529

### DIFF
--- a/cmd/pgwatch/version.go
+++ b/cmd/pgwatch/version.go
@@ -8,7 +8,7 @@ var (
 	version      = "unknown"
 	date         = "unknown"
 	configSchema = "00824"
-	sinkSchema   = "01474"
+	sinkSchema   = "01529"
 )
 
 func printVersion() {

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -471,7 +471,16 @@ func (pgw *PostgresWriter) EnsureMetricTimePartsExist(metricPartBounds map[strin
 			return fmt.Errorf("zero StartTime/EndTime in partitioning request: [%s:%v]", metric, pb)
 		}
 		partInfo, ok := pgw.partitionMapMetric[metric]
-		if !ok || pb.EndTime.After(partInfo.EndTime) || pb.EndTime.Equal(partInfo.EndTime) || pgw.forceRecreatePartitions {
+		if !ok || pb.StartTime.Before(partInfo.StartTime) || pgw.forceRecreatePartitions {
+			if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, pb.StartTime, pgw.opts.PartitionInterval); err != nil {
+				return err
+			}
+			if partInfo, err = pgx.CollectOneRow(rows, pgx.RowToStructByPos[ExistingPartitionInfo]); err != nil {
+				return err
+			}
+			pgw.partitionMapMetric[metric] = partInfo
+		}
+		if pb.EndTime.After(partInfo.EndTime) || pb.EndTime.Equal(partInfo.EndTime) || pgw.forceRecreatePartitions {
 			if rows, err = pgw.sinkDb.Query(pgw.ctx, sqlEnsure, metric, pb.EndTime, pgw.opts.PartitionInterval); err != nil {
 				return err
 			}
@@ -720,6 +729,14 @@ var migrations func() migrator.Option = func() migrator.Option {
 			Name: "01474 Change drop_all_metric_tables to procedure",
 			Func: func(ctx context.Context, tx pgx.Tx) error {
 				_, err := tx.Exec(ctx, sqlMetricAdminFunctions)
+				return err
+			},
+		},
+
+		&migrator.Migration{
+			Name: "01529 Fix ensure_partition_metric_time partitioning strategy",
+			Func: func(ctx context.Context, tx pgx.Tx) error {
+				_, err := tx.Exec(ctx, sqlMetricEnsurePartitionPostgres)
 				return err
 			},
 		},

--- a/internal/sinks/postgres_migration_test.go
+++ b/internal/sinks/postgres_migration_test.go
@@ -240,7 +240,7 @@ func TestMigration01474_DropAllMetricTablesProcedure(t *testing.T) {
 	_, err = conn.Exec(ctx, `
 		DROP PROCEDURE IF EXISTS admin.drop_all_metric_tables();
 		CREATE FUNCTION admin.drop_all_metric_tables() RETURNS int AS $$ BEGIN RETURN 0; END $$ LANGUAGE plpgsql;
-		DELETE FROM admin.migration WHERE id = (SELECT max(id) FROM admin.migration);
+		DELETE FROM admin.migration WHERE id >= 3;
 	`)
 	r.NoError(err)
 

--- a/internal/sinks/postgres_test.go
+++ b/internal/sinks/postgres_test.go
@@ -662,6 +662,75 @@ func TestPartitionInterval(t *testing.T) {
 	a.Equal(part.StartTime.Add(3*7*24*time.Hour), part.EndTime)
 }
 
+// TestPartitionForwardTimeJump checks #1529
+func TestPartitionForwardTimeJump(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+
+	pgContainer, pgTearDown, err := testutil.SetupPostgresContainer()
+	r.NoError(err)
+	defer pgTearDown()
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	r.NoError(err)
+
+	opts := &CmdOpts{
+		PartitionInterval:   "1 day",
+		RetentionInterval:   "14 days",
+		MaintenanceInterval: "12 hours",
+		BatchingDelay:       time.Second,
+	}
+
+	pgw, err := NewPostgresWriter(ctx, connStr, opts)
+	r.NoError(err)
+
+	conn, err := pgx.Connect(ctx, connStr)
+	r.NoError(err)
+	defer conn.Close(ctx)
+
+	// 1. Create partitions for an early period.
+	early := time.Date(2026, 2, 5, 10, 0, 0, 0, time.UTC)
+	r.NoError(pgw.EnsureMetricTimePartsExist(map[string]ExistingPartitionInfo{
+		"jump_metric": {StartTime: early, EndTime: early},
+	}))
+
+	// 2. Simulate a restart: the in-memory partition cache is lost, while the
+	//    existing partitions remain in the database.
+	pgw.partitionMapMetric = make(map[string]ExistingPartitionInfo)
+
+	// 3. New data arrives weeks later, well beyond the pre-created partitions'
+	//    upper bound (the "forward time jump" / gap scenario).
+	late := time.Date(2026, 8, 19, 0, 49, 18, 0, time.UTC)
+	err = pgw.EnsureMetricTimePartsExist(map[string]ExistingPartitionInfo{
+		"jump_metric": {StartTime: late, EndTime: late},
+	})
+	// Must not error (previously failed with "cannot scan NULL into *time.Time").
+	r.NoError(err)
+
+	// The returned/cached range must be non-zero and must contain the new timestamp.
+	part := pgw.partitionMapMetric["jump_metric"]
+	a.False(part.StartTime.IsZero(), "part_available_from must not be NULL")
+	a.False(part.EndTime.IsZero(), "part_available_to must not be NULL")
+	a.False(late.Before(part.StartTime), "new timestamp must be >= partition start")
+	a.True(late.Before(part.EndTime), "new timestamp must be < partition end")
+
+	// A subpartition physically covering the new timestamp must exist, otherwise
+	// the CopyFrom insert would fail with SQLSTATE 23514 (no partition for row).
+	var covering int
+	r.NoError(conn.QueryRow(ctx, `
+		SELECT count(*)
+		FROM pg_catalog.pg_class c
+		JOIN pg_catalog.pg_inherits i ON i.inhrelid = c.oid
+		JOIN pg_catalog.pg_class parent ON parent.oid = i.inhparent
+		WHERE c.relispartition
+		  AND c.relnamespace = 'subpartitions'::regnamespace
+		  AND parent.relname = 'jump_metric'
+		  AND $1::timestamptz >= substring(pg_catalog.pg_get_expr(c.relpartbound, c.oid, true) from 'FOR VALUES FROM \(''([^'']+)''')::timestamptz
+		  AND $1::timestamptz <  substring(pg_catalog.pg_get_expr(c.relpartbound, c.oid, true) from 'TO \(''([^'']+)''')::timestamptz
+	`, late).Scan(&covering))
+	a.Equal(1, covering, "exactly one subpartition must cover the new timestamp")
+}
+
 func Test_Maintain(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)

--- a/internal/sinks/sql/admin_schema.sql
+++ b/internal/sinks/sql/admin_schema.sql
@@ -97,6 +97,7 @@ VALUES
     (0,  '01110 Apply postgres sink schema migrations'),
     (1,  '01180 Apply admin functions migrations for v5'),
     (2,  '01409 Switch to time-only partitioning'),
-    (3,  '01474 Change drop_all_metric_tables to procedure');
+    (3,  '01474 Change drop_all_metric_tables to procedure'),
+    (4,  '01529 Fix ensure_partition_metric_time partitioning strategy');
     -- apply new migration value to `sinkSchema` in `cmd/pgwatch/version.go` file as well
 

--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -10,7 +10,7 @@
 CREATE OR REPLACE FUNCTION admin.ensure_partition_metric_time(
     metric text,
     metric_timestamp timestamptz,
-    partition_period interval default '1 week'::interval,
+    partition_period interval default '1 day'::interval,
     partitions_to_precreate int default 3,
     OUT part_available_from timestamptz,
     OUT part_available_to timestamptz)
@@ -46,14 +46,11 @@ BEGIN
 
   PERFORM pg_advisory_xact_lock(regexp_replace( md5(metric) , E'\\D', '', 'g')::varchar(10)::int8);
 
-  -- 1. level
   IF to_regclass('public.' || quote_ident(metric)) IS NULL
   THEN
     EXECUTE format('CREATE TABLE public.%I (LIKE admin.metrics_template INCLUDING INDEXES) PARTITION BY RANGE (time)', metric);
     EXECUTE format('COMMENT ON TABLE public.%I IS $$pgwatch-generated-metric-lvl$$', metric);
   END IF;
-
-  -- 2. level
 
   -- Get existing partition upper bound
   SELECT max(substring(pg_catalog.pg_get_expr(c.relpartbound, c.oid, true) from 'TO \(''([^'']+)''')::timestamptz)
@@ -65,60 +62,7 @@ BEGIN
     AND c.relnamespace = 'subpartitions'::regnamespace
     AND parent.relname = metric;
 
-  -- Determine starting point for new partitions
-  IF l_existing_upper_bound IS NOT NULL THEN
-    -- Start from the existing upper bound to maintain continuity
-    l_part_start := l_existing_upper_bound;
-  ELSE
-    -- No existing partitions, align to clean boundaries based on period size
-    CASE
-      WHEN partition_period >= interval '1 week' THEN
-        l_part_start := date_trunc('week', metric_timestamp);
-      WHEN partition_period >= interval '1 day' THEN
-        l_part_start := date_trunc('day', metric_timestamp);
-      ELSE
-        -- For hourly periods (>= 1 hour, < 1 day)
-        l_part_start := date_trunc('hour', metric_timestamp);
-    END CASE;
-
-    -- For the first partition, set the available range
-    part_available_from := l_part_start;
-    part_available_to := l_part_start + partition_period;
-  END IF;
-
-  -- Create partitions
-  FOR i IN 0..partitions_to_precreate LOOP
-      l_part_end := l_part_start + partition_period;
-
-      -- Update the available range for the first partition only if we started from metric_timestamp
-      IF i = 0 AND l_existing_upper_bound IS NULL THEN
-          part_available_from := l_part_start;
-          part_available_to := l_part_end;
-      ELSIF i = 0 AND l_existing_upper_bound IS NOT NULL THEN
-          -- For existing partitions, we need to find which partition contains the metric_timestamp
-          IF metric_timestamp >= l_part_start AND metric_timestamp < l_part_end THEN
-              part_available_from := l_part_start;
-              part_available_to := l_part_end;
-          ELSEIF metric_timestamp < l_part_start THEN
-              EXIT; -- No need to create further partitions
-          END IF;
-      END IF;
-
-      l_time_suffix := to_char(l_part_start, l_partition_format);
-      l_part_name := format('%s_%s', metric, l_time_suffix);
-
-      IF to_regclass('subpartitions.' || quote_ident(l_part_name)) IS NULL
-      THEN
-        EXECUTE format('CREATE TABLE subpartitions.%I PARTITION OF public.%I FOR VALUES FROM ($$%s$$) TO ($$%s$$)',
-                        l_part_name, metric, l_part_start, l_part_end);
-        EXECUTE format('COMMENT ON TABLE subpartitions.%I IS $$pgwatch-generated-metric-time-lvl$$', l_part_name);
-      END IF;
-
-      l_part_start := l_part_end;
-  END LOOP;
-
-  -- If we still don't have part_available_from/to set, find the partition containing metric_timestamp
-  IF part_available_from IS NULL THEN
+  IF l_existing_upper_bound IS NOT NULL AND metric_timestamp < l_existing_upper_bound THEN
     SELECT lower_text::timestamptz, upper_text::timestamptz
     INTO part_available_from, part_available_to
     FROM (
@@ -135,7 +79,43 @@ BEGIN
     WHERE metric_timestamp >= lower_text::timestamptz
       AND metric_timestamp < upper_text::timestamptz
     LIMIT 1;
+    RETURN; -- No need to create more partitions.
   END IF;
 
+  -- Determine starting point for new partitions
+  CASE
+    WHEN partition_period >= interval '1 week' THEN
+      l_part_start := date_trunc('week', metric_timestamp);
+    WHEN partition_period >= interval '1 day' THEN
+      l_part_start := date_trunc('day', metric_timestamp);
+    ELSE
+      -- For hourly periods (>= 1 hour, < 1 day)
+      l_part_start := date_trunc('hour', metric_timestamp);
+  END CASE;
+
+  -- Avoid overlapping with existing partitions
+  l_part_start := GREATEST(l_part_start, l_existing_upper_bound);
+
+  -- Create partitions
+  FOR i IN 0..partitions_to_precreate LOOP
+      l_part_end := l_part_start + partition_period;
+
+      IF i = 0 THEN
+          part_available_from := l_part_start;
+          part_available_to := l_part_end;
+      END IF;
+
+      l_time_suffix := to_char(l_part_start, l_partition_format);
+      l_part_name := format('%s_%s', metric, l_time_suffix);
+
+      IF to_regclass('subpartitions.' || quote_ident(l_part_name)) IS NULL
+      THEN
+        EXECUTE format('CREATE TABLE subpartitions.%I PARTITION OF public.%I FOR VALUES FROM ($$%s$$) TO ($$%s$$)',
+                        l_part_name, metric, l_part_start, l_part_end);
+        EXECUTE format('COMMENT ON TABLE subpartitions.%I IS $$pgwatch-generated-metric-time-lvl$$', l_part_name);
+      END IF;
+
+      l_part_start := l_part_end;
+  END LOOP;
 END;
 $SQL$ LANGUAGE plpgsql;

--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -24,7 +24,6 @@ DECLARE
   l_part_name text;
   l_part_start timestamptz;
   l_part_end timestamptz;
-  ideal_length int;
   l_template_table text := 'admin.metrics_template';
   l_partition_format text;
   l_time_suffix text;

--- a/internal/sinks/sql/ensure_partition_postgres.sql
+++ b/internal/sinks/sql/ensure_partition_postgres.sql
@@ -78,7 +78,10 @@ BEGIN
     WHERE metric_timestamp >= lower_text::timestamptz
       AND metric_timestamp < upper_text::timestamptz
     LIMIT 1;
-    RETURN; -- No need to create more partitions.
+    IF part_available_from IS NOT NULL AND part_available_to IS NOT NULL THEN
+      RETURN; -- No need to create more partitions.
+    END IF;
+    -- Fallthrough to creating new partitions to hold the metric_timestamp
   END IF;
 
   -- Determine starting point for new partitions


### PR DESCRIPTION
When incoming data exceeds the last existing partition's upper bound, partitions will be created starting from the metric timestamp instead of the previous upper bound, avoiding NULL available ranges and missing-partition insert errors after pgwatch has been down for longer than the pre-created window.

Closes #1529