### PR TITLE
[*] optimize `flush()` in pg sink

### DIFF
--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -134,8 +134,9 @@ func (m Measurement) GetEpoch() int64 {
 			return epoch
 		}
 	}
-	m[EpochColumnName] = time.Now().UnixNano()
-	return m[EpochColumnName].(int64)
+	t := time.Now().UnixNano()
+	m[EpochColumnName] = t
+	return t
 }
 
 type Measurements []map[string]any

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -134,7 +134,8 @@ func (m Measurement) GetEpoch() int64 {
 			return epoch
 		}
 	}
-	return time.Now().UnixNano()
+	m[EpochColumnName] = time.Now().UnixNano()
+	return m[EpochColumnName].(int64)
 }
 
 type Measurements []map[string]any

--- a/internal/sinks/postgres.go
+++ b/internal/sinks/postgres.go
@@ -382,8 +382,8 @@ func (pgw *PostgresWriter) flush(msgs []metrics.MeasurementEnvelope) {
 	})
 
 	for _, msg := range msgs {
-		for _, dataRow := range msg.Data {
-			epochTime := time.Unix(0, metrics.Measurement(dataRow).GetEpoch())
+		if len(msg.Data) > 0 {
+			epochTime := time.Unix(0, msg.Data.GetEpoch())
 			bounds, ok := pgPartBounds[msg.MetricName]
 			if !ok || (ok && epochTime.Before(bounds.StartTime)) {
 				bounds.StartTime = epochTime


### PR DESCRIPTION
We don't need to loop over all the rows in `Measurements` and read `epoch_ns` from each, because they typically all contain the same value extracted from `now()` in the same txn.