### PR TITLE
[*] optimize prom sink memory usage

### DIFF
--- a/internal/sinks/prometheus.go
+++ b/internal/sinks/prometheus.go
@@ -318,6 +318,7 @@ func (promw *PrometheusWriter) WritePromMetrics(msg metrics.MeasurementEnvelope,
 		for i, k := range labelKeys {
 			labelValues[i] = labels[k]
 		}
+		joinedLabelValues := strings.Join(labelValues, "_")
 
 		for field, value := range fields {
 			var fqName string
@@ -346,7 +347,7 @@ func (promw *PrometheusWriter) WritePromMetrics(msg metrics.MeasurementEnvelope,
 			}
 
 			// skip if this exact identity was already emitted in this scrape
-			identity := fqName + "_" + strings.Join(labelValues, "_")
+			identity := fqName + "_" + joinedLabelValues
 			if _, dup := seen[identity]; dup {
 				promw.logger.
 					WithField("metric", msg.MetricName).


### PR DESCRIPTION
Don't repeat the fixed-output `strings.Join()` in the `fields` loop

A memory profile was collected before and after the change on a pgwatch test instance that ran for ~1.5 hours with 2 sources using the `exhaustive_no_python` preset and both Postgres and Prometheus sinks.

Before:
- `sinks.(*PrometheusWriter).WritePromMetrics()` consumed 85% of `alloc_space` and 90% of `alloc_objects`
- The `strings.Join()` call in `WritePromMetrics()` consumed 14% of `alloc_space`
- `alloc_space` = 18GB, `alloc_objects` = 300 millions

<img width="1920" height="473" alt="image" src="https://github.com/user-attachments/assets/cb9f3873-50c9-4734-ac72-e40dd5bb37d7" />


<img width="1906" height="384" alt="image" src="https://github.com/user-attachments/assets/6cb3ae89-35d9-4ad4-9756-207513ec80e8" />


After:
 - `sinks.(*PrometheusWriter).WritePromMetrics()` consumed 79% of `alloc_space` and 89% of `alloc_objects`
 -  The `strings.Join()` call no longer appears in the memory profile
 - `alloc_space` = 12Gb, `alloc_objects` = 216 millions
 
 
<img width="1910" height="486" alt="image" src="https://github.com/user-attachments/assets/18a2c600-195a-42f0-aad5-1334f68afa9c" />

