### PR TITLE
[+] bump Go toolchain to 1.27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       if: needs.changes.outputs.code == 'true'
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26'
+        go-version: '1.27'
         cache-dependency-path: 'go.sum'
 
     - name: Setup Protobuf
@@ -129,7 +129,7 @@ jobs:
     - name: Set up Golang
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26'
+        go-version: '1.27'
         cache-dependency-path: 'go.sum'
 
     - name: Download webui artifact
@@ -165,7 +165,7 @@ jobs:
     - name: Set up Golang
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26'
+        go-version: '1.27'
         cache-dependency-path: 'go.sum'
 
     - name: Set up Node.js
@@ -231,7 +231,7 @@ jobs:
     - name: Set up Golang
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26'      
+        go-version: '1.27'      
     
     - name: Set up gopages
       run: go install github.com/johnstarich/go/gopages@v0.1.29

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Golang
       uses: actions/setup-go@v7
       with:
-        go-version: '1.26'
+        go-version: '1.27'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v7

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 # pgwatch cross-platform development tasks (Windows / Linux / macOS).
-# Toolchain: Go 1.26, Node.js 22 + Yarn 1.x, Docker with compose v2, protoc (proto task only).
+# Toolchain: Go 1.27, Node.js 22 + Yarn 1.x, Docker with compose v2, protoc (proto task only).
 # Run `task --list` for all tasks and `task tools` to install the Go-based tool dependencies.
 
 vars:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn build
 # ----------------------------------------------------------------
 # 3. Go Dependencies and Tools (cached separately)
 # ----------------------------------------------------------------
-FROM golang:1.26 AS go-deps
+FROM golang:1.27 AS go-deps
 # Install protoc and required tools for protobuf generation
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn build
 # ----------------------------------------------------------------
 # 3. Go Dependencies and Tools (cached separately)
 # ----------------------------------------------------------------
-FROM golang:1.26 AS go-deps
+FROM golang:1.27 AS go-deps
 # Install protoc and required tools for protobuf generation
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cybertec-postgresql/pgwatch/v6
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/cybertec-postgresql/pgx-migrator v1.4.0

--- a/pkg/sinks/postgres_feedback_test.go
+++ b/pkg/sinks/postgres_feedback_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/pashagolub/pgxmock/v4"
+	"github.com/pashagolub/pgxmock/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/spec/design-sink-feedback.md
+++ b/spec/design-sink-feedback.md
@@ -66,7 +66,7 @@ layout.
 
 **Assumptions**:
 
-- Repository module path is `github.com/cybertec-postgresql/pgwatch/v6`, Go 1.26.
+- Repository module path is `github.com/cybertec-postgresql/pgwatch/v6`, Go 1.27.
 - The measurement epoch column is `epoch_ns` (`metrics.EpochColumnName`), Unix nanoseconds,
   `int64`.
 - Sinks are constructed once at start-up by `sinks.NewSinkWriter` and live for the process
@@ -546,7 +546,7 @@ specification; each needs its own:
 
 ### Technology Platform Dependencies
 
-- **PLT-001**: Go 1.26 — the module's declared version; no newer language feature is required beyond the builtin `min`, available since Go 1.21.
+- **PLT-001**: Go 1.27 — the module's declared version; no newer language feature is required beyond the builtin `min`, available since Go 1.21.
 - **PLT-002**: gRPC and protobuf toolchain — regenerating `api/pb` after the additive `.proto` change requires `protoc` with `protoc-gen-go` and `protoc-gen-go-grpc`, per the repository's existing generation step.
 
 ### Compliance Dependencies

--- a/spec/oss-published-packages.md
+++ b/spec/oss-published-packages.md
@@ -328,7 +328,7 @@ the packages, not the binary.
 
 ## 8. Dependencies & External Integrations
 
-- Go 1.26 module system (`internal/` rule, module proxy).
+- Go 1.27 module system (`internal/` rule, module proxy).
 - Existing JWT middleware (`internal/webserver/jwt.go`) and CORS middleware.
 - GoReleaser and Docker builds: the build of the default provider's assets stays in
   `cmd/pgwatch` builds only.


### PR DESCRIPTION
## Summary
- Bump Go from 1.26 to 1.27 across go.mod, CI workflows, Dockerfiles, Taskfile, and spec docs.
- Fix a leftover `pgxmock/v4` import in `pkg/sinks/postgres_feedback_test.go` missed during the earlier v4->v5 bump rebase.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/... ./internal/...`